### PR TITLE
feat: seller payment methods, admin catalog & timeout settings [GH-16]

### DIFF
--- a/apps/admin/src/app/[locale]/payment-methods/page.tsx
+++ b/apps/admin/src/app/[locale]/payment-methods/page.tsx
@@ -1,0 +1,13 @@
+import { setRequestLocale } from "next-intl/server";
+
+import { PaymentMethodTypesPage } from "@/features/payment-method-types";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  return <PaymentMethodTypesPage />;
+}

--- a/apps/admin/src/app/[locale]/settings/page.tsx
+++ b/apps/admin/src/app/[locale]/settings/page.tsx
@@ -1,0 +1,13 @@
+import { setRequestLocale } from "next-intl/server";
+
+import { SettingsPage } from "@/features/settings";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  return <SettingsPage />;
+}

--- a/apps/admin/src/features/payment-method-types/application/hooks/usePaymentMethodTypeMutations.ts
+++ b/apps/admin/src/features/payment-method-types/application/hooks/usePaymentMethodTypeMutations.ts
@@ -1,0 +1,76 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createBrowserSupabaseClient } from "api/supabase";
+import { useMemo } from "react";
+
+import { PAYMENT_METHOD_TYPES_QUERY_KEY } from "@/features/payment-method-types/domain/constants";
+import type { PaymentMethodTypeFormValues } from "@/features/payment-method-types/domain/types";
+import {
+  deletePaymentMethodType,
+  insertPaymentMethodType,
+  togglePaymentMethodTypeActive,
+  updatePaymentMethodType,
+} from "@/features/payment-method-types/infrastructure/paymentMethodTypeQueries";
+
+export function useInsertPaymentMethodType() {
+  const queryClient = useQueryClient();
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useMutation({
+    mutationFn: (values: PaymentMethodTypeFormValues) =>
+      insertPaymentMethodType(supabase, values),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [PAYMENT_METHOD_TYPES_QUERY_KEY],
+      });
+    },
+  });
+}
+
+export function useUpdatePaymentMethodType() {
+  const queryClient = useQueryClient();
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      values,
+    }: {
+      id: string;
+      values: Partial<PaymentMethodTypeFormValues>;
+    }) => updatePaymentMethodType(supabase, id, values),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [PAYMENT_METHOD_TYPES_QUERY_KEY],
+      });
+    },
+  });
+}
+
+export function useDeletePaymentMethodType() {
+  const queryClient = useQueryClient();
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useMutation({
+    mutationFn: (id: string) => deletePaymentMethodType(supabase, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [PAYMENT_METHOD_TYPES_QUERY_KEY],
+      });
+    },
+  });
+}
+
+export function useTogglePaymentMethodTypeActive() {
+  const queryClient = useQueryClient();
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useMutation({
+    mutationFn: ({ id, isActive }: { id: string; isActive: boolean }) =>
+      togglePaymentMethodTypeActive(supabase, id, isActive),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [PAYMENT_METHOD_TYPES_QUERY_KEY],
+      });
+    },
+  });
+}

--- a/apps/admin/src/features/payment-method-types/application/hooks/usePaymentMethodTypes.ts
+++ b/apps/admin/src/features/payment-method-types/application/hooks/usePaymentMethodTypes.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { createBrowserSupabaseClient } from "api/supabase";
+import { useMemo } from "react";
+
+import { PAYMENT_METHOD_TYPES_QUERY_KEY } from "@/features/payment-method-types/domain/constants";
+import { fetchPaymentMethodTypes } from "@/features/payment-method-types/infrastructure/paymentMethodTypeQueries";
+
+export function usePaymentMethodTypes() {
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- supabase client is stable (memoized)
+    queryKey: [PAYMENT_METHOD_TYPES_QUERY_KEY],
+    queryFn: () => fetchPaymentMethodTypes(supabase),
+    staleTime: 30_000,
+  });
+}

--- a/apps/admin/src/features/payment-method-types/domain/constants.ts
+++ b/apps/admin/src/features/payment-method-types/domain/constants.ts
@@ -1,0 +1,14 @@
+import type { PaymentMethodTypeFormValues } from "./types";
+
+export const PAYMENT_METHOD_TYPES_QUERY_KEY = "payment-method-types";
+
+export const PAYMENT_METHOD_TYPE_FORM_DEFAULTS: PaymentMethodTypeFormValues = {
+  name_en: "",
+  name_es: "",
+  description_en: "",
+  description_es: "",
+  icon: "",
+  requires_receipt: true,
+  requires_transfer_number: true,
+  is_active: true,
+};

--- a/apps/admin/src/features/payment-method-types/domain/types.ts
+++ b/apps/admin/src/features/payment-method-types/domain/types.ts
@@ -1,0 +1,25 @@
+export interface PaymentMethodType {
+  id: string;
+  name_en: string;
+  name_es: string;
+  description_en: string | null;
+  description_es: string | null;
+  icon: string | null;
+  requires_receipt: boolean;
+  requires_transfer_number: boolean;
+  is_active: boolean;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PaymentMethodTypeFormValues {
+  name_en: string;
+  name_es: string;
+  description_en: string;
+  description_es: string;
+  icon: string;
+  requires_receipt: boolean;
+  requires_transfer_number: boolean;
+  is_active: boolean;
+}

--- a/apps/admin/src/features/payment-method-types/index.ts
+++ b/apps/admin/src/features/payment-method-types/index.ts
@@ -1,0 +1,1 @@
+export { PaymentMethodTypesPage } from "./presentation/pages/PaymentMethodTypesPage";

--- a/apps/admin/src/features/payment-method-types/infrastructure/paymentMethodTypeQueries.ts
+++ b/apps/admin/src/features/payment-method-types/infrastructure/paymentMethodTypeQueries.ts
@@ -1,0 +1,80 @@
+import type { createBrowserSupabaseClient } from "api/supabase";
+
+import type {
+  PaymentMethodType,
+  PaymentMethodTypeFormValues,
+} from "@/features/payment-method-types/domain/types";
+
+type SupabaseClient = ReturnType<typeof createBrowserSupabaseClient>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- table not in generated types yet
+const TABLE = "payment_method_types" as any;
+
+/** Fetch all payment method types ordered by sort_order */
+export async function fetchPaymentMethodTypes(
+  supabase: SupabaseClient,
+): Promise<PaymentMethodType[]> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select("*")
+    .order("sort_order", { ascending: true });
+
+  if (error) throw error;
+  return data as unknown as PaymentMethodType[];
+}
+
+/** Create a new payment method type */
+export async function insertPaymentMethodType(
+  supabase: SupabaseClient,
+  values: PaymentMethodTypeFormValues,
+): Promise<PaymentMethodType> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .insert(values)
+    .select("*")
+    .single();
+
+  if (error) throw error;
+  return data as unknown as PaymentMethodType;
+}
+
+/** Update an existing payment method type */
+export async function updatePaymentMethodType(
+  supabase: SupabaseClient,
+  id: string,
+  values: Partial<PaymentMethodTypeFormValues>,
+): Promise<PaymentMethodType> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update(values)
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (error) throw error;
+  return data as unknown as PaymentMethodType;
+}
+
+/** Delete a payment method type by ID */
+export async function deletePaymentMethodType(
+  supabase: SupabaseClient,
+  id: string,
+): Promise<void> {
+  const { error } = await supabase.from(TABLE).delete().eq("id", id);
+
+  if (error) throw error;
+}
+
+/** Toggle the is_active field on a payment method type */
+export async function togglePaymentMethodTypeActive(
+  supabase: SupabaseClient,
+  id: string,
+  isActive: boolean,
+): Promise<void> {
+  const { error } = await supabase
+    .from(TABLE)
+    .update({ is_active: isActive })
+    .eq("id", id);
+
+  if (error) throw error;
+}

--- a/apps/admin/src/features/payment-method-types/presentation/components/PaymentMethodTypeEditor.tsx
+++ b/apps/admin/src/features/payment-method-types/presentation/components/PaymentMethodTypeEditor.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { tid } from "shared";
+import { Input, Switch } from "ui";
+
+import { PAYMENT_METHOD_TYPE_FORM_DEFAULTS } from "@/features/payment-method-types/domain/constants";
+import type { PaymentMethodTypeFormValues } from "@/features/payment-method-types/domain/types";
+
+interface PaymentMethodTypeEditorProps {
+  initial?: PaymentMethodTypeFormValues;
+  isSaving: boolean;
+  onSave: (values: PaymentMethodTypeFormValues) => void;
+  onCancel: () => void;
+}
+
+export function PaymentMethodTypeEditor({
+  initial,
+  isSaving,
+  onSave,
+  onCancel,
+}: PaymentMethodTypeEditorProps) {
+  const t = useTranslations("paymentMethodTypes");
+  const [form, setForm] = useState<PaymentMethodTypeFormValues>(
+    initial ?? PAYMENT_METHOD_TYPE_FORM_DEFAULTS,
+  );
+
+  const updateField = <K extends keyof PaymentMethodTypeFormValues>(
+    key: K,
+    value: PaymentMethodTypeFormValues[K],
+  ) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <div
+      className="flex flex-col gap-6 border-3 border-foreground bg-background p-6 nb-shadow-md"
+      {...tid("payment-type-editor")}
+    >
+      {/* Name fields */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1">
+          <label className="font-display text-xs font-bold uppercase tracking-wider">
+            {t("name")}{" "}
+            {
+              "(EN)" /* eslint-disable-line i18next/no-literal-string -- language code */
+            }
+          </label>
+          <Input
+            value={form.name_en}
+            onChange={(e) => updateField("name_en", e.target.value)}
+            {...tid("payment-type-name-en")}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="font-display text-xs font-bold uppercase tracking-wider">
+            {t("name")}{" "}
+            {
+              "(ES)" /* eslint-disable-line i18next/no-literal-string -- language code */
+            }
+          </label>
+          <Input
+            value={form.name_es}
+            onChange={(e) => updateField("name_es", e.target.value)}
+            {...tid("payment-type-name-es")}
+          />
+        </div>
+      </div>
+
+      {/* Description fields */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1">
+          <label className="font-display text-xs font-bold uppercase tracking-wider">
+            {t("description")}{" "}
+            {
+              "(EN)" /* eslint-disable-line i18next/no-literal-string -- language code */
+            }
+          </label>
+          <Input
+            value={form.description_en}
+            onChange={(e) => updateField("description_en", e.target.value)}
+            {...tid("payment-type-desc-en")}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="font-display text-xs font-bold uppercase tracking-wider">
+            {t("description")}{" "}
+            {
+              "(ES)" /* eslint-disable-line i18next/no-literal-string -- language code */
+            }
+          </label>
+          <Input
+            value={form.description_es}
+            onChange={(e) => updateField("description_es", e.target.value)}
+            {...tid("payment-type-desc-es")}
+          />
+        </div>
+      </div>
+
+      {/* Icon */}
+      <div className="flex flex-col gap-1">
+        <label className="font-display text-xs font-bold uppercase tracking-wider">
+          {t("icon")}
+        </label>
+        <Input
+          value={form.icon}
+          onChange={(e) => updateField("icon", e.target.value)}
+          placeholder="Building, Smartphone, Globe..." // eslint-disable-line i18next/no-literal-string -- icon examples
+          {...tid("payment-type-icon")}
+        />
+      </div>
+
+      {/* Toggles */}
+      <div className="grid grid-cols-3 gap-6">
+        <label className="flex items-center gap-3">
+          <Switch
+            checked={form.requires_receipt}
+            onCheckedChange={(checked: boolean) =>
+              updateField("requires_receipt", checked)
+            }
+            {...tid("payment-type-requires-receipt")}
+          />
+          <span className="font-display text-xs font-bold uppercase tracking-wider">
+            {t("requiresReceipt")}
+          </span>
+        </label>
+
+        <label className="flex items-center gap-3">
+          <Switch
+            checked={form.requires_transfer_number}
+            onCheckedChange={(checked: boolean) =>
+              updateField("requires_transfer_number", checked)
+            }
+            {...tid("payment-type-requires-transfer")}
+          />
+          <span className="font-display text-xs font-bold uppercase tracking-wider">
+            {t("requiresTransferNumber")}
+          </span>
+        </label>
+
+        <label className="flex items-center gap-3">
+          <Switch
+            checked={form.is_active}
+            onCheckedChange={(checked: boolean) =>
+              updateField("is_active", checked)
+            }
+            {...tid("payment-type-is-active")}
+          />
+          <span className="font-display text-xs font-bold uppercase tracking-wider">
+            {t("active")}
+          </span>
+        </label>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-end gap-3 border-t-2 border-foreground/10 pt-4">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-sm border-2 border-foreground px-5 py-2 font-display text-xs font-bold uppercase tracking-widest transition-colors hover:bg-muted"
+          {...tid("payment-type-cancel")}
+        >
+          {t("cancel")}
+        </button>
+        <button
+          type="button"
+          onClick={() => onSave(form)}
+          disabled={isSaving}
+          className="rounded-sm border-2 border-foreground bg-foreground px-5 py-2 font-display text-xs font-bold uppercase tracking-widest text-background transition-colors hover:bg-foreground/90 disabled:opacity-50"
+          {...tid("payment-type-save")}
+        >
+          {isSaving ? t("saving") : t("save")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/payment-method-types/presentation/components/PaymentMethodTypeTable.tsx
+++ b/apps/admin/src/features/payment-method-types/presentation/components/PaymentMethodTypeTable.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Pencil, Trash2 } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { tid } from "shared";
+import { Switch } from "ui";
+
+import type { PaymentMethodType } from "@/features/payment-method-types/domain/types";
+
+interface PaymentMethodTypeTableProps {
+  types: PaymentMethodType[];
+  isLoading: boolean;
+  onEdit: (type: PaymentMethodType) => void;
+  onDelete: (id: string) => void;
+  onToggleActive: (id: string, isActive: boolean) => void;
+}
+
+const GRID_COLS = "grid-cols-[1fr_1fr_80px_100px_100px_80px_100px]";
+
+export function PaymentMethodTypeTable({
+  types,
+  isLoading,
+  onEdit,
+  onDelete,
+  onToggleActive,
+}: PaymentMethodTypeTableProps) {
+  const t = useTranslations("paymentMethodTypes");
+  const tCommon = useTranslations("common");
+  const locale = useLocale();
+
+  if (isLoading && types.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        {tCommon("loading")}
+      </div>
+    );
+  }
+
+  if (types.length === 0) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center gap-2 rounded-xl border-3 border-dashed border-border bg-muted/30 py-16"
+        {...tid("payment-types-empty")}
+      >
+        <p className="font-display text-lg font-bold uppercase">
+          {t("noTypes")}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="overflow-x-auto border-3 border-foreground bg-background nb-shadow-md"
+      {...tid("payment-types-table")}
+    >
+      {/* Header row */}
+      <div
+        className={`grid ${GRID_COLS} border-b-3 border-foreground bg-muted/50`}
+      >
+        <span className="px-4 py-3 font-display text-xs font-bold uppercase tracking-wider">
+          {t("name")}
+        </span>
+        <span className="px-4 py-3 font-display text-xs font-bold uppercase tracking-wider">
+          {t("description")}
+        </span>
+        <span className="px-4 py-3 font-display text-xs font-bold uppercase tracking-wider">
+          {t("icon")}
+        </span>
+        <span className="px-4 py-3 font-display text-xs font-bold uppercase tracking-wider">
+          {t("requiresReceipt")}
+        </span>
+        <span className="px-4 py-3 font-display text-xs font-bold uppercase tracking-wider">
+          {t("requiresTransferNumber")}
+        </span>
+        <span className="px-4 py-3 font-display text-xs font-bold uppercase tracking-wider">
+          {t("active")}
+        </span>
+        <span className="px-4 py-3 font-display text-xs font-bold uppercase tracking-wider" />
+      </div>
+
+      {/* Data rows */}
+      <div className="divide-y divide-foreground/8">
+        {types.map((type) => {
+          const name = locale === "es" ? type.name_es : type.name_en;
+          const description =
+            locale === "es" ? type.description_es : type.description_en;
+
+          return (
+            <div
+              key={type.id}
+              className={`grid ${GRID_COLS} items-center transition-colors hover:bg-muted/30`}
+              {...tid(`payment-type-row-${type.id}`)}
+            >
+              {/* Name */}
+              <span className="truncate px-4 py-2.5 font-mono text-sm font-bold">
+                {name}
+              </span>
+
+              {/* Description */}
+              <span className="truncate px-4 py-2.5 text-xs text-muted-foreground">
+                {description ?? "\u2014"}
+              </span>
+
+              {/* Icon */}
+              <span className="px-4 py-2.5 font-mono text-xs">
+                {type.icon ?? "\u2014"}
+              </span>
+
+              {/* Requires receipt */}
+              <span className="px-4 py-2.5 font-mono text-xs">
+                {type.requires_receipt ? "\u2713" : "\u2014"}
+              </span>
+
+              {/* Requires transfer number */}
+              <span className="px-4 py-2.5 font-mono text-xs">
+                {type.requires_transfer_number ? "\u2713" : "\u2014"}
+              </span>
+
+              {/* Active toggle */}
+              <span className="px-4 py-2.5">
+                <Switch
+                  checked={type.is_active}
+                  onCheckedChange={(checked: boolean) =>
+                    onToggleActive(type.id, checked)
+                  }
+                  {...tid(`payment-type-active-${type.id}`)}
+                />
+              </span>
+
+              {/* Actions */}
+              <span className="flex items-center gap-1 px-4 py-2.5">
+                <button
+                  type="button"
+                  onClick={() => onEdit(type)}
+                  aria-label={t("editPaymentType")}
+                  className="rounded-sm p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  {...tid(`payment-type-edit-${type.id}`)}
+                >
+                  <Pencil className="size-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (globalThis.confirm(t("deleteConfirm"))) {
+                      onDelete(type.id);
+                    }
+                  }}
+                  aria-label={t("deletePaymentType")}
+                  className="rounded-sm p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                  {...tid(`payment-type-delete-${type.id}`)}
+                >
+                  <Trash2 className="size-3.5" />
+                </button>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/payment-method-types/presentation/pages/PaymentMethodTypesPage.tsx
+++ b/apps/admin/src/features/payment-method-types/presentation/pages/PaymentMethodTypesPage.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { tid } from "shared";
+
+import {
+  useDeletePaymentMethodType,
+  useInsertPaymentMethodType,
+  useTogglePaymentMethodTypeActive,
+  useUpdatePaymentMethodType,
+} from "@/features/payment-method-types/application/hooks/usePaymentMethodTypeMutations";
+import { usePaymentMethodTypes } from "@/features/payment-method-types/application/hooks/usePaymentMethodTypes";
+import type {
+  PaymentMethodType,
+  PaymentMethodTypeFormValues,
+} from "@/features/payment-method-types/domain/types";
+import { PaymentMethodTypeEditor } from "@/features/payment-method-types/presentation/components/PaymentMethodTypeEditor";
+import { PaymentMethodTypeTable } from "@/features/payment-method-types/presentation/components/PaymentMethodTypeTable";
+
+type EditorState =
+  | { mode: "closed" }
+  | { mode: "create" }
+  | { mode: "edit"; paymentType: PaymentMethodType };
+
+export function PaymentMethodTypesPage() {
+  const t = useTranslations("paymentMethodTypes");
+  const { data: types, isLoading } = usePaymentMethodTypes();
+  const insertMutation = useInsertPaymentMethodType();
+  const updateMutation = useUpdatePaymentMethodType();
+  const deleteMutation = useDeletePaymentMethodType();
+  const toggleMutation = useTogglePaymentMethodTypeActive();
+
+  const [editor, setEditor] = useState<EditorState>({ mode: "closed" });
+
+  const handleSave = (values: PaymentMethodTypeFormValues) => {
+    if (editor.mode === "create") {
+      insertMutation.mutate(values, {
+        onSuccess: () => setEditor({ mode: "closed" }),
+      });
+    } else if (editor.mode === "edit") {
+      updateMutation.mutate(
+        { id: editor.paymentType.id, values },
+        { onSuccess: () => setEditor({ mode: "closed" }) },
+      );
+    }
+  };
+
+  const isSaving = insertMutation.isPending || updateMutation.isPending;
+
+  return (
+    <main
+      className="flex flex-1 flex-col bg-dots"
+      {...tid("payment-types-page")}
+    >
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 py-8">
+        {/* Header */}
+        <header className="flex items-start justify-between">
+          <div>
+            <h1
+              className="font-display text-4xl font-extrabold uppercase tracking-tight"
+              {...tid("payment-types-title")}
+            >
+              {t("title")}
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {t("subtitle")}
+            </p>
+          </div>
+          {editor.mode === "closed" && (
+            <button
+              type="button"
+              onClick={() => setEditor({ mode: "create" })}
+              className="flex items-center gap-2 border-3 border-foreground bg-foreground px-4 py-2.5 font-display text-xs font-bold uppercase tracking-widest text-background transition-colors hover:bg-foreground/90 nb-shadow-sm"
+              {...tid("payment-types-add")}
+            >
+              <Plus className="size-4" strokeWidth={3} />
+              {t("addType")}
+            </button>
+          )}
+        </header>
+
+        {/* Editor or Table */}
+        {editor.mode === "closed" ? (
+          <PaymentMethodTypeTable
+            types={types ?? []}
+            isLoading={isLoading}
+            onEdit={(paymentType) => setEditor({ mode: "edit", paymentType })}
+            onDelete={(id) => deleteMutation.mutate(id)}
+            onToggleActive={(id, isActive) =>
+              toggleMutation.mutate({ id, isActive })
+            }
+          />
+        ) : (
+          <PaymentMethodTypeEditor
+            initial={
+              editor.mode === "edit"
+                ? {
+                    name_en: editor.paymentType.name_en,
+                    name_es: editor.paymentType.name_es,
+                    description_en: editor.paymentType.description_en ?? "",
+                    description_es: editor.paymentType.description_es ?? "",
+                    icon: editor.paymentType.icon ?? "",
+                    requires_receipt: editor.paymentType.requires_receipt,
+                    requires_transfer_number:
+                      editor.paymentType.requires_transfer_number,
+                    is_active: editor.paymentType.is_active,
+                  }
+                : undefined
+            }
+            isSaving={isSaving}
+            onSave={handleSave}
+            onCancel={() => setEditor({ mode: "closed" })}
+          />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/admin/src/features/settings/application/hooks/usePaymentSettings.ts
+++ b/apps/admin/src/features/settings/application/hooks/usePaymentSettings.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { createBrowserSupabaseClient } from "api/supabase";
+import { useMemo } from "react";
+
+import { SETTINGS_QUERY_KEY } from "@/features/settings/domain/constants";
+import { fetchPaymentSettings } from "@/features/settings/infrastructure/settingsQueries";
+
+export function usePaymentSettings() {
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- supabase client is stable (memoized)
+    queryKey: [SETTINGS_QUERY_KEY],
+    queryFn: () => fetchPaymentSettings(supabase),
+    staleTime: 30_000,
+  });
+}

--- a/apps/admin/src/features/settings/application/hooks/useUpdateSettings.ts
+++ b/apps/admin/src/features/settings/application/hooks/useUpdateSettings.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createBrowserSupabaseClient } from "api/supabase";
+import { useMemo } from "react";
+
+import { SETTINGS_QUERY_KEY } from "@/features/settings/domain/constants";
+import { updatePaymentSetting } from "@/features/settings/infrastructure/settingsQueries";
+
+export function useUpdateSettings() {
+  const queryClient = useQueryClient();
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useMutation({
+    mutationFn: ({ key, value }: { key: string; value: string }) =>
+      updatePaymentSetting(supabase, key, Number(value)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [SETTINGS_QUERY_KEY] });
+    },
+  });
+}

--- a/apps/admin/src/features/settings/domain/constants.ts
+++ b/apps/admin/src/features/settings/domain/constants.ts
@@ -1,0 +1,7 @@
+export const SETTINGS_QUERY_KEY = "payment-settings";
+
+export const DEFAULT_SETTINGS = {
+  timeout_awaiting_payment_hours: 48,
+  timeout_pending_verification_hours: 72,
+  timeout_evidence_requested_hours: 24,
+};

--- a/apps/admin/src/features/settings/domain/types.ts
+++ b/apps/admin/src/features/settings/domain/types.ts
@@ -1,0 +1,11 @@
+export interface PaymentSettings {
+  timeout_awaiting_payment_hours: number;
+  timeout_pending_verification_hours: number;
+  timeout_evidence_requested_hours: number;
+}
+
+export const SETTING_KEYS: (keyof PaymentSettings)[] = [
+  "timeout_awaiting_payment_hours",
+  "timeout_pending_verification_hours",
+  "timeout_evidence_requested_hours",
+];

--- a/apps/admin/src/features/settings/index.ts
+++ b/apps/admin/src/features/settings/index.ts
@@ -1,0 +1,1 @@
+export { SettingsPage } from "./presentation/pages/SettingsPage";

--- a/apps/admin/src/features/settings/infrastructure/settingsQueries.ts
+++ b/apps/admin/src/features/settings/infrastructure/settingsQueries.ts
@@ -1,0 +1,51 @@
+import type { createBrowserSupabaseClient } from "api/supabase";
+
+import { DEFAULT_SETTINGS } from "@/features/settings/domain/constants";
+import type { PaymentSettings } from "@/features/settings/domain/types";
+
+type SupabaseClient = ReturnType<typeof createBrowserSupabaseClient>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- table not in generated types yet
+const TABLE = "payment_settings" as any;
+
+/** Fetch all payment settings and parse into a typed object */
+export async function fetchPaymentSettings(
+  supabase: SupabaseClient,
+): Promise<PaymentSettings> {
+  const { data, error } = await supabase.from(TABLE).select("*");
+
+  if (error) throw error;
+
+  const rows = (data ?? []) as unknown as { key: string; value: string }[];
+  const record: Record<string, string> = {};
+  for (const row of rows) {
+    record[row.key] = row.value;
+  }
+
+  return {
+    timeout_awaiting_payment_hours:
+      Number(record.timeout_awaiting_payment_hours) ||
+      DEFAULT_SETTINGS.timeout_awaiting_payment_hours,
+    timeout_pending_verification_hours:
+      Number(record.timeout_pending_verification_hours) ||
+      DEFAULT_SETTINGS.timeout_pending_verification_hours,
+    timeout_evidence_requested_hours:
+      Number(record.timeout_evidence_requested_hours) ||
+      DEFAULT_SETTINGS.timeout_evidence_requested_hours,
+  };
+}
+
+/** Upsert a single payment setting by key */
+export async function updatePaymentSetting(
+  supabase: SupabaseClient,
+  key: string,
+  value: number,
+): Promise<void> {
+  const { error } = await supabase.from(TABLE).upsert({
+    key,
+    value: String(value),
+    updated_at: new Date().toISOString(),
+  });
+
+  if (error) throw error;
+}

--- a/apps/admin/src/features/settings/presentation/components/TimeoutSettings.tsx
+++ b/apps/admin/src/features/settings/presentation/components/TimeoutSettings.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { tid } from "shared";
+import { Input } from "ui";
+
+import type { PaymentSettings } from "@/features/settings/domain/types";
+
+interface TimeoutSettingsProps {
+  settings: PaymentSettings;
+  onSave: (settings: PaymentSettings) => void;
+  isPending: boolean;
+}
+
+const TIMEOUT_FIELDS = [
+  {
+    key: "timeout_awaiting_payment_hours" as const,
+    labelKey: "awaitingPayment",
+    hintKey: "awaitingPaymentHint",
+  },
+  {
+    key: "timeout_pending_verification_hours" as const,
+    labelKey: "pendingVerification",
+    hintKey: "pendingVerificationHint",
+  },
+  {
+    key: "timeout_evidence_requested_hours" as const,
+    labelKey: "evidenceRequested",
+    hintKey: "evidenceRequestedHint",
+  },
+];
+
+export function TimeoutSettings({
+  settings,
+  onSave,
+  isPending,
+}: TimeoutSettingsProps) {
+  const t = useTranslations("settings");
+  const [local, setLocal] = useState<PaymentSettings>(settings);
+
+  const handleChange = (key: keyof PaymentSettings, value: number) => {
+    setLocal((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <div
+      className="border-3 border-foreground bg-background p-6 nb-shadow-sm"
+      {...tid("timeout-settings-card")}
+    >
+      <h2 className="mb-4 font-display text-xl font-extrabold uppercase tracking-tight">
+        {t("timeouts.title")}
+      </h2>
+
+      <div className="flex flex-col gap-5">
+        {TIMEOUT_FIELDS.map(({ key, labelKey, hintKey }) => (
+          <div key={key} className="flex flex-col gap-1.5">
+            <label
+              htmlFor={key}
+              className="font-display text-sm font-bold uppercase tracking-wider"
+            >
+              {t(`timeouts.${labelKey}`)}
+            </label>
+            <div className="flex items-center gap-2">
+              <Input
+                id={key}
+                type="number"
+                min={1}
+                value={local[key]}
+                onChange={(e) => handleChange(key, Number(e.target.value))}
+                className="w-28 border-2 border-foreground"
+                {...tid(`timeout-input-${key}`)}
+              />
+              <span className="text-sm text-muted-foreground">
+                {t("timeouts.hours")}
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {t(`timeouts.${hintKey}`)}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onSave(local)}
+        disabled={isPending}
+        className="mt-6 border-3 border-foreground bg-foreground px-5 py-2.5 font-display text-xs font-bold uppercase tracking-widest text-background transition-colors hover:bg-foreground/90 disabled:opacity-50"
+        {...tid("timeout-settings-save")}
+      >
+        {isPending ? t("saving") : t("save")}
+      </button>
+    </div>
+  );
+}

--- a/apps/admin/src/features/settings/presentation/pages/SettingsPage.tsx
+++ b/apps/admin/src/features/settings/presentation/pages/SettingsPage.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { tid } from "shared";
+import { Skeleton } from "ui";
+
+import { usePaymentSettings } from "@/features/settings/application/hooks/usePaymentSettings";
+import { useUpdateSettings } from "@/features/settings/application/hooks/useUpdateSettings";
+import type { PaymentSettings } from "@/features/settings/domain/types";
+import { SETTING_KEYS } from "@/features/settings/domain/types";
+import { TimeoutSettings } from "@/features/settings/presentation/components/TimeoutSettings";
+
+export function SettingsPage() {
+  const t = useTranslations("settings");
+  const { data: settings, isLoading, isError } = usePaymentSettings();
+  const updateMutation = useUpdateSettings();
+
+  const handleSave = (updated: PaymentSettings) => {
+    for (const key of SETTING_KEYS) {
+      if (!settings || updated[key] !== settings[key]) {
+        updateMutation.mutate({ key, value: String(updated[key]) });
+      }
+    }
+  };
+
+  return (
+    <main className="flex flex-1 flex-col bg-dots" {...tid("settings-page")}>
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 py-8">
+        {/* Header */}
+        <header>
+          <h1
+            className="font-display text-4xl font-extrabold uppercase tracking-tight"
+            {...tid("settings-title")}
+          >
+            {t("title")}
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">{t("subtitle")}</p>
+        </header>
+
+        {/* Content */}
+        {isLoading && (
+          <div className="flex flex-col gap-4" {...tid("settings-loading")}>
+            <Skeleton className="h-10 w-64" />
+            <Skeleton className="h-48 w-full" />
+          </div>
+        )}
+
+        {isError && (
+          <div
+            className="border-3 border-destructive bg-destructive/10 p-4 font-display text-sm font-bold uppercase tracking-wider text-destructive"
+            {...tid("settings-error")}
+          >
+            {t("error")}
+          </div>
+        )}
+
+        {settings && (
+          <TimeoutSettings
+            settings={settings}
+            onSave={handleSave}
+            isPending={updateMutation.isPending}
+          />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/admin/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/admin/src/shared/infrastructure/i18n/messages/en.json
@@ -28,7 +28,10 @@
     "monitoring": "Monitoring",
     "system": "System",
     "version": "v0.1.0",
-    "status": "All systems nominal"
+    "status": "All systems nominal",
+    "paymentMethods": "Payment Methods",
+    "settings": "Settings",
+    "configuration": "Configuration"
   },
   "dashboard": {
     "welcome": "Good to see you, operator.",
@@ -130,6 +133,43 @@
     "removeItem": "Remove item",
     "removeSection": "Remove section",
     "deleteTemplate": "Delete template"
+  },
+  "paymentMethodTypes": {
+    "title": "Payment Method Types",
+    "subtitle": "Manage payment options available to sellers",
+    "addType": "Add Type",
+    "editType": "Edit Type",
+    "name": "Name",
+    "description": "Description",
+    "icon": "Icon",
+    "requiresReceipt": "Requires Receipt",
+    "requiresTransferNumber": "Requires Transfer Number",
+    "active": "Active",
+    "noTypes": "No payment method types yet",
+    "deleteConfirm": "Deactivate this payment method type? Sellers using it will no longer be able to accept new payments with it.",
+    "save": "Save",
+    "saving": "Saving...",
+    "cancel": "Cancel",
+    "editPaymentType": "Edit payment type",
+    "deletePaymentType": "Delete payment type"
+  },
+  "settings": {
+    "title": "Platform Settings",
+    "subtitle": "Global configuration for the platform",
+    "timeouts": {
+      "title": "Payment Timeouts",
+      "awaitingPayment": "Awaiting Payment",
+      "awaitingPaymentHint": "Hours before unpaid order expires",
+      "pendingVerification": "Pending Verification",
+      "pendingVerificationHint": "Hours seller has to verify receipt",
+      "evidenceRequested": "Evidence Requested",
+      "evidenceRequestedHint": "Hours buyer has to re-upload evidence",
+      "hours": "hours"
+    },
+    "save": "Save Settings",
+    "saving": "Saving...",
+    "saved": "Settings updated",
+    "error": "Failed to save settings"
   },
   "common": {
     "loading": "Loading...",

--- a/apps/admin/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/admin/src/shared/infrastructure/i18n/messages/es.json
@@ -28,7 +28,10 @@
     "monitoring": "Monitoreo",
     "system": "Sistema",
     "version": "v0.1.0",
-    "status": "Todos los sistemas nominales"
+    "status": "Todos los sistemas nominales",
+    "paymentMethods": "Metodos de Pago",
+    "settings": "Configuracion",
+    "configuration": "Configuracion"
   },
   "dashboard": {
     "welcome": "Buen día, operador.",
@@ -130,6 +133,43 @@
     "removeItem": "Eliminar elemento",
     "removeSection": "Eliminar seccion",
     "deleteTemplate": "Eliminar plantilla"
+  },
+  "paymentMethodTypes": {
+    "title": "Tipos de Metodo de Pago",
+    "subtitle": "Administra las opciones de pago disponibles para vendedores",
+    "addType": "Agregar Tipo",
+    "editType": "Editar Tipo",
+    "name": "Nombre",
+    "description": "Descripcion",
+    "icon": "Icono",
+    "requiresReceipt": "Requiere Comprobante",
+    "requiresTransferNumber": "Requiere Numero de Transferencia",
+    "active": "Activo",
+    "noTypes": "Sin tipos de metodo de pago aun",
+    "deleteConfirm": "Desactivar este tipo de metodo de pago? Los vendedores que lo usen ya no podran aceptar nuevos pagos con el.",
+    "save": "Guardar",
+    "saving": "Guardando...",
+    "cancel": "Cancelar",
+    "editPaymentType": "Editar tipo de pago",
+    "deletePaymentType": "Eliminar tipo de pago"
+  },
+  "settings": {
+    "title": "Configuracion de Plataforma",
+    "subtitle": "Configuracion global de la plataforma",
+    "timeouts": {
+      "title": "Tiempos de Pago",
+      "awaitingPayment": "Esperando Pago",
+      "awaitingPaymentHint": "Horas antes de que expire una orden sin pagar",
+      "pendingVerification": "Verificacion Pendiente",
+      "pendingVerificationHint": "Horas que el vendedor tiene para verificar el comprobante",
+      "evidenceRequested": "Evidencia Solicitada",
+      "evidenceRequestedHint": "Horas que el comprador tiene para reenviar la evidencia",
+      "hours": "horas"
+    },
+    "save": "Guardar Configuracion",
+    "saving": "Guardando...",
+    "saved": "Configuracion actualizada",
+    "error": "Error al guardar configuracion"
   },
   "common": {
     "loading": "Cargando...",

--- a/apps/admin/src/shared/presentation/components/AdminSidebar.tsx
+++ b/apps/admin/src/shared/presentation/components/AdminSidebar.tsx
@@ -3,10 +3,12 @@
 import {
   ChevronLeft,
   ChevronRight,
+  CreditCard,
   FileText,
   Layers,
   LayoutDashboard,
   Radio,
+  Settings,
 } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -21,11 +23,20 @@ const NAV_SECTIONS = [
     items: [
       { key: "dashboard" as const, href: "/", icon: LayoutDashboard },
       { key: "templates" as const, href: "/templates", icon: Layers },
+      {
+        key: "paymentMethods" as const,
+        href: "/payment-methods",
+        icon: CreditCard,
+      },
     ],
   },
   {
     labelKey: "monitoring" as const,
     items: [{ key: "auditLog" as const, href: "/audit", icon: FileText }],
+  },
+  {
+    labelKey: "configuration" as const,
+    items: [{ key: "settings" as const, href: "/settings", icon: Settings }],
   },
 ] as const;
 

--- a/apps/studio/src/app/[locale]/payment-methods/page.tsx
+++ b/apps/studio/src/app/[locale]/payment-methods/page.tsx
@@ -1,0 +1,14 @@
+import { setRequestLocale } from "next-intl/server";
+
+import { PaymentMethodsPage } from "@/features/payment-methods";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return <PaymentMethodsPage />;
+}

--- a/apps/studio/src/features/payment-methods/application/hooks/usePaymentMethodMutations.ts
+++ b/apps/studio/src/features/payment-methods/application/hooks/usePaymentMethodMutations.ts
@@ -1,0 +1,68 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createBrowserSupabaseClient } from "api/supabase";
+import { useMemo } from "react";
+
+import { PAYMENT_METHODS_QUERY_KEY } from "@/features/payment-methods/domain/constants";
+import type { SellerPaymentMethodFormValues } from "@/features/payment-methods/domain/types";
+import {
+  deleteSellerPaymentMethod,
+  insertSellerPaymentMethod,
+  toggleSellerPaymentMethodActive,
+  updateSellerPaymentMethod,
+} from "@/features/payment-methods/infrastructure/paymentMethodQueries";
+
+export function useInsertSellerPaymentMethod() {
+  const queryClient = useQueryClient();
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useMutation({
+    mutationFn: (values: SellerPaymentMethodFormValues) =>
+      insertSellerPaymentMethod(supabase, values),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [PAYMENT_METHODS_QUERY_KEY] });
+    },
+  });
+}
+
+export function useUpdateSellerPaymentMethod() {
+  const queryClient = useQueryClient();
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      values,
+    }: {
+      id: string;
+      values: SellerPaymentMethodFormValues;
+    }) => updateSellerPaymentMethod(supabase, id, values),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [PAYMENT_METHODS_QUERY_KEY] });
+    },
+  });
+}
+
+export function useDeleteSellerPaymentMethod() {
+  const queryClient = useQueryClient();
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useMutation({
+    mutationFn: (id: string) => deleteSellerPaymentMethod(supabase, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [PAYMENT_METHODS_QUERY_KEY] });
+    },
+  });
+}
+
+export function useToggleSellerPaymentMethodActive() {
+  const queryClient = useQueryClient();
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useMutation({
+    mutationFn: ({ id, isActive }: { id: string; isActive: boolean }) =>
+      toggleSellerPaymentMethodActive(supabase, id, isActive),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [PAYMENT_METHODS_QUERY_KEY] });
+    },
+  });
+}

--- a/apps/studio/src/features/payment-methods/application/hooks/usePaymentMethods.ts
+++ b/apps/studio/src/features/payment-methods/application/hooks/usePaymentMethods.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import { createBrowserSupabaseClient } from "api/supabase";
+import { useMemo } from "react";
+
+import {
+  PAYMENT_METHODS_QUERY_KEY,
+  PAYMENT_TYPES_QUERY_KEY,
+} from "@/features/payment-methods/domain/constants";
+import {
+  fetchPaymentMethodTypes,
+  fetchSellerPaymentMethods,
+} from "@/features/payment-methods/infrastructure/paymentMethodQueries";
+
+/** Fetch the admin-defined catalog of payment method types */
+export function usePaymentMethodTypes() {
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- supabase client is stable (memoized)
+    queryKey: [PAYMENT_TYPES_QUERY_KEY],
+    queryFn: () => fetchPaymentMethodTypes(supabase),
+  });
+}
+
+/** Fetch the seller's configured payment methods */
+export function useSellerPaymentMethods() {
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  return useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- supabase client is stable (memoized)
+    queryKey: [PAYMENT_METHODS_QUERY_KEY],
+    queryFn: () => fetchSellerPaymentMethods(supabase),
+  });
+}

--- a/apps/studio/src/features/payment-methods/domain/constants.ts
+++ b/apps/studio/src/features/payment-methods/domain/constants.ts
@@ -1,0 +1,13 @@
+import type { SellerPaymentMethodFormValues } from "./types";
+
+export const PAYMENT_METHODS_QUERY_KEY = "seller-payment-methods";
+export const PAYMENT_TYPES_QUERY_KEY = "payment-method-types";
+
+export const SELLER_PAYMENT_METHOD_DEFAULTS: SellerPaymentMethodFormValues = {
+  type_id: "",
+  account_details_en: "",
+  account_details_es: "",
+  seller_note_en: "",
+  seller_note_es: "",
+  is_active: true,
+};

--- a/apps/studio/src/features/payment-methods/domain/types.ts
+++ b/apps/studio/src/features/payment-methods/domain/types.ts
@@ -1,0 +1,37 @@
+/** Admin-defined payment method type from the catalog */
+export interface PaymentMethodType {
+  id: string;
+  name_en: string;
+  name_es: string;
+  description_en: string | null;
+  description_es: string | null;
+  icon: string | null;
+  requires_receipt: boolean;
+  requires_transfer_number: boolean;
+  is_active: boolean;
+}
+
+/** Seller's configured payment method (references a type) */
+export interface SellerPaymentMethod {
+  id: string;
+  seller_id: string;
+  type_id: string;
+  account_details_en: string | null;
+  account_details_es: string | null;
+  seller_note_en: string | null;
+  seller_note_es: string | null;
+  is_active: boolean;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Form values for creating/editing a seller payment method */
+export interface SellerPaymentMethodFormValues {
+  type_id: string;
+  account_details_en: string;
+  account_details_es: string;
+  seller_note_en: string;
+  seller_note_es: string;
+  is_active: boolean;
+}

--- a/apps/studio/src/features/payment-methods/index.ts
+++ b/apps/studio/src/features/payment-methods/index.ts
@@ -1,0 +1,1 @@
+export { PaymentMethodsPage } from "./presentation/pages/PaymentMethodsPage";

--- a/apps/studio/src/features/payment-methods/infrastructure/paymentMethodQueries.ts
+++ b/apps/studio/src/features/payment-methods/infrastructure/paymentMethodQueries.ts
@@ -1,0 +1,133 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- tables not in generated types yet */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "api/types/database";
+
+import type {
+  PaymentMethodType,
+  SellerPaymentMethod,
+  SellerPaymentMethodFormValues,
+} from "@/features/payment-methods/domain/types";
+
+type SupabaseDB = SupabaseClient<Database>;
+
+/** Fetch all active payment method types from the catalog */
+export async function fetchPaymentMethodTypes(
+  supabase: SupabaseDB,
+): Promise<PaymentMethodType[]> {
+  const { data, error } = await (supabase.from as any)("payment_method_types")
+    .select("*")
+    .eq("is_active", true)
+    .order("sort_order", { ascending: true });
+
+  if (error) throw error;
+  return data as PaymentMethodType[];
+}
+
+/** Fetch seller's configured payment methods */
+export async function fetchSellerPaymentMethods(
+  supabase: SupabaseDB,
+): Promise<SellerPaymentMethod[]> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { data, error } = await (supabase.from as any)("seller_payment_methods")
+    .select("*")
+    .eq("seller_id", user?.id ?? "")
+    .order("sort_order", { ascending: true });
+
+  if (error) throw error;
+  return data as SellerPaymentMethod[];
+}
+
+/** Get the next sort_order value for seller payment methods */
+async function getNextSortOrder(supabase: SupabaseDB): Promise<number> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { data } = await (supabase.from as any)("seller_payment_methods")
+    .select("sort_order")
+    .eq("seller_id", user?.id ?? "")
+    .order("sort_order", { ascending: false })
+    .limit(1)
+    .single();
+
+  return ((data as { sort_order: number } | null)?.sort_order ?? 0) + 1;
+}
+
+/** Insert a new seller payment method */
+export async function insertSellerPaymentMethod(
+  supabase: SupabaseDB,
+  values: SellerPaymentMethodFormValues,
+): Promise<SellerPaymentMethod> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const sortOrder = await getNextSortOrder(supabase);
+
+  const { data, error } = await (supabase.from as any)("seller_payment_methods")
+    .insert({
+      seller_id: user?.id ?? "",
+      type_id: values.type_id,
+      account_details_en: values.account_details_en || null,
+      account_details_es: values.account_details_es || null,
+      seller_note_en: values.seller_note_en || null,
+      seller_note_es: values.seller_note_es || null,
+      is_active: values.is_active,
+      sort_order: sortOrder,
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as SellerPaymentMethod;
+}
+
+/** Update an existing seller payment method */
+export async function updateSellerPaymentMethod(
+  supabase: SupabaseDB,
+  id: string,
+  values: SellerPaymentMethodFormValues,
+): Promise<SellerPaymentMethod> {
+  const { data, error } = await (supabase.from as any)("seller_payment_methods")
+    .update({
+      type_id: values.type_id,
+      account_details_en: values.account_details_en || null,
+      account_details_es: values.account_details_es || null,
+      seller_note_en: values.seller_note_en || null,
+      seller_note_es: values.seller_note_es || null,
+      is_active: values.is_active,
+    })
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as SellerPaymentMethod;
+}
+
+/** Delete a seller payment method */
+export async function deleteSellerPaymentMethod(
+  supabase: SupabaseDB,
+  id: string,
+): Promise<void> {
+  const { error } = await (supabase.from as any)("seller_payment_methods")
+    .delete()
+    .eq("id", id);
+
+  if (error) throw error;
+}
+
+/** Toggle active state on a seller payment method */
+export async function toggleSellerPaymentMethodActive(
+  supabase: SupabaseDB,
+  id: string,
+  isActive: boolean,
+): Promise<void> {
+  const { error } = await (supabase.from as any)("seller_payment_methods")
+    .update({ is_active: isActive })
+    .eq("id", id);
+
+  if (error) throw error;
+}

--- a/apps/studio/src/features/payment-methods/presentation/components/PaymentMethodEditor.tsx
+++ b/apps/studio/src/features/payment-methods/presentation/components/PaymentMethodEditor.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useLocale, useTranslations } from "next-intl";
+import { useState } from "react";
+import { tid } from "shared";
+import { Button, Switch } from "ui";
+
+import { SELLER_PAYMENT_METHOD_DEFAULTS } from "@/features/payment-methods/domain/constants";
+import type {
+  PaymentMethodType,
+  SellerPaymentMethodFormValues,
+} from "@/features/payment-methods/domain/types";
+
+const TEXTAREA_CLASS =
+  "flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs";
+
+interface PaymentMethodEditorProps {
+  types: PaymentMethodType[];
+  initial?: SellerPaymentMethodFormValues;
+  onSave: (values: SellerPaymentMethodFormValues) => void;
+  onCancel: () => void;
+  isPending: boolean;
+}
+
+export function PaymentMethodEditor({
+  types,
+  initial,
+  onSave,
+  onCancel,
+  isPending,
+}: PaymentMethodEditorProps) {
+  const t = useTranslations("paymentMethods");
+  const locale = useLocale();
+  const isEditing = !!initial?.type_id;
+
+  const [form, setForm] = useState<SellerPaymentMethodFormValues>(
+    initial ?? SELLER_PAYMENT_METHOD_DEFAULTS,
+  );
+
+  const handleChange = (
+    field: keyof SellerPaymentMethodFormValues,
+    value: string | boolean,
+  ) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = () => {
+    onSave(form);
+  };
+
+  const getTypeName = (type: PaymentMethodType): string => {
+    return locale === "es" ? type.name_es : type.name_en;
+  };
+
+  return (
+    <div
+      className="flex flex-col gap-6 rounded-xl border-3 border-border bg-background p-6 nb-shadow-md"
+      {...tid("payment-method-editor")}
+    >
+      <h2 className="font-display text-2xl font-bold uppercase tracking-tight">
+        {isEditing ? t("editMethod") : t("addMethod")}
+      </h2>
+
+      {/* Payment Type */}
+      <div className="flex flex-col gap-2">
+        <label
+          htmlFor="type_id"
+          className="text-sm font-semibold"
+          {...tid("payment-method-type-label")}
+        >
+          {t("selectType")}
+        </label>
+        <select
+          id="type_id"
+          className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs disabled:cursor-not-allowed disabled:opacity-50"
+          value={form.type_id}
+          onChange={(e) => handleChange("type_id", e.target.value)}
+          disabled={isEditing}
+          {...tid("payment-method-type-select")}
+        >
+          <option value="">{t("selectTypePlaceholder")}</option>
+          {types.map((type) => (
+            <option key={type.id} value={type.id}>
+              {getTypeName(type)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Account Details (EN) */}
+      <div className="flex flex-col gap-2">
+        <label htmlFor="account_details_en" className="text-sm font-semibold">
+          {t("accountDetails")}{" "}
+          {/* eslint-disable-next-line i18next/no-literal-string -- language code */}
+          {"(EN)"}
+        </label>
+        <textarea
+          id="account_details_en"
+          className={TEXTAREA_CLASS}
+          rows={3}
+          placeholder={t("accountDetailsHint")}
+          value={form.account_details_en}
+          onChange={(e) => handleChange("account_details_en", e.target.value)}
+          {...tid("payment-method-account-en")}
+        />
+      </div>
+
+      {/* Account Details (ES) */}
+      <div className="flex flex-col gap-2">
+        <label htmlFor="account_details_es" className="text-sm font-semibold">
+          {t("accountDetails")}{" "}
+          {/* eslint-disable-next-line i18next/no-literal-string -- language code */}
+          {"(ES)"}
+        </label>
+        <textarea
+          id="account_details_es"
+          className={TEXTAREA_CLASS}
+          rows={3}
+          placeholder={t("accountDetailsHint")}
+          value={form.account_details_es}
+          onChange={(e) => handleChange("account_details_es", e.target.value)}
+          {...tid("payment-method-account-es")}
+        />
+      </div>
+
+      {/* Seller Note (EN) */}
+      <div className="flex flex-col gap-2">
+        <label htmlFor="seller_note_en" className="text-sm font-semibold">
+          {t("sellerNote")}{" "}
+          {/* eslint-disable-next-line i18next/no-literal-string -- language code */}
+          {"(EN)"}
+        </label>
+        <textarea
+          id="seller_note_en"
+          className={TEXTAREA_CLASS}
+          rows={2}
+          placeholder={t("sellerNoteHint")}
+          value={form.seller_note_en}
+          onChange={(e) => handleChange("seller_note_en", e.target.value)}
+          {...tid("payment-method-note-en")}
+        />
+      </div>
+
+      {/* Seller Note (ES) */}
+      <div className="flex flex-col gap-2">
+        <label htmlFor="seller_note_es" className="text-sm font-semibold">
+          {t("sellerNote")}{" "}
+          {/* eslint-disable-next-line i18next/no-literal-string -- language code */}
+          {"(ES)"}
+        </label>
+        <textarea
+          id="seller_note_es"
+          className={TEXTAREA_CLASS}
+          rows={2}
+          placeholder={t("sellerNoteHint")}
+          value={form.seller_note_es}
+          onChange={(e) => handleChange("seller_note_es", e.target.value)}
+          {...tid("payment-method-note-es")}
+        />
+      </div>
+
+      {/* Active toggle */}
+      <div className="flex items-center gap-3">
+        <Switch
+          checked={form.is_active}
+          onCheckedChange={(checked: boolean) =>
+            handleChange("is_active", checked)
+          }
+          {...tid("payment-method-active-toggle")}
+        />
+        <label className="text-sm font-semibold">{t("active")}</label>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-3">
+        <Button
+          type="button"
+          className="nb-btn nb-shadow-md nb-btn-press-sm rounded-xl border-3 bg-brand px-6 py-3 text-brand-foreground hover:bg-brand-hover"
+          disabled={isPending || !form.type_id}
+          onClick={handleSubmit}
+          {...tid("payment-method-save")}
+        >
+          {isPending ? t("saving") : t("save")}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="rounded-xl border-3 px-6 py-3"
+          onClick={onCancel}
+          {...tid("payment-method-cancel")}
+        >
+          {t("cancel")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/src/features/payment-methods/presentation/components/PaymentMethodTable.tsx
+++ b/apps/studio/src/features/payment-methods/presentation/components/PaymentMethodTable.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { Pencil, Trash2 } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { tid } from "shared";
+import { Skeleton, Switch } from "ui";
+
+import type {
+  PaymentMethodType,
+  SellerPaymentMethod,
+} from "@/features/payment-methods/domain/types";
+
+const TABLE_HEADER_CLASS = "text-table-header px-4 py-3";
+const ZEBRA_MODULO = 2;
+const SKELETON_ROWS = 3;
+
+interface PaymentMethodTableProps {
+  methods: SellerPaymentMethod[];
+  types: PaymentMethodType[];
+  onEdit: (method: SellerPaymentMethod) => void;
+  onDelete: (id: string) => void;
+  onToggleActive: (id: string, isActive: boolean) => void;
+  isLoading: boolean;
+}
+
+export function PaymentMethodTable({
+  methods,
+  types,
+  onEdit,
+  onDelete,
+  onToggleActive,
+  isLoading,
+}: PaymentMethodTableProps) {
+  const t = useTranslations("paymentMethods");
+  const locale = useLocale();
+
+  const getTypeName = (typeId: string): string => {
+    const type = types.find((pt) => pt.id === typeId);
+    if (!type) return typeId;
+    return locale === "es" ? type.name_es : type.name_en;
+  };
+
+  if (isLoading) {
+    return (
+      <div
+        className="overflow-x-auto rounded-xl border-3 border-border bg-background nb-shadow-md"
+        {...tid("payment-methods-table-loading")}
+      >
+        <div className="flex flex-col gap-4 p-6">
+          {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+            // eslint-disable-next-line react/no-array-index-key -- static skeleton placeholders
+            <Skeleton key={i} className="h-12 w-full rounded-lg" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (methods.length === 0) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center gap-2 rounded-xl border-3 border-dashed border-border bg-muted/30 py-16"
+        {...tid("payment-methods-empty-state")}
+      >
+        <p className="font-display text-lg font-bold uppercase">
+          {t("noMethods")}
+        </p>
+        <p className="text-sm text-muted-foreground">{t("noMethodsHint")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="overflow-x-auto rounded-xl border-3 border-border bg-background nb-shadow-md"
+      {...tid("payment-methods-table")}
+    >
+      <table className="w-full">
+        <thead>
+          <tr className="border-b-3 border-border bg-muted/50">
+            <th className={`${TABLE_HEADER_CLASS} text-left`}>
+              {t("selectType")}
+            </th>
+            <th className={`${TABLE_HEADER_CLASS} text-center`}>
+              {t("active")}
+            </th>
+            <th className={`${TABLE_HEADER_CLASS} text-right`}>
+              {}
+              {""}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {methods.map((method, index) => (
+            <tr
+              key={method.id}
+              className={`border-b border-border last:border-b-0 ${index % ZEBRA_MODULO === 1 ? "bg-muted/20" : ""}`}
+              {...tid(`payment-method-row-${method.id}`)}
+            >
+              <td className="px-4 py-3 text-sm font-medium">
+                {getTypeName(method.type_id)}
+              </td>
+              <td className="px-4 py-3 text-center">
+                <Switch
+                  checked={method.is_active}
+                  onCheckedChange={(checked: boolean) =>
+                    onToggleActive(method.id, checked)
+                  }
+                  {...tid(`payment-method-active-${method.id}`)}
+                />
+              </td>
+              <td className="px-4 py-3 text-right">
+                <div className="flex items-center justify-end gap-1">
+                  <button
+                    type="button"
+                    className="rounded-lg p-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    aria-label={t("editPaymentMethod")}
+                    onClick={() => onEdit(method)}
+                    {...tid(`payment-method-edit-${method.id}`)}
+                  >
+                    <Pencil className="size-4" />
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-lg p-2 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                    aria-label={t("removeMethod")}
+                    onClick={() => {
+                      if (globalThis.confirm(t("deleteConfirm"))) {
+                        onDelete(method.id);
+                      }
+                    }}
+                    {...tid(`payment-method-delete-${method.id}`)}
+                  >
+                    <Trash2 className="size-4" />
+                  </button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/studio/src/features/payment-methods/presentation/pages/PaymentMethodsPage.tsx
+++ b/apps/studio/src/features/payment-methods/presentation/pages/PaymentMethodsPage.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { ArrowLeft, Plus } from "lucide-react";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { useCallback, useState } from "react";
+import { tid } from "shared";
+import { Button } from "ui";
+
+import {
+  useDeleteSellerPaymentMethod,
+  useInsertSellerPaymentMethod,
+  useToggleSellerPaymentMethodActive,
+  useUpdateSellerPaymentMethod,
+} from "@/features/payment-methods/application/hooks/usePaymentMethodMutations";
+import {
+  usePaymentMethodTypes,
+  useSellerPaymentMethods,
+} from "@/features/payment-methods/application/hooks/usePaymentMethods";
+import type {
+  SellerPaymentMethod,
+  SellerPaymentMethodFormValues,
+} from "@/features/payment-methods/domain/types";
+import { PaymentMethodEditor } from "@/features/payment-methods/presentation/components/PaymentMethodEditor";
+import { PaymentMethodTable } from "@/features/payment-methods/presentation/components/PaymentMethodTable";
+
+type EditorState =
+  | { mode: "closed" }
+  | { mode: "create" }
+  | { mode: "edit"; method: SellerPaymentMethod };
+
+export function PaymentMethodsPage() {
+  const t = useTranslations("paymentMethods");
+  const tCommon = useTranslations("common");
+
+  const { data: types, isLoading: typesLoading } = usePaymentMethodTypes();
+  const { data: methods, isLoading: methodsLoading } =
+    useSellerPaymentMethods();
+
+  const insertMutation = useInsertSellerPaymentMethod();
+  const updateMutation = useUpdateSellerPaymentMethod();
+  const deleteMutation = useDeleteSellerPaymentMethod();
+  const toggleMutation = useToggleSellerPaymentMethodActive();
+
+  const [editor, setEditor] = useState<EditorState>({ mode: "closed" });
+
+  const handleEdit = useCallback((method: SellerPaymentMethod) => {
+    setEditor({ mode: "edit", method });
+  }, []);
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      deleteMutation.mutate(id);
+    },
+    [deleteMutation],
+  );
+
+  const handleToggleActive = useCallback(
+    (id: string, isActive: boolean) => {
+      toggleMutation.mutate({ id, isActive });
+    },
+    [toggleMutation],
+  );
+
+  const handleSave = useCallback(
+    (values: SellerPaymentMethodFormValues) => {
+      if (editor.mode === "edit") {
+        updateMutation.mutate(
+          { id: editor.method.id, values },
+          { onSuccess: () => setEditor({ mode: "closed" }) },
+        );
+      } else {
+        insertMutation.mutate(values, {
+          onSuccess: () => setEditor({ mode: "closed" }),
+        });
+      }
+    },
+    [editor, insertMutation, updateMutation],
+  );
+
+  const handleCancel = useCallback(() => {
+    setEditor({ mode: "closed" });
+  }, []);
+
+  const isLoading = typesLoading || methodsLoading;
+
+  const editorInitial =
+    editor.mode === "edit"
+      ? {
+          type_id: editor.method.type_id,
+          account_details_en: editor.method.account_details_en ?? "",
+          account_details_es: editor.method.account_details_es ?? "",
+          seller_note_en: editor.method.seller_note_en ?? "",
+          seller_note_es: editor.method.seller_note_es ?? "",
+          is_active: editor.method.is_active,
+        }
+      : undefined;
+
+  if (isLoading) {
+    return (
+      <main className="flex flex-1 flex-col bg-dots">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-8">
+          <p className="text-muted-foreground">{tCommon("loading")}</p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main
+      className="flex flex-1 flex-col bg-dots"
+      {...tid("payment-methods-page")}
+    >
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-8">
+        {/* Back link */}
+        <Link
+          href="/"
+          className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+          {...tid("payment-methods-back")}
+        >
+          <ArrowLeft className="size-4" />
+          {t("backToProducts")}
+        </Link>
+
+        {/* Header */}
+        <header className="flex items-center justify-between">
+          <div>
+            <h1
+              className="font-display text-4xl font-extrabold uppercase tracking-tight"
+              {...tid("payment-methods-title")}
+            >
+              {t("title")}
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {t("subtitle")}
+            </p>
+          </div>
+          {editor.mode === "closed" && (
+            <Button
+              type="button"
+              className="nb-btn nb-shadow-md nb-btn-press-sm rounded-xl border-3 bg-brand px-6 py-3 text-brand-foreground hover:bg-brand-hover"
+              onClick={() => setEditor({ mode: "create" })}
+              {...tid("add-payment-method-button")}
+            >
+              <Plus className="size-5" />
+              {t("addMethod")}
+            </Button>
+          )}
+        </header>
+
+        {/* Editor or Table */}
+        {editor.mode === "closed" ? (
+          <PaymentMethodTable
+            methods={methods ?? []}
+            types={types ?? []}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+            onToggleActive={handleToggleActive}
+            isLoading={isLoading}
+          />
+        ) : (
+          <PaymentMethodEditor
+            types={types ?? []}
+            initial={editorInitial}
+            onSave={handleSave}
+            onCancel={handleCancel}
+            isPending={insertMutation.isPending || updateMutation.isPending}
+          />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/studio/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/studio/src/shared/infrastructure/i18n/messages/en.json
@@ -88,6 +88,28 @@
     "digital": "Digital",
     "deals": "Deals"
   },
+  "paymentMethods": {
+    "title": "My Payment Methods",
+    "subtitle": "Configure how buyers can pay you",
+    "addMethod": "Add Method",
+    "editMethod": "Edit Method",
+    "selectType": "Payment Type",
+    "selectTypePlaceholder": "Choose a payment method...",
+    "accountDetails": "Account Details",
+    "accountDetailsHint": "Bank account, phone number, or payment details",
+    "sellerNote": "Note to Buyers",
+    "sellerNoteHint": "Personal message shown to buyers (optional)",
+    "active": "Active",
+    "noMethods": "No payment methods configured yet",
+    "noMethodsHint": "Add a payment method so buyers can pay you",
+    "deleteConfirm": "Remove this payment method?",
+    "save": "Save",
+    "saving": "Saving...",
+    "cancel": "Cancel",
+    "backToProducts": "Products",
+    "removeMethod": "Remove method",
+    "editPaymentMethod": "Edit payment method"
+  },
   "form": {
     "subtitleCreate": "Fill in the details to create a new product.",
     "subtitleEdit": "Update the product details below.",

--- a/apps/studio/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/studio/src/shared/infrastructure/i18n/messages/es.json
@@ -88,6 +88,28 @@
     "digital": "Digital",
     "deals": "Ofertas"
   },
+  "paymentMethods": {
+    "title": "Mis Metodos de Pago",
+    "subtitle": "Configura como los compradores pueden pagarte",
+    "addMethod": "Agregar Metodo",
+    "editMethod": "Editar Metodo",
+    "selectType": "Tipo de Pago",
+    "selectTypePlaceholder": "Elige un metodo de pago...",
+    "accountDetails": "Datos de la Cuenta",
+    "accountDetailsHint": "Cuenta bancaria, numero de telefono o datos de pago",
+    "sellerNote": "Nota para Compradores",
+    "sellerNoteHint": "Mensaje personal mostrado a los compradores (opcional)",
+    "active": "Activo",
+    "noMethods": "Sin metodos de pago configurados aun",
+    "noMethodsHint": "Agrega un metodo de pago para que los compradores puedan pagarte",
+    "deleteConfirm": "Eliminar este metodo de pago?",
+    "save": "Guardar",
+    "saving": "Guardando...",
+    "cancel": "Cancelar",
+    "backToProducts": "Productos",
+    "removeMethod": "Eliminar metodo",
+    "editPaymentMethod": "Editar metodo de pago"
+  },
   "form": {
     "subtitleCreate": "Completa los datos para crear un nuevo producto.",
     "subtitleEdit": "Actualiza los detalles del producto.",

--- a/docs/superpowers/plans/2026-03-26-payment-methods.md
+++ b/docs/superpowers/plans/2026-03-26-payment-methods.md
@@ -1,0 +1,123 @@
+# Seller Payment Methods & Admin Settings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Sellers configure custom payment methods in Studio; admins configure payment timeout settings.
+
+**Architecture:** New `seller_payment_methods` + `payment_settings` tables. Studio gets a new payment-methods feature. Admin gets a new settings feature. Both follow existing Clean Architecture patterns.
+
+**Tech Stack:** Supabase, React Query, react-hook-form, next-intl, Zod
+
+**Spec:** `docs/superpowers/specs/2026-03-26-payment-methods-design.md`
+
+---
+
+## File Map
+
+### New Files
+
+| File                                                                                       | Responsibility                             |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| `supabase/migrations/20260326000000_payment_methods.sql`                                   | Tables, RLS, indexes, audit, seed settings |
+| `apps/studio/src/features/payment-methods/domain/types.ts`                                 | SellerPaymentMethod interface              |
+| `apps/studio/src/features/payment-methods/domain/constants.ts`                             | Query key, form defaults                   |
+| `apps/studio/src/features/payment-methods/infrastructure/paymentMethodQueries.ts`          | Supabase CRUD                              |
+| `apps/studio/src/features/payment-methods/application/hooks/usePaymentMethods.ts`          | Fetch hook                                 |
+| `apps/studio/src/features/payment-methods/application/hooks/usePaymentMethodMutations.ts`  | CUD mutations                              |
+| `apps/studio/src/features/payment-methods/presentation/pages/PaymentMethodsPage.tsx`       | Main page                                  |
+| `apps/studio/src/features/payment-methods/presentation/components/PaymentMethodTable.tsx`  | List table                                 |
+| `apps/studio/src/features/payment-methods/presentation/components/PaymentMethodEditor.tsx` | Create/edit form                           |
+| `apps/studio/src/features/payment-methods/index.ts`                                        | Barrel exports                             |
+| `apps/studio/src/app/[locale]/payment-methods/page.tsx`                                    | Route                                      |
+| `apps/admin/src/features/settings/domain/types.ts`                                         | PaymentSettings interface                  |
+| `apps/admin/src/features/settings/domain/constants.ts`                                     | Query key, setting keys                    |
+| `apps/admin/src/features/settings/infrastructure/settingsQueries.ts`                       | Supabase read/write                        |
+| `apps/admin/src/features/settings/application/hooks/usePaymentSettings.ts`                 | Fetch hook                                 |
+| `apps/admin/src/features/settings/application/hooks/useUpdateSettings.ts`                  | Update mutation                            |
+| `apps/admin/src/features/settings/presentation/pages/SettingsPage.tsx`                     | Settings page                              |
+| `apps/admin/src/features/settings/presentation/components/TimeoutSettings.tsx`             | Timeout form                               |
+| `apps/admin/src/features/settings/index.ts`                                                | Barrel exports                             |
+| `apps/admin/src/app/[locale]/settings/page.tsx`                                            | Route                                      |
+
+### Modified Files
+
+| File                                                             | Change                |
+| ---------------------------------------------------------------- | --------------------- |
+| `apps/admin/src/shared/presentation/components/AdminSidebar.tsx` | Add Settings nav item |
+| `apps/admin/src/shared/infrastructure/i18n/messages/en.json`     | Settings i18n keys    |
+| `apps/admin/src/shared/infrastructure/i18n/messages/es.json`     | Settings i18n keys    |
+| `apps/studio/src/shared/infrastructure/i18n/messages/en.json`    | Payment methods i18n  |
+| `apps/studio/src/shared/infrastructure/i18n/messages/es.json`    | Payment methods i18n  |
+
+---
+
+## Task 1: Database Migration
+
+**Files:**
+
+- Create: `supabase/migrations/20260326000000_payment_methods.sql`
+
+Create both tables, RLS, indexes, audit, and seed default timeout settings. Follow exact patterns from `20260325700000_product_templates.sql`.
+
+---
+
+## Task 2: Studio — Payment Methods Feature (domain + infrastructure + hooks)
+
+**Files:**
+
+- Create: All files under `apps/studio/src/features/payment-methods/` (domain, infrastructure, application layers)
+
+Domain types match the DB schema. Infrastructure uses `SupabaseClient<Database>` pattern from `productQueries.ts`. Hooks use `useQuery`/`useMutation` with memoized Supabase client.
+
+---
+
+## Task 3: Studio — Payment Methods UI + Route + i18n
+
+**Files:**
+
+- Create: `PaymentMethodsPage.tsx`, `PaymentMethodTable.tsx`, `PaymentMethodEditor.tsx`, route page, barrel export
+- Modify: Studio i18n en.json + es.json
+
+Page layout: header with "Add Method" button, table with toggle/edit/delete, editor form. Follow the admin TemplatesPage pattern but adapted for studio (no sidebar — use a back link to products like EditorToolbar does).
+
+---
+
+## Task 4: Admin — Settings Feature (domain + infrastructure + hooks)
+
+**Files:**
+
+- Create: All files under `apps/admin/src/features/settings/` (domain, infrastructure, application layers)
+
+Key-value settings from `payment_settings` table. Read all settings as a record, update individual settings.
+
+---
+
+## Task 5: Admin — Settings UI + Route + Sidebar + i18n
+
+**Files:**
+
+- Create: `SettingsPage.tsx`, `TimeoutSettings.tsx`, route page, barrel export
+- Modify: AdminSidebar (add "Settings" under new "Configuration" section), admin i18n en.json + es.json
+
+Settings page with a "Payment Timeouts" card containing 3 number inputs (hours) and a save button.
+
+---
+
+## Task 6: Final Verification
+
+Run format, lint, typecheck, test, build. Fix any issues.
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (migration) ─────┐
+Task 2 (studio domain) ──┤  (parallel after Task 1)
+Task 3 (studio UI) ──────┘
+Task 4 (admin domain) ───┐  (parallel with studio track)
+Task 5 (admin UI) ───────┘
+Task 6 (verification)
+```
+
+Studio (Tasks 2-3) and Admin (Tasks 4-5) tracks are independent and can run in parallel after the migration.

--- a/docs/superpowers/specs/2026-03-26-payment-methods-design.md
+++ b/docs/superpowers/specs/2026-03-26-payment-methods-design.md
@@ -1,0 +1,287 @@
+# Seller Payment Methods & Admin Payment Settings — Design Spec
+
+**Date:** 2026-03-26
+**Status:** Approved
+**Part:** 1 of 3 (Payment Methods → Checkout Flow → Verification)
+
+---
+
+## Overview
+
+Sellers configure custom payment methods (bank transfer, Nequi, PayPal, etc.) that buyers choose from at checkout. Admin configures global timeout settings for the payment lifecycle.
+
+This is the **foundation** — checkout flow and seller verification depend on these existing first.
+
+---
+
+## Sub-Order Lifecycle (for context)
+
+```
+AWAITING_PAYMENT        → timeout expires → EXPIRED (stock released)
+    ↓ buyer uploads receipt
+PENDING_VERIFICATION    → timeout expires → EXPIRED (stock released)
+    ↓ seller reviews
+APPROVED                → stock permanently decremented
+REJECTED                → stock released, buyer starts over from cart
+EVIDENCE_REQUESTED      → timeout expires → EXPIRED (stock released)
+    ↓ buyer re-uploads
+PENDING_VERIFICATION    → (back to verification)
+```
+
+Each step has its own admin-configured timeout. Rejection or expiration releases stock immediately.
+
+---
+
+## Database Schema
+
+### `public.seller_payment_methods`
+
+| Column                     | Type        | Nullable | Default             | Notes                                          |
+| -------------------------- | ----------- | -------- | ------------------- | ---------------------------------------------- |
+| `id`                       | uuid        | NO       | `gen_random_uuid()` | PK                                             |
+| `seller_id`                | uuid        | NO       | —                   | FK → auth.users(id)                            |
+| `name_en`                  | text        | NO       | —                   | Display name (e.g., "Bancolombia Transfer")    |
+| `name_es`                  | text        | NO       | —                   | Spanish name                                   |
+| `instructions_en`          | text        | YES      | NULL                | How to pay (account number, email, etc.)       |
+| `instructions_es`          | text        | YES      | NULL                | Spanish instructions                           |
+| `icon`                     | text        | YES      | NULL                | Lucide icon name or image URL                  |
+| `requires_receipt`         | boolean     | NO       | true                | Buyer must upload proof                        |
+| `requires_transfer_number` | boolean     | NO       | true                | Buyer must enter reference                     |
+| `currency`                 | text        | YES      | NULL                | NULL = any currency, or "COP", "USD"           |
+| `min_amount`               | integer     | YES      | NULL                | Minimum order amount (in currency minor units) |
+| `max_amount`               | integer     | YES      | NULL                | Maximum order amount                           |
+| `is_active`                | boolean     | NO       | true                | Seller can disable without deleting            |
+| `sort_order`               | integer     | NO       | 0                   | Display order                                  |
+| `created_at`               | timestamptz | NO       | `now()`             |                                                |
+| `updated_at`               | timestamptz | NO       | `now()`             |                                                |
+
+### `public.payment_settings`
+
+Global platform settings managed by admin. Key-value store for flexibility.
+
+| Column       | Type        | Nullable | Default | Notes                         |
+| ------------ | ----------- | -------- | ------- | ----------------------------- |
+| `key`        | text        | NO       | —       | PK, setting name              |
+| `value`      | text        | NO       | —       | Setting value (parsed by app) |
+| `updated_at` | timestamptz | NO       | `now()` |                               |
+
+**Initial settings:**
+
+| Key                                  | Default Value | Description                           |
+| ------------------------------------ | ------------- | ------------------------------------- |
+| `timeout_awaiting_payment_hours`     | `48`          | Hours before unpaid sub-order expires |
+| `timeout_pending_verification_hours` | `72`          | Hours seller has to verify receipt    |
+| `timeout_evidence_requested_hours`   | `24`          | Hours buyer has to re-upload evidence |
+
+### RLS Policies
+
+**seller_payment_methods:**
+
+- SELECT: public (buyers need to see them at checkout)
+- INSERT: `auth.uid() = seller_id`
+- UPDATE: `auth.uid() = seller_id`
+- DELETE: `auth.uid() = seller_id`
+
+**payment_settings:**
+
+- SELECT: public (all apps need to read timeouts)
+- INSERT/UPDATE/DELETE: authenticated only (admin enforced at app level for now)
+
+### Indexes
+
+- `seller_payment_methods_seller_id_idx` on `(seller_id, sort_order)`
+
+### Audit
+
+Both tables tracked via `audit.enable_tracking()`.
+
+---
+
+## Studio App — Seller Payment Methods
+
+### Location
+
+`apps/studio/src/features/payment-methods/`
+
+### Architecture
+
+```
+features/payment-methods/
+├── domain/
+│   ├── types.ts              # SellerPaymentMethod interface
+│   └── constants.ts          # Query key, form defaults
+├── infrastructure/
+│   └── paymentMethodQueries.ts  # Supabase CRUD
+├── application/
+│   └── hooks/
+│       ├── usePaymentMethods.ts      # Fetch seller's methods
+│       └── usePaymentMethodMutations.ts  # CUD mutations
+├── presentation/
+│   ├── pages/
+│   │   └── PaymentMethodsPage.tsx    # Main page
+│   └── components/
+│       ├── PaymentMethodTable.tsx     # List table
+│       └── PaymentMethodEditor.tsx   # Create/edit form
+└── index.ts
+```
+
+### Route
+
+`/[locale]/payment-methods` — new route in studio app
+
+### Sidebar
+
+New item "Payment Methods" in studio sidebar (after Products).
+
+### Page Layout
+
+Same pattern as admin templates:
+
+1. **Header** — "Payment Methods" title + "Add Method" button
+2. **Table** — rows: name, currency, receipt required?, active toggle, edit/delete
+3. **Editor** — opens when creating or editing. Fields: name (EN/ES), instructions (EN/ES), icon, requires_receipt, requires_transfer_number, currency, min/max amount, active
+
+### Key Behaviors
+
+- Sellers only see/manage their OWN payment methods (RLS enforced)
+- At least one active payment method required to sell (validated at checkout, not at method creation)
+- Instructions field supports markdown-like formatting for account details
+- Currency restriction: NULL means "any currency", otherwise limits to specific currency
+
+---
+
+## Admin App — Payment Settings
+
+### Location
+
+`apps/admin/src/features/settings/`
+
+### Architecture
+
+```
+features/settings/
+├── domain/
+│   ├── types.ts              # PaymentSettings interface
+│   └── constants.ts          # Query key, setting keys
+├── infrastructure/
+│   └── settingsQueries.ts    # Supabase read/write
+├── application/
+│   └── hooks/
+│       ├── usePaymentSettings.ts     # Fetch settings
+│       └── useUpdateSettings.ts      # Update mutations
+├── presentation/
+│   ├── pages/
+│   │   └── SettingsPage.tsx          # Settings page
+│   └── components/
+│       └── TimeoutSettings.tsx       # Timeout configuration form
+└── index.ts
+```
+
+### Route
+
+`/[locale]/settings` — new route in admin app
+
+### Sidebar
+
+New item "Settings" under a new "Configuration" section in admin sidebar.
+
+### Page Layout
+
+Card-based form:
+
+1. **Payment Timeouts** card
+   - Awaiting Payment timeout (hours input)
+   - Pending Verification timeout (hours input)
+   - Evidence Requested timeout (hours input)
+   - Save button
+
+Future settings cards can be added below.
+
+---
+
+## i18n Keys
+
+### Studio (payment methods)
+
+```
+sidebar.paymentMethods — "Payment Methods" / "Metodos de Pago"
+paymentMethods.title — "Payment Methods"
+paymentMethods.subtitle — "Configure how buyers can pay you"
+paymentMethods.addMethod — "Add Method"
+paymentMethods.name — "Method Name"
+paymentMethods.instructions — "Payment Instructions"
+paymentMethods.icon — "Icon"
+paymentMethods.requiresReceipt — "Requires Receipt Upload"
+paymentMethods.requiresTransferNumber — "Requires Transfer Number"
+paymentMethods.currency — "Currency"
+paymentMethods.anyCurrency — "Any Currency"
+paymentMethods.minAmount — "Minimum Amount"
+paymentMethods.maxAmount — "Maximum Amount"
+paymentMethods.active — "Active"
+paymentMethods.noMethods — "No payment methods yet"
+paymentMethods.save — "Save"
+paymentMethods.saving — "Saving..."
+paymentMethods.cancel — "Cancel"
+paymentMethods.deleteConfirm — "Delete this payment method?"
+paymentMethods.editMethod — "Edit Method"
+```
+
+### Admin (settings)
+
+```
+sidebar.settings — "Settings"
+sidebar.configuration — "Configuration"
+settings.title — "Platform Settings"
+settings.subtitle — "Global configuration for the platform"
+settings.timeouts.title — "Payment Timeouts"
+settings.timeouts.awaitingPayment — "Awaiting Payment"
+settings.timeouts.awaitingPaymentHint — "Hours before unpaid order expires"
+settings.timeouts.pendingVerification — "Pending Verification"
+settings.timeouts.pendingVerificationHint — "Hours seller has to verify receipt"
+settings.timeouts.evidenceRequested — "Evidence Requested"
+settings.timeouts.evidenceRequestedHint — "Hours buyer has to re-upload evidence"
+settings.timeouts.hours — "hours"
+settings.save — "Save Settings"
+settings.saving — "Saving..."
+settings.saved — "Settings updated"
+```
+
+---
+
+## Migration
+
+Single migration: `20260326000000_payment_methods.sql`
+
+1. Create `seller_payment_methods` table
+2. Create `payment_settings` table
+3. RLS policies for both
+4. Indexes
+5. Audit tracking
+6. Seed default payment settings (3 timeout values)
+
+---
+
+## What This Does NOT Include
+
+- Checkout flow (Part 2)
+- Sub-order creation, stock reservation (Part 2)
+- Seller verification UI (Part 3)
+- Buyer order history (Part 3)
+- Receipt upload/storage (Part 2)
+- Payment status notifications (Part 3)
+
+---
+
+## What Changes Where
+
+| File/Area                                               | Change                                        |
+| ------------------------------------------------------- | --------------------------------------------- |
+| `supabase/migrations/`                                  | New migration for both tables                 |
+| `apps/studio/src/features/payment-methods/`             | New feature: payment method CRUD              |
+| `apps/studio/src/app/[locale]/payment-methods/page.tsx` | New route                                     |
+| Studio sidebar                                          | Add "Payment Methods" nav item                |
+| Studio i18n (en/es)                                     | Payment method keys                           |
+| `apps/admin/src/features/settings/`                     | New feature: timeout settings                 |
+| `apps/admin/src/app/[locale]/settings/page.tsx`         | New route                                     |
+| Admin sidebar                                           | Add "Settings" nav item under "Configuration" |
+| Admin i18n (en/es)                                      | Settings keys                                 |

--- a/supabase/migrations/20260326000000_payment_methods.sql
+++ b/supabase/migrations/20260326000000_payment_methods.sql
@@ -1,0 +1,134 @@
+-- =============================================================================
+-- Payment Methods System
+-- =============================================================================
+-- Admin catalog of payment method types + seller-specific payment methods
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. payment_method_types — admin-managed catalog
+-- ---------------------------------------------------------------------------
+create table public.payment_method_types (
+  id uuid primary key default gen_random_uuid(),
+  name_en text not null,
+  name_es text not null,
+  description_en text,
+  description_es text,
+  icon text,
+  requires_receipt boolean not null default true,
+  requires_transfer_number boolean not null default true,
+  is_active boolean not null default true,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create trigger set_payment_method_types_updated_at
+  before update on public.payment_method_types
+  for each row execute function trigger_set_updated_at();
+
+create index payment_method_types_sort_order_idx on public.payment_method_types(sort_order);
+
+alter table public.payment_method_types enable row level security;
+
+create policy "Payment types: read all"
+  on public.payment_method_types for select using (true);
+
+create policy "Payment types: insert auth"
+  on public.payment_method_types for insert
+  with check (auth.role() = 'authenticated');
+
+create policy "Payment types: update auth"
+  on public.payment_method_types for update
+  using (auth.role() = 'authenticated');
+
+create policy "Payment types: delete auth"
+  on public.payment_method_types for delete
+  using (auth.role() = 'authenticated');
+
+select audit.enable_tracking('public.payment_method_types'::regclass);
+
+-- ---------------------------------------------------------------------------
+-- 2. seller_payment_methods — seller picks type + adds details
+-- ---------------------------------------------------------------------------
+create table public.seller_payment_methods (
+  id uuid primary key default gen_random_uuid(),
+  seller_id uuid not null references auth.users(id) on delete cascade,
+  type_id uuid not null references public.payment_method_types(id) on delete cascade,
+  account_details_en text,
+  account_details_es text,
+  seller_note_en text,
+  seller_note_es text,
+  is_active boolean not null default true,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create trigger set_seller_payment_methods_updated_at
+  before update on public.seller_payment_methods
+  for each row execute function trigger_set_updated_at();
+
+create index seller_payment_methods_seller_idx on public.seller_payment_methods(seller_id, sort_order);
+
+alter table public.seller_payment_methods enable row level security;
+
+create policy "Seller methods: read all"
+  on public.seller_payment_methods for select using (true);
+
+create policy "Seller methods: insert own"
+  on public.seller_payment_methods for insert
+  with check (auth.uid() = seller_id);
+
+create policy "Seller methods: update own"
+  on public.seller_payment_methods for update
+  using (auth.uid() = seller_id);
+
+create policy "Seller methods: delete own"
+  on public.seller_payment_methods for delete
+  using (auth.uid() = seller_id);
+
+select audit.enable_tracking('public.seller_payment_methods'::regclass);
+
+-- ---------------------------------------------------------------------------
+-- 3. payment_settings — global key-value config
+-- ---------------------------------------------------------------------------
+create table public.payment_settings (
+  key text primary key,
+  value text not null,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.payment_settings enable row level security;
+
+create policy "Settings: read all"
+  on public.payment_settings for select using (true);
+
+create policy "Settings: write auth"
+  on public.payment_settings for insert
+  with check (auth.role() = 'authenticated');
+
+create policy "Settings: update auth"
+  on public.payment_settings for update
+  using (auth.role() = 'authenticated');
+
+select audit.enable_tracking('public.payment_settings'::regclass);
+
+-- ---------------------------------------------------------------------------
+-- 4. Seed data
+-- ---------------------------------------------------------------------------
+
+-- Default timeout settings
+insert into public.payment_settings (key, value) values
+  ('timeout_awaiting_payment_hours', '48'),
+  ('timeout_pending_verification_hours', '72'),
+  ('timeout_evidence_requested_hours', '24');
+
+-- Seed payment method types for Colombian market
+insert into public.payment_method_types (name_en, name_es, description_en, description_es, icon, requires_receipt, requires_transfer_number, sort_order) values
+  ('Bancolombia Transfer', 'Transferencia Bancolombia', 'Bank transfer via Bancolombia', 'Transferencia bancaria via Bancolombia', 'Building', true, true, 1),
+  ('Nequi', 'Nequi', 'Mobile payment via Nequi', 'Pago movil via Nequi', 'Smartphone', true, true, 2),
+  ('Daviplata', 'Daviplata', 'Mobile payment via Daviplata', 'Pago movil via Daviplata', 'Smartphone', true, true, 3),
+  ('Davivienda Transfer', 'Transferencia Davivienda', 'Bank transfer via Davivienda', 'Transferencia bancaria via Davivienda', 'Building', true, true, 4),
+  ('BBVA Transfer', 'Transferencia BBVA', 'Bank transfer via BBVA Colombia', 'Transferencia bancaria via BBVA Colombia', 'Building', true, true, 5),
+  ('PayPal', 'PayPal', 'International payment via PayPal', 'Pago internacional via PayPal', 'Globe', true, false, 6),
+  ('TuLlave / BREB', 'TuLlave / BREB', 'Bogota transit card top-up as payment', 'Recarga de tarjeta de transporte de Bogota como pago', 'CreditCard', true, true, 7);


### PR DESCRIPTION
## Summary

Part 1 of the payment system — foundation for checkout flow.

- **Admin catalog** — payment method types (Bancolombia, Nequi, Daviplata, BBVA, PayPal, TuLlave/BREB) with CRUD management
- **Admin settings** — configurable timeouts for payment lifecycle (awaiting payment, verification, evidence re-upload)
- **Studio picker** — sellers select from catalog and add account details + personal note to buyers
- **Database** — 3 new tables with RLS, audit tracking, seed data

## Related Issue

Closes #16

## Changes

### Database
- `payment_method_types` table — admin-managed catalog, 7 seeded Colombian payment methods
- `seller_payment_methods` table — seller picks type + adds account details (EN/ES) + buyer note (EN/ES)
- `payment_settings` table — key-value store with 3 default timeouts (48h/72h/24h)

### Admin App
- Payment method type catalog: PaymentMethodTypesPage with table + editor
- Platform settings: SettingsPage with TimeoutSettings card (3 hour inputs)
- Sidebar: "Payment Methods" in Operations + "Settings" in Configuration

### Studio App
- Seller payment method picker: PaymentMethodsPage with table + editor
- Sellers choose from admin catalog, add bilingual account details + personal note
- Route: `/payment-methods`

## Testing

- `pnpm typecheck` — pass (12/12)
- `pnpm lint` — pass (0 errors)
- `pnpm test` — pass (10/10)
- `pnpm build` — pass (7/7)

---

Generated with [Claude Code](https://claude.com/claude-code)