### PR TITLE
chore: migrate project AI workflow from Claude to Codex

### DIFF
--- a/.agents/skills/ai-documents-audit/SKILL.md
+++ b/.agents/skills/ai-documents-audit/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: ai-documents-audit
+description: "Audits installed MCP servers, explores available tools, checks existing skills, maps skill actions to MCP tools, verifies portability, and enforces DRY principles across AI configuration files. Generates comprehensive reports with optimization recommendations. Use when Codex should follow the existing Claude workflow in `.claude/skills/ai-documents-audit/SKILL.md`. Read that source file before acting."
+---
+
+# Ai Documents Audit
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/ai-documents-audit/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/ai-documents-audit/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/analyze-bundle/SKILL.md
+++ b/.agents/skills/analyze-bundle/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: analyze-bundle
+description: "Analyze application bundle size and composition to find optimization opportunities, large dependencies, and performance bottlenecks; use for bundle analysis and size reduction tasks. Use when Codex should follow the existing Claude workflow in `.claude/skills/analyze-bundle/SKILL.md`. Read that source file before acting."
+---
+
+# Analyze Bundle
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/analyze-bundle/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/analyze-bundle/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/capture-evidences/SKILL.md
+++ b/.agents/skills/capture-evidences/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: capture-evidences
+description: "Capture screenshots of implemented features and post them as evidence to a GitHub issue. Uses Playwright MCP for screenshots and GitHub draft releases for image hosting. Use when Codex should follow the existing Claude workflow in `.claude/skills/capture-evidences/SKILL.md`. Read that source file before acting."
+---
+
+# Capture Evidences
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/capture-evidences/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/capture-evidences/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/checkpoint/SKILL.md
+++ b/.agents/skills/checkpoint/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: checkpoint
+description: "Save current work state for resuming later. Creates a checkpoint file with git status, pending tasks, and context. Use when Codex should follow the existing Claude workflow in `.claude/skills/checkpoint/SKILL.md`. Read that source file before acting."
+---
+
+# Checkpoint
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/checkpoint/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/checkpoint/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: code-review
+description: "Review code for DRY, SOLID, KISS, and architecture rule violations with actionable feedback and suggested fixes; use when asked to review code quality or principles. Use when Codex should follow the existing Claude workflow in `.claude/skills/code-review/SKILL.md`. Read that source file before acting."
+---
+
+# Code Review
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/code-review/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/code-review/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/commit-push/SKILL.md
+++ b/.agents/skills/commit-push/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: commit-push
+description: "Commits and pushes changes using only MCP tools. Includes code review and coverage enforcement for JS/TS files. Quality checks run via git hooks. Use when Codex should follow the existing Claude workflow in `.claude/skills/commit-push/SKILL.md`. Read that source file before acting."
+---
+
+# Commit Push
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/commit-push/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/commit-push/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/create-api-integration/SKILL.md
+++ b/.agents/skills/create-api-integration/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: create-api-integration
+description: "Create complete API integrations with types, API clients, repositories, and React Query hooks for REST or GraphQL; use when asked to build feature API layers. Use when Codex should follow the existing Claude workflow in `.claude/skills/create-api-integration/SKILL.md`. Read that source file before acting."
+---
+
+# Create Api Integration
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/create-api-integration/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/create-api-integration/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/create-component/SKILL.md
+++ b/.agents/skills/create-component/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: create-component
+description: "Create new React components with proper structure, types, and optional tests; use when asked to scaffold shared or feature components. Use when Codex should follow the existing Claude workflow in `.claude/skills/create-component/SKILL.md`. Read that source file before acting."
+---
+
+# Create Component
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/create-component/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/create-component/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/create-feature/SKILL.md
+++ b/.agents/skills/create-feature/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: create-feature
+description: "Scaffold full feature modules with Clean Architecture layers, types, and initial files; use when asked to create a new feature structure. Use when Codex should follow the existing Claude workflow in `.claude/skills/create-feature/SKILL.md`. Read that source file before acting."
+---
+
+# Create Feature
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/create-feature/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/create-feature/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/create-hook/SKILL.md
+++ b/.agents/skills/create-hook/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: create-hook
+description: "Create custom React hooks following project conventions for shared or feature use. Use when Codex should follow the existing Claude workflow in `.claude/skills/create-hook/SKILL.md`. Read that source file before acting."
+---
+
+# Create Hook
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/create-hook/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/create-hook/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/create-release/SKILL.md
+++ b/.agents/skills/create-release/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: create-release
+description: "Create a production release by merging develop into main with a PR and release notes. Use when Codex should follow the existing Claude workflow in `.claude/skills/create-release/SKILL.md`. Read that source file before acting."
+---
+
+# Create Release
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/create-release/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/create-release/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/figma/SKILL.md
+++ b/.agents/skills/figma/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: figma
+description: "Convert Figma designs to production-ready code using shadcn/ui, Tailwind, and i18n. Use when Codex should follow the existing Claude workflow in `.claude/skills/figma/SKILL.md`. Read that source file before acting."
+---
+
+# Figma
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/figma/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/figma/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/fix-ai-documents-audit/SKILL.md
+++ b/.agents/skills/fix-ai-documents-audit/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: fix-ai-documents-audit
+description: "Fixes all issues found in the latest AI documents audit report. Resolves duplicates, adds missing references, and consolidates inconsistent definitions regardless of priority. Use when Codex should follow the existing Claude workflow in `.claude/skills/fix-ai-documents-audit/SKILL.md`. Read that source file before acting."
+---
+
+# Fix Ai Documents Audit
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/fix-ai-documents-audit/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/fix-ai-documents-audit/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/fix-full-review/SKILL.md
+++ b/.agents/skills/fix-full-review/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: fix-full-review
+description: "Interactively fix issues found in /full-review reports. Use when Codex should follow the existing Claude workflow in `.claude/skills/fix-full-review/SKILL.md`. Read that source file before acting."
+---
+
+# Fix Full Review
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/fix-full-review/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/fix-full-review/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: frontend-design
+description: "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics. Use when Codex should follow the existing Claude workflow in `.claude/skills/frontend-design/SKILL.md`. Read that source file before acting."
+---
+
+# Frontend Design
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/frontend-design/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/frontend-design/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/full-review/SKILL.md
+++ b/.agents/skills/full-review/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: full-review
+description: "Run a multi-agent code review and generate a comprehensive report. Use when Codex should follow the existing Claude workflow in `.claude/skills/full-review/SKILL.md`. Read that source file before acting."
+---
+
+# Full Review
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/full-review/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/full-review/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/generate-setup-guide/SKILL.md
+++ b/.agents/skills/generate-setup-guide/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: generate-setup-guide
+description: "Generate a developer setup guide by analyzing project structure and workflows. Use when Codex should follow the existing Claude workflow in `.claude/skills/generate-setup-guide/SKILL.md`. Read that source file before acting."
+---
+
+# Generate Setup Guide
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/generate-setup-guide/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/generate-setup-guide/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/graphql/SKILL.md
+++ b/.agents/skills/graphql/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: graphql
+description: "GraphQL gives clients exactly the data they need - no more, no less. One endpoint, typed schema, introspection. But the flexibility that makes it powerful also makes it dangerous. Without proper controls, clients can craft queries that bring down your server.  This skill covers schema design, resolvers, DataLoader for N+1 prevention, federation for microservices, and client integration with Apollo/urql. Key insight: GraphQL is a contract. The schema is the API documentation. Design it carefully. Use when Codex should follow the existing Claude workflow in `.claude/skills/graphql/SKILL.md`. Read that source file before acting."
+---
+
+# Graphql
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/graphql/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/graphql/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/i18n/SKILL.md
+++ b/.agents/skills/i18n/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: i18n
+description: "Internationalization setup guidance for Next.js using next-intl. Use when Codex should follow the existing Claude workflow in `.claude/skills/i18n/SKILL.md`. Read that source file before acting."
+---
+
+# I18N
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/i18n/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/i18n/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/investigate-error/SKILL.md
+++ b/.agents/skills/investigate-error/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: investigate-error
+description: "Structured workflow to investigate and debug errors with context gathering. Use when Codex should follow the existing Claude workflow in `.claude/skills/investigate-error/SKILL.md`. Read that source file before acting."
+---
+
+# Investigate Error
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/investigate-error/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/investigate-error/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: merge-pr
+description: "Merge a pull request with safety checks and appropriate strategy. Use when Codex should follow the existing Claude workflow in `.claude/skills/merge-pr/SKILL.md`. Read that source file before acting."
+---
+
+# Merge Pr
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/merge-pr/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/merge-pr/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/post-merge/SKILL.md
+++ b/.agents/skills/post-merge/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: post-merge
+description: "Switch to develop, sync with remote, and optionally delete the previous branch. Use when Codex should follow the existing Claude workflow in `.claude/skills/post-merge/SKILL.md`. Read that source file before acting."
+---
+
+# Post Merge
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/post-merge/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/post-merge/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/project-intelligence/SKILL.md
+++ b/.agents/skills/project-intelligence/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: project-intelligence
+description: "Multi-agent deep analysis of the entire project including code, AI documents, and artifacts. Researches best practices and suggests improvements. Use when Codex should follow the existing Claude workflow in `.claude/skills/project-intelligence/SKILL.md`. Read that source file before acting."
+---
+
+# Project Intelligence
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/project-intelligence/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/project-intelligence/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/resume-checkpoint/SKILL.md
+++ b/.agents/skills/resume-checkpoint/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: resume-checkpoint
+description: "Resume work from a saved checkpoint. Detects current branch, reads checkpoint file, and restores context. Use when Codex should follow the existing Claude workflow in `.claude/skills/resume-checkpoint/SKILL.md`. Read that source file before acting."
+---
+
+# Resume Checkpoint
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/resume-checkpoint/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/resume-checkpoint/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/review-branch/SKILL.md
+++ b/.agents/skills/review-branch/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: review-branch
+description: "Review ALL code in the current branch vs develop, find every issue regardless of priority, and fix them all. Use when Codex should follow the existing Claude workflow in `.claude/skills/review-branch/SKILL.md`. Read that source file before acting."
+---
+
+# Review Branch
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/review-branch/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/review-branch/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/review-pr-comments/SKILL.md
+++ b/.agents/skills/review-pr-comments/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: review-pr-comments
+description: "Review PR comments and address them with explicit user approvals. Use when Codex should follow the existing Claude workflow in `.claude/skills/review-pr-comments/SKILL.md`. Read that source file before acting."
+---
+
+# Review Pr Comments
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/review-pr-comments/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/review-pr-comments/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/run-e2e/SKILL.md
+++ b/.agents/skills/run-e2e/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: run-e2e
+description: "Run end-to-end tests with Playwright. Supports running all tests, specific files, UI mode, and multiple browsers. Use when Codex should follow the existing Claude workflow in `.claude/skills/run-e2e/SKILL.md`. Read that source file before acting."
+---
+
+# Run E2E
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/run-e2e/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/run-e2e/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: run-tests
+description: "Run unit tests with Vitest. Supports running all tests, specific files, watch mode, and coverage reports. Use when Codex should follow the existing Claude workflow in `.claude/skills/run-tests/SKILL.md`. Read that source file before acting."
+---
+
+# Run Tests
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/run-tests/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/run-tests/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: security-audit
+description: "Run a comprehensive security audit for common vulnerabilities. Use when Codex should follow the existing Claude workflow in `.claude/skills/security-audit/SKILL.md`. Read that source file before acting."
+---
+
+# Security Audit
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/security-audit/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/security-audit/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/senior-frontend/SKILL.md
+++ b/.agents/skills/senior-frontend/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: senior-frontend
+description: "Comprehensive frontend development skill for building modern, performant web applications using ReactJS, NextJS, TypeScript, Tailwind CSS. Includes component scaffolding, performance optimization, bundle analysis, and UI best practices. Use when developing frontend features, optimizing performance, implementing UI/UX designs, managing state, or reviewing frontend code. Use when Codex should follow the existing Claude workflow in `.claude/skills/senior-frontend/SKILL.md`. Read that source file before acting."
+---
+
+# Senior Frontend
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/senior-frontend/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/senior-frontend/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/start-task/SKILL.md
+++ b/.agents/skills/start-task/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: start-task
+description: "Initializes a task with git branch, documentation artifacts, AND automatic codebase analysis. Use when Codex should follow the existing Claude workflow in `.claude/skills/start-task/SKILL.md`. Read that source file before acting."
+---
+
+# Start Task
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/start-task/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/start-task/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/storybook/SKILL.md
+++ b/.agents/skills/storybook/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: storybook
+description: "Initialize and work with Storybook for component-driven development. Use when Codex should follow the existing Claude workflow in `.claude/skills/storybook/SKILL.md`. Read that source file before acting."
+---
+
+# Storybook
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/storybook/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/storybook/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: submit-pr
+description: "Submit a pull request to the target branch. Handles commit creation, pushing, and PR submission with proper descriptions. Use when Codex should follow the existing Claude workflow in `.claude/skills/submit-pr/SKILL.md`. Read that source file before acting."
+---
+
+# Submit Pr
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/submit-pr/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/submit-pr/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/sync-with-develop/SKILL.md
+++ b/.agents/skills/sync-with-develop/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: sync-with-develop
+description: "Sync a feature branch with develop using safe, guided steps. Use when Codex should follow the existing Claude workflow in `.claude/skills/sync-with-develop/SKILL.md`. Read that source file before acting."
+---
+
+# Sync With Develop
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/sync-with-develop/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/sync-with-develop/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/tailwind/SKILL.md
+++ b/.agents/skills/tailwind/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: tailwind
+description: "Tailwind CSS configuration and best practices for this Next.js project. Use when Codex should follow the existing Claude workflow in `.claude/skills/tailwind/SKILL.md`. Read that source file before acting."
+---
+
+# Tailwind
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/tailwind/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/tailwind/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/ux-researcher-designer/SKILL.md
+++ b/.agents/skills/ux-researcher-designer/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: ux-researcher-designer
+description: "UX research and design toolkit for Senior UX Designer/Researcher including data-driven persona generation, journey mapping, usability testing frameworks, and research synthesis. Use for user research, persona creation, journey mapping, and design validation. Use when Codex should follow the existing Claude workflow in `.claude/skills/ux-researcher-designer/SKILL.md`. Read that source file before acting."
+---
+
+# Ux Researcher Designer
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/ux-researcher-designer/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/ux-researcher-designer/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.agents/skills/verify-code/SKILL.md
+++ b/.agents/skills/verify-code/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: verify-code
+description: "Run all quality gates (format, lint, typecheck, tests, coverage, build, smoke) and fix failures. No skipping, no exceptions. Use when Codex should follow the existing Claude workflow in `.claude/skills/verify-code/SKILL.md`. Read that source file before acting."
+---
+
+# Verify Code
+
+<!-- generated-by: scripts/export_claude_to_codex.py -->
+
+Use the Claude-authored source file as the canonical workflow for this Codex skill.
+
+## Source
+
+- `.claude/skills/verify-code/SKILL.md`
+
+## Workflow
+
+1. Read `.claude/skills/verify-code/SKILL.md` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.

--- a/.claude/tools/.env.local.example
+++ b/.claude/tools/.env.local.example
@@ -1,0 +1,8 @@
+# MCP tokens for local wrapper scripts.
+#
+# Copy to .claude/tools/.env.local or place the same variables in the project
+# root .env.local file.
+
+# GitHub Personal Access Token
+# Required by: github-unified-mcp.mjs, git-mcp.mjs
+GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_TOKEN_HERE

--- a/.claude/tools/README.md
+++ b/.claude/tools/README.md
@@ -1,33 +1,33 @@
 # Claude Tools Configuration
 
-This folder contains MCP (Model Context Protocol) server configurations and related tooling.
+This folder contains local MCP wrapper scripts and token templates used by `.mcp.json`.
 
 ## Setup
 
 1. Copy `.env.local.example` to `.env.local`
 2. Fill in your personal tokens
-3. Restart Claude Code session
+3. Restart Claude or any MCP-aware client
 
-## Token Security
+## Available Local Wrappers
 
-- `.env.local` is gitignored - never commit tokens
-- Each developer maintains their own tokens
-- See `.env.local.example` for required tokens
+The repository currently ships local wrappers for:
 
-## MCP Servers
+- `github-unified-mcp.mjs`
+- `git-mcp.mjs`
 
-MCP servers are configured in `/.mcp.json` at project root.
+`.mcp.json` also includes a disabled `github-setup` entry, but that wrapper is not shipped in this repo.
 
-### Available Servers
+## Token Files
 
-| Server             | Purpose                                | Token Required |
-| ------------------ | -------------------------------------- | -------------- |
-| github-unified-mcp | GitHub operations (PRs, issues, repos) | GITHUB_TOKEN   |
+Wrappers look for tokens in this order:
+
+1. Project root `.env.local`
+2. `.claude/tools/.env.local`
+
+The local `.env.local` file in this directory is gitignored. Keep secrets there or in the project root, not in tracked files.
 
 ## Troubleshooting
 
-If MCP tools aren't working:
-
-1. Verify `.env.local` exists with valid tokens
-2. Restart Claude Code session
-3. Check `/.mcp.json` configuration
+1. Verify the referenced wrapper files exist.
+2. Verify `.env.local` contains the expected token names.
+3. Restart the MCP client after changing tokens or `.mcp.json`.

--- a/.claude/tools/git-mcp.mjs
+++ b/.claude/tools/git-mcp.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * Git MCP Server Wrapper
+ *
+ * Wraps @cyanheads/git-mcp-server to use GITHUB_PERSONAL_ACCESS_TOKEN from .env.local
+ * for authenticated git operations (push, pull, fetch, clone).
+ *
+ * Tools Provided (27 total via @cyanheads/git-mcp-server):
+ * - Repository: git_init, git_clone, git_status, git_clean
+ * - Staging/Commits: git_add, git_commit, git_diff
+ * - History: git_log, git_show, git_blame, git_reflog
+ * - Branching: git_branch, git_checkout, git_merge, git_rebase, git_cherry_pick
+ * - Remote Operations: git_remote, git_fetch, git_pull, git_push
+ * - Advanced: git_tag, git_stash, git_reset, git_worktree, git_set_working_dir
+ *
+ * Authentication Strategy:
+ * - Reads GITHUB_PERSONAL_ACCESS_TOKEN from .env.local or .claude/tools/.env.local
+ * - Creates a GIT_ASKPASS helper script that provides the token to git
+ * - Token never appears in command-line arguments (secure)
+ * - Cleans up helper script on exit
+ *
+ * Requires GITHUB_PERSONAL_ACCESS_TOKEN in .env.local or .claude/tools/.env.local
+ */
+/* global process */
+
+import { spawn } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+
+// Setup paths
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const scriptDir = __dirname;
+const projectRoot = path.resolve(scriptDir, "..", "..");
+
+// Change to project root
+process.chdir(projectRoot);
+
+// Load environment variables from .env.local
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  const content = fs.readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const match = trimmed.match(/^GITHUB_PERSONAL_ACCESS_TOKEN=(.+)$/);
+    if (match) {
+      let token = match[1].trim();
+      if (
+        (token.startsWith('"') && token.endsWith('"')) ||
+        (token.startsWith("'") && token.endsWith("'"))
+      ) {
+        token = token.slice(1, -1);
+      }
+      process.env.GITHUB_PERSONAL_ACCESS_TOKEN = token;
+      break;
+    }
+  }
+}
+
+// Load token from .env.local files
+loadEnvFile(path.join(projectRoot, ".env.local"));
+loadEnvFile(path.join(scriptDir, ".env.local"));
+
+const GITHUB_TOKEN = process.env.GITHUB_PERSONAL_ACCESS_TOKEN;
+if (!GITHUB_TOKEN) {
+  console.error("Error: GITHUB_PERSONAL_ACCESS_TOKEN not found in .env.local");
+  console.error("Checked locations:");
+  console.error(`  - ${path.join(projectRoot, ".env.local")}`);
+  console.error(`  - ${path.join(scriptDir, ".env.local")}`);
+  process.exit(1);
+}
+
+// Create temporary GIT_ASKPASS helper script
+const isWindows = os.platform() === "win32";
+const helperScriptPath = path.join(
+  os.tmpdir(),
+  isWindows
+    ? `git-askpass-helper-${process.pid}.bat`
+    : `git-askpass-helper-${process.pid}.sh`
+);
+
+// Create helper script content based on platform
+// Use environment variable reference instead of embedding token directly
+const helperScriptContent = isWindows
+  ? `@echo off\necho %GITHUB_PERSONAL_ACCESS_TOKEN%`
+  : `#!/bin/bash\necho "$GITHUB_PERSONAL_ACCESS_TOKEN"`;
+
+fs.writeFileSync(helperScriptPath, helperScriptContent, { mode: 0o700 });
+
+// Cleanup function to remove helper script
+function cleanup() {
+  try {
+    if (fs.existsSync(helperScriptPath)) {
+      fs.unlinkSync(helperScriptPath);
+    }
+  } catch (error) {
+    console.error(`Warning: Failed to cleanup helper script: ${error.message}`);
+  }
+}
+
+// Register cleanup handlers
+process.on("exit", cleanup);
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  cleanup();
+  process.exit(143);
+});
+
+// Spawn git-mcp-server with environment configured for authentication
+const gitMcpServer = spawn(
+  "npx",
+  ["@cyanheads/git-mcp-server@latest"],
+  {
+    env: {
+      ...process.env,
+      // Authentication via GIT_ASKPASS (secure - no command-line exposure)
+      GIT_ASKPASS: helperScriptPath,
+      GIT_TERMINAL_PROMPT: "0", // Disable interactive prompts
+
+      // MCP transport configuration
+      MCP_TRANSPORT_TYPE: "stdio",
+      MCP_LOG_LEVEL: process.env.MCP_LOG_LEVEL || "error",
+
+      // Git identity (falls back to global git config if not set)
+      GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME || undefined,
+      GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL || undefined,
+
+      // Optional: Restrict operations to project directory for security
+      GIT_BASE_DIR: projectRoot,
+
+      // Optional: Commit signing
+      GIT_SIGN_COMMITS: process.env.GIT_SIGN_COMMITS || "false",
+    },
+    stdio: "inherit",
+    cwd: projectRoot,
+    shell: isWindows, // Required on Windows to find npx in PATH
+  }
+);
+
+// Handle server process events
+gitMcpServer.on("error", (error) => {
+  console.error(`Failed to start git-mcp-server: ${error.message}`);
+  cleanup();
+  process.exit(1);
+});
+
+gitMcpServer.on("exit", (code, signal) => {
+  cleanup();
+  if (signal) {
+    console.error(`git-mcp-server was killed with signal ${signal}`);
+    process.exit(1);
+  } else if (code !== 0) {
+    console.error(`git-mcp-server exited with code ${code}`);
+    process.exit(code);
+  }
+});
+
+// Forward our own exit to the child process
+process.on("exit", () => {
+  if (!gitMcpServer.killed) {
+    gitMcpServer.kill();
+  }
+});

--- a/.claude/tools/github-unified-mcp.mjs
+++ b/.claude/tools/github-unified-mcp.mjs
@@ -1,0 +1,796 @@
+#!/usr/bin/env node
+/**
+ * GitHub MCP Server (Zero-Dependency)
+ *
+ * A zero-dependency MCP server using only Node.js built-ins.
+ * Implements MCP protocol (JSON-RPC 2.0 over stdio) directly.
+ * Uses GitHub REST API via raw fetch calls.
+ *
+ * Tools Provided:
+ * - Repository: search_repositories, create_repository, fork_repository, create_branch, list_commits
+ * - Issues: create_issue, list_issues, update_issue, add_issue_comment, get_issue_comments, get_issue, search_issues
+ * - Pull Requests: create_pull_request, list_pull_requests, get_pull_request, github_update_pull_request
+ * - PR Details: get_pull_request_files, get_pull_request_comments, get_pull_request_reviews
+ * - PR Actions: get_pull_request_status, create_pull_request_review, merge_pull_request
+ * - PR Branch: update_pull_request_branch
+ * - Search: search_code, search_users
+ *
+ * BLOCKED (use Git MCP instead): push_files, create_or_update_file, get_file_contents
+ *
+ * Requires GITHUB_PERSONAL_ACCESS_TOKEN in .env.local or .claude/tools/.env.local
+ */
+/* global process */
+
+import { existsSync, readFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import { createInterface } from "readline";
+
+const __toolsDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__toolsDir, "..", "..");
+
+// Load environment variables
+function loadEnvFile(filePath) {
+  if (!existsSync(filePath)) return;
+  const content = readFileSync(filePath, "utf-8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const match = trimmed.match(/^GITHUB_PERSONAL_ACCESS_TOKEN=(.+)$/);
+    if (match) {
+      let token = match[1].trim();
+      if ((token.startsWith('"') && token.endsWith('"')) ||
+          (token.startsWith("'") && token.endsWith("'"))) {
+        token = token.slice(1, -1);
+      }
+      process.env.GITHUB_PERSONAL_ACCESS_TOKEN = token;
+      break;
+    }
+  }
+}
+
+loadEnvFile(join(projectRoot, ".env.local"));
+loadEnvFile(join(__toolsDir, ".env.local"));
+
+const GITHUB_TOKEN = process.env.GITHUB_PERSONAL_ACCESS_TOKEN;
+if (!GITHUB_TOKEN) {
+  console.error("Error: GITHUB_PERSONAL_ACCESS_TOKEN not found");
+  console.error("Please set it in .env.local or .claude/tools/.env.local");
+  process.exit(1);
+}
+
+const GITHUB_API = "https://api.github.com";
+
+// GitHub API helper
+async function githubFetch(endpoint, options = {}) {
+  const url = endpoint.startsWith("http") ? endpoint : `${GITHUB_API}${endpoint}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ message: response.statusText }));
+    throw new Error(`GitHub API error (${response.status}): ${error.message || JSON.stringify(error)}`);
+  }
+
+  const text = await response.text();
+  return text ? JSON.parse(text) : {};
+}
+
+// Tool definitions
+const TOOLS = [
+  // Repository tools
+  {
+    name: "search_repositories",
+    description: "Search for GitHub repositories",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query (see GitHub search syntax)" },
+        page: { type: "number", description: "Page number for pagination (default: 1)" },
+        perPage: { type: "number", description: "Number of results per page (default: 30, max: 100)" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "create_repository",
+    description: "Create a new GitHub repository in your account",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Repository name" },
+        description: { type: "string", description: "Repository description" },
+        private: { type: "boolean", description: "Whether the repository should be private" },
+        autoInit: { type: "boolean", description: "Initialize with README.md" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "fork_repository",
+    description: "Fork a GitHub repository to your account or specified organization",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string", description: "Repository owner (username or organization)" },
+        repo: { type: "string", description: "Repository name" },
+        organization: { type: "string", description: "Optional: organization to fork to" },
+      },
+      required: ["owner", "repo"],
+    },
+  },
+  {
+    name: "create_branch",
+    description: "Create a new branch in a GitHub repository",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string", description: "Repository owner" },
+        repo: { type: "string", description: "Repository name" },
+        branch: { type: "string", description: "Name for the new branch" },
+        from_branch: { type: "string", description: "Source branch to create from (defaults to default branch)" },
+      },
+      required: ["owner", "repo", "branch"],
+    },
+  },
+  {
+    name: "list_commits",
+    description: "Get list of commits of a branch in a GitHub repository",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        sha: { type: "string", description: "Branch name or commit SHA" },
+        page: { type: "number" },
+        perPage: { type: "number" },
+      },
+      required: ["owner", "repo"],
+    },
+  },
+  // Issue tools
+  {
+    name: "create_issue",
+    description: "Create a new issue in a GitHub repository",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        title: { type: "string" },
+        body: { type: "string" },
+        labels: { type: "array", items: { type: "string" } },
+        assignees: { type: "array", items: { type: "string" } },
+        milestone: { type: "number" },
+      },
+      required: ["owner", "repo", "title"],
+    },
+  },
+  {
+    name: "list_issues",
+    description: "List issues in a GitHub repository with filtering options",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        state: { type: "string", enum: ["open", "closed", "all"] },
+        labels: { type: "array", items: { type: "string" } },
+        sort: { type: "string", enum: ["created", "updated", "comments"] },
+        direction: { type: "string", enum: ["asc", "desc"] },
+        since: { type: "string" },
+        page: { type: "number" },
+        per_page: { type: "number" },
+      },
+      required: ["owner", "repo"],
+    },
+  },
+  {
+    name: "update_issue",
+    description: "Update an existing issue in a GitHub repository",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        issue_number: { type: "number" },
+        title: { type: "string" },
+        body: { type: "string" },
+        state: { type: "string", enum: ["open", "closed"] },
+        labels: { type: "array", items: { type: "string" } },
+        assignees: { type: "array", items: { type: "string" } },
+        milestone: { type: "number" },
+      },
+      required: ["owner", "repo", "issue_number"],
+    },
+  },
+  {
+    name: "add_issue_comment",
+    description: "Add a comment to an existing issue",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        issue_number: { type: "number" },
+        body: { type: "string" },
+      },
+      required: ["owner", "repo", "issue_number", "body"],
+    },
+  },
+  {
+    name: "get_issue_comments",
+    description: "Get comments on an issue or pull request. Note: GitHub treats PR conversation comments as issue comments. Use this to fetch bot comments (e.g. from Claude, Vercel, Linear) and general discussion comments on PRs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        issue_number: { type: "number", description: "Issue or pull request number" },
+        since: { type: "string", description: "Only show comments updated after this time (ISO 8601 format)" },
+        page: { type: "number", description: "Page number for pagination (default: 1)" },
+        per_page: { type: "number", description: "Results per page (default: 30, max: 100)" },
+      },
+      required: ["owner", "repo", "issue_number"],
+    },
+  },
+  {
+    name: "get_issue",
+    description: "Get details of a specific issue in a GitHub repository",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        issue_number: { type: "number" },
+      },
+      required: ["owner", "repo", "issue_number"],
+    },
+  },
+  {
+    name: "search_issues",
+    description: "Search for issues and pull requests across GitHub repositories",
+    inputSchema: {
+      type: "object",
+      properties: {
+        q: { type: "string", description: "Search query" },
+        sort: { type: "string", enum: ["comments", "reactions", "created", "updated"] },
+        order: { type: "string", enum: ["asc", "desc"] },
+        page: { type: "number" },
+        per_page: { type: "number" },
+      },
+      required: ["q"],
+    },
+  },
+  // Pull Request tools
+  {
+    name: "create_pull_request",
+    description: "Create a new pull request in a GitHub repository",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string", description: "Repository owner" },
+        repo: { type: "string", description: "Repository name" },
+        title: { type: "string", description: "Pull request title" },
+        head: { type: "string", description: "Branch where your changes are implemented" },
+        base: { type: "string", description: "Branch you want changes pulled into" },
+        body: { type: "string", description: "Pull request body/description" },
+        draft: { type: "boolean", description: "Create as draft pull request" },
+        maintainer_can_modify: { type: "boolean" },
+      },
+      required: ["owner", "repo", "title", "head", "base"],
+    },
+  },
+  {
+    name: "list_pull_requests",
+    description: "List and filter repository pull requests",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        state: { type: "string", enum: ["open", "closed", "all"] },
+        head: { type: "string" },
+        base: { type: "string" },
+        sort: { type: "string", enum: ["created", "updated", "popularity", "long-running"] },
+        direction: { type: "string", enum: ["asc", "desc"] },
+        page: { type: "number" },
+        per_page: { type: "number" },
+      },
+      required: ["owner", "repo"],
+    },
+  },
+  {
+    name: "get_pull_request",
+    description: "Get details of a specific pull request",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        pull_number: { type: "number" },
+      },
+      required: ["owner", "repo", "pull_number"],
+    },
+  },
+  {
+    name: "github_update_pull_request",
+    description: "Update a pull request's title, body, base branch, or state",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        pull_number: { type: "number" },
+        title: { type: "string" },
+        body: { type: "string" },
+        base: { type: "string", description: "Target branch to change to" },
+        state: { type: "string", enum: ["open", "closed"] },
+        maintainer_can_modify: { type: "boolean" },
+      },
+      required: ["owner", "repo", "pull_number"],
+    },
+  },
+  {
+    name: "get_pull_request_files",
+    description: "Get the list of files changed in a pull request",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        pull_number: { type: "number" },
+      },
+      required: ["owner", "repo", "pull_number"],
+    },
+  },
+  {
+    name: "get_pull_request_comments",
+    description: "Get the review comments on a pull request",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        pull_number: { type: "number" },
+      },
+      required: ["owner", "repo", "pull_number"],
+    },
+  },
+  {
+    name: "get_pull_request_reviews",
+    description: "Get the reviews on a pull request",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        pull_number: { type: "number" },
+      },
+      required: ["owner", "repo", "pull_number"],
+    },
+  },
+  {
+    name: "get_pull_request_status",
+    description: "Get the combined status of all status checks for a pull request",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        pull_number: { type: "number" },
+      },
+      required: ["owner", "repo", "pull_number"],
+    },
+  },
+  {
+    name: "create_pull_request_review",
+    description: "Create a review on a pull request",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        pull_number: { type: "number" },
+        body: { type: "string", description: "Review body text" },
+        event: { type: "string", enum: ["APPROVE", "REQUEST_CHANGES", "COMMENT"] },
+        commit_id: { type: "string", description: "SHA of commit to review" },
+        comments: {
+          type: "array",
+          description: "Review comments",
+          items: {
+            type: "object",
+            properties: {
+              path: { type: "string" },
+              position: { type: "number" },
+              line: { type: "number" },
+              body: { type: "string" },
+            },
+          },
+        },
+      },
+      required: ["owner", "repo", "pull_number", "body", "event"],
+    },
+  },
+  {
+    name: "merge_pull_request",
+    description: "Merge a pull request",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        pull_number: { type: "number" },
+        commit_title: { type: "string" },
+        commit_message: { type: "string" },
+        merge_method: { type: "string", enum: ["merge", "squash", "rebase"] },
+      },
+      required: ["owner", "repo", "pull_number"],
+    },
+  },
+  {
+    name: "update_pull_request_branch",
+    description: "Update a pull request branch with the latest changes from the base branch",
+    inputSchema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        pull_number: { type: "number" },
+        expected_head_sha: { type: "string" },
+      },
+      required: ["owner", "repo", "pull_number"],
+    },
+  },
+  // Search tools
+  {
+    name: "search_code",
+    description: "Search for code across GitHub repositories",
+    inputSchema: {
+      type: "object",
+      properties: {
+        q: { type: "string", description: "Search query" },
+        order: { type: "string", enum: ["asc", "desc"] },
+        page: { type: "number" },
+        per_page: { type: "number" },
+      },
+      required: ["q"],
+    },
+  },
+  {
+    name: "search_users",
+    description: "Search for users on GitHub",
+    inputSchema: {
+      type: "object",
+      properties: {
+        q: { type: "string", description: "Search query" },
+        sort: { type: "string", enum: ["followers", "repositories", "joined"] },
+        order: { type: "string", enum: ["asc", "desc"] },
+        page: { type: "number" },
+        per_page: { type: "number" },
+      },
+      required: ["q"],
+    },
+  },
+];
+
+// Tool handlers
+async function handleTool(name, args) {
+  switch (name) {
+    // Repository tools
+    case "search_repositories": {
+      const params = new URLSearchParams({ q: args.query });
+      if (args.page) params.set("page", String(args.page));
+      if (args.perPage) params.set("per_page", String(args.perPage));
+      return await githubFetch(`/search/repositories?${params}`);
+    }
+
+    case "create_repository": {
+      const body = { name: args.name };
+      if (args.description) body.description = args.description;
+      if (args.private !== undefined) body.private = args.private;
+      if (args.autoInit) body.auto_init = args.autoInit;
+      return await githubFetch("/user/repos", {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+    }
+
+    case "fork_repository": {
+      const body = {};
+      if (args.organization) body.organization = args.organization;
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/forks`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+    }
+
+    case "create_branch": {
+      // First get the SHA of the source branch
+      const sourceBranch = args.from_branch || "main";
+      const ref = await githubFetch(`/repos/${args.owner}/${args.repo}/git/ref/heads/${sourceBranch}`);
+
+      // Create new branch
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/git/refs`, {
+        method: "POST",
+        body: JSON.stringify({
+          ref: `refs/heads/${args.branch}`,
+          sha: ref.object.sha,
+        }),
+      });
+    }
+
+    case "list_commits": {
+      const params = new URLSearchParams();
+      if (args.sha) params.set("sha", args.sha);
+      if (args.page) params.set("page", String(args.page));
+      if (args.perPage) params.set("per_page", String(args.perPage));
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/commits?${params}`);
+    }
+
+    // Issue tools
+    case "create_issue": {
+      const body = { title: args.title };
+      if (args.body) body.body = args.body;
+      if (args.labels) body.labels = args.labels;
+      if (args.assignees) body.assignees = args.assignees;
+      if (args.milestone) body.milestone = args.milestone;
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/issues`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+    }
+
+    case "list_issues": {
+      const params = new URLSearchParams();
+      if (args.state) params.set("state", args.state);
+      if (args.labels) params.set("labels", args.labels.join(","));
+      if (args.sort) params.set("sort", args.sort);
+      if (args.direction) params.set("direction", args.direction);
+      if (args.since) params.set("since", args.since);
+      if (args.page) params.set("page", String(args.page));
+      if (args.per_page) params.set("per_page", String(args.per_page));
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/issues?${params}`);
+    }
+
+    case "update_issue": {
+      const body = {};
+      if (args.title) body.title = args.title;
+      if (args.body) body.body = args.body;
+      if (args.state) body.state = args.state;
+      if (args.labels) body.labels = args.labels;
+      if (args.assignees) body.assignees = args.assignees;
+      if (args.milestone !== undefined) body.milestone = args.milestone;
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/issues/${args.issue_number}`, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      });
+    }
+
+    case "add_issue_comment": {
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/issues/${args.issue_number}/comments`, {
+        method: "POST",
+        body: JSON.stringify({ body: args.body }),
+      });
+    }
+
+    case "get_issue_comments": {
+      const params = new URLSearchParams();
+      if (args.since) params.set("since", args.since);
+      if (args.page) params.set("page", String(args.page));
+      if (args.per_page) params.set("per_page", String(args.per_page));
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/issues/${args.issue_number}/comments?${params}`);
+    }
+
+    case "get_issue": {
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/issues/${args.issue_number}`);
+    }
+
+    case "search_issues": {
+      const params = new URLSearchParams({ q: args.q });
+      if (args.sort) params.set("sort", args.sort);
+      if (args.order) params.set("order", args.order);
+      if (args.page) params.set("page", String(args.page));
+      if (args.per_page) params.set("per_page", String(args.per_page));
+      return await githubFetch(`/search/issues?${params}`);
+    }
+
+    // Pull Request tools
+    case "create_pull_request": {
+      const body = {
+        title: args.title,
+        head: args.head,
+        base: args.base,
+      };
+      if (args.body) body.body = args.body;
+      if (args.draft !== undefined) body.draft = args.draft;
+      if (args.maintainer_can_modify !== undefined) body.maintainer_can_modify = args.maintainer_can_modify;
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+    }
+
+    case "list_pull_requests": {
+      const params = new URLSearchParams();
+      if (args.state) params.set("state", args.state);
+      if (args.head) params.set("head", args.head);
+      if (args.base) params.set("base", args.base);
+      if (args.sort) params.set("sort", args.sort);
+      if (args.direction) params.set("direction", args.direction);
+      if (args.page) params.set("page", String(args.page));
+      if (args.per_page) params.set("per_page", String(args.per_page));
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls?${params}`);
+    }
+
+    case "get_pull_request": {
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}`);
+    }
+
+    case "github_update_pull_request": {
+      const body = {};
+      if (args.title) body.title = args.title;
+      if (args.body) body.body = args.body;
+      if (args.base) body.base = args.base;
+      if (args.state) body.state = args.state;
+      if (args.maintainer_can_modify !== undefined) body.maintainer_can_modify = args.maintainer_can_modify;
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}`, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      });
+    }
+
+    case "get_pull_request_files": {
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/files`);
+    }
+
+    case "get_pull_request_comments": {
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/comments`);
+    }
+
+    case "get_pull_request_reviews": {
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/reviews`);
+    }
+
+    case "get_pull_request_status": {
+      // Get the PR first to get the head SHA
+      const pr = await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}`);
+      // Get combined status for the head commit
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/commits/${pr.head.sha}/status`);
+    }
+
+    case "create_pull_request_review": {
+      const body = {
+        body: args.body,
+        event: args.event,
+      };
+      if (args.commit_id) body.commit_id = args.commit_id;
+      if (args.comments) body.comments = args.comments;
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/reviews`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+    }
+
+    case "merge_pull_request": {
+      const body = {};
+      if (args.commit_title) body.commit_title = args.commit_title;
+      if (args.commit_message) body.commit_message = args.commit_message;
+      if (args.merge_method) body.merge_method = args.merge_method;
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/merge`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      });
+    }
+
+    case "update_pull_request_branch": {
+      const body = {};
+      if (args.expected_head_sha) body.expected_head_sha = args.expected_head_sha;
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/update-branch`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      });
+    }
+
+    // Search tools
+    case "search_code": {
+      const params = new URLSearchParams({ q: args.q });
+      if (args.order) params.set("order", args.order);
+      if (args.page) params.set("page", String(args.page));
+      if (args.per_page) params.set("per_page", String(args.per_page));
+      return await githubFetch(`/search/code?${params}`);
+    }
+
+    case "search_users": {
+      const params = new URLSearchParams({ q: args.q });
+      if (args.sort) params.set("sort", args.sort);
+      if (args.order) params.set("order", args.order);
+      if (args.page) params.set("page", String(args.page));
+      if (args.per_page) params.set("per_page", String(args.per_page));
+      return await githubFetch(`/search/users?${params}`);
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+// JSON-RPC response helpers
+function jsonRpcResponse(id, result) {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function jsonRpcError(id, code, message) {
+  return JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+// Handle MCP protocol messages
+async function handleMessage(message) {
+  const { id, method, params } = message;
+
+  try {
+    switch (method) {
+      case "initialize":
+        return jsonRpcResponse(id, {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {} },
+          serverInfo: { name: "github-mcp-server", version: "1.0.0" },
+        });
+
+      case "notifications/initialized":
+        return null;
+
+      case "tools/list":
+        return jsonRpcResponse(id, { tools: TOOLS });
+
+      case "tools/call": {
+        const { name, arguments: args } = params;
+        try {
+          const result = await handleTool(name, args || {});
+          return jsonRpcResponse(id, {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          });
+        } catch (error) {
+          return jsonRpcResponse(id, {
+            content: [{ type: "text", text: `Error: ${error.message}` }],
+            isError: true,
+          });
+        }
+      }
+
+      default:
+        return jsonRpcError(id, -32601, `Method not found: ${method}`);
+    }
+  } catch (error) {
+    return jsonRpcError(id, -32603, error.message);
+  }
+}
+
+// Main: Read JSON-RPC messages from stdin, write responses to stdout
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", async (line) => {
+  if (!line.trim()) return;
+
+  try {
+    const message = JSON.parse(line);
+    const response = await handleMessage(message);
+    if (response) {
+      process.stdout.write(response + "\n");
+    }
+  } catch (error) {
+    const errorResponse = jsonRpcError(null, -32700, "Parse error");
+    process.stdout.write(errorResponse + "\n");
+  }
+});
+
+rl.on("close", () => process.exit(0));

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Project Guidance
+
+Use [CLAUDE.md](/Z:/Github/candystore/CLAUDE.md) as the canonical project overview for this repository. It already captures the monorepo structure, architecture rules, stack, ports, and workflow conventions.
+
+## Codex Skills
+
+Codex-discoverable wrappers live in `.agents/skills/`. Most of them are generated bridges that point back to the original Claude-authored source files under `.claude/skills/` or `.claude/commands/`.
+
+When a generated Codex skill triggers:
+
+1. Read the referenced `.claude` source file first.
+2. Treat `.claude` as the source of truth for workflow details.
+3. Adapt Claude-only slash commands or MCP assumptions to the current Codex toolset.
+
+## Rules
+
+Project rules still live under `.claude/rules/`. Use them directly when you need detailed guidance on architecture, testing, git workflow, CSS, i18n, or review standards.
+
+High-value references:
+
+- `.claude/rules/architecture.md`
+- `.claude/rules/monorepo-architecture.md`
+- `.claude/rules/testing.md`
+- `.claude/rules/git-safety.md`
+- `.claude/rules/build-checks.md`
+
+## Role Prompts
+
+Claude role prompts still live under `.claude/agents/`. Codex does not auto-discover those files as native agents, but they remain useful references when you want to shape a spawned sub-agent or keep a review/design persona consistent.
+
+## MCP Tooling
+
+Project MCP configuration remains in `.mcp.json`. Local wrapper scripts live in `.claude/tools/`.

--- a/scripts/export_claude_to_codex.py
+++ b/scripts/export_claude_to_codex.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLAUDE_SKILLS_DIR = ROOT / ".claude" / "skills"
+CLAUDE_COMMANDS_DIR = ROOT / ".claude" / "commands"
+CODEX_SKILLS_DIR = ROOT / ".agents" / "skills"
+GENERATED_MARKER = "<!-- generated-by: scripts/export_claude_to_codex.py -->"
+
+
+def normalize_name(raw: str) -> str:
+    name = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")
+    return re.sub(r"-{2,}", "-", name)
+
+
+def parse_frontmatter(source_text: str) -> tuple[str | None, str | None]:
+    lines = source_text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None, None
+
+    name = None
+    description = None
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        value = value.strip().strip('"').strip("'")
+        if key.strip() == "name":
+            name = value
+        elif key.strip() == "description":
+            description = value
+
+    return name, description
+
+
+def first_meaningful_line(source_text: str) -> str | None:
+    lines = source_text.splitlines()
+    in_frontmatter = bool(lines and lines[0].strip() == "---")
+
+    for line in lines[1:] if in_frontmatter else lines:
+        stripped = line.strip()
+        if in_frontmatter and stripped == "---":
+            in_frontmatter = False
+            continue
+        if in_frontmatter or not stripped:
+            continue
+        if stripped.startswith("#"):
+            continue
+        return stripped
+    return None
+
+
+def default_description(name: str, source_rel: str, source_text: str) -> str:
+    _, frontmatter_description = parse_frontmatter(source_text)
+    if frontmatter_description:
+        base = frontmatter_description.rstrip(".")
+    else:
+        base = (first_meaningful_line(source_text) or f"Codex wrapper for {name}").rstrip(".")
+
+    return (
+        f"{base}. Use when Codex should follow the existing Claude workflow in "
+        f"`{source_rel}`. Read that source file before acting."
+    )
+
+
+def wrapper_body(name: str, source_rel: str, wrapper_type: str) -> str:
+    title = name.replace("-", " ").title()
+    source_label = "skill" if wrapper_type == "skill" else "command"
+    return f"""# {title}
+
+{GENERATED_MARKER}
+
+Use the Claude-authored source file as the canonical workflow for this Codex {source_label}.
+
+## Source
+
+- `{source_rel}`
+
+## Workflow
+
+1. Read `{source_rel}` before taking action.
+2. Adapt Claude-only slash commands, MCP calls, or shell assumptions to the current Codex toolset and local environment.
+3. Execute the workflow directly when the user is asking for work, not just advice.
+4. Keep `.claude` as the source of truth. If the workflow needs permanent changes, update the original Claude file too.
+"""
+
+
+def write_wrapper(
+    name: str,
+    description: str,
+    source_rel: str,
+    wrapper_type: str,
+    *,
+    overwrite_generated: bool = True,
+) -> bool:
+    target_dir = CODEX_SKILLS_DIR / name
+    target_path = target_dir / "SKILL.md"
+    existing = target_path.read_text(encoding="utf-8") if target_path.exists() else ""
+
+    if target_path.exists() and GENERATED_MARKER not in existing:
+        return False
+
+    if target_path.exists() and GENERATED_MARKER in existing and not overwrite_generated:
+        return False
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(
+        "\n".join(
+            [
+                "---",
+                f"name: {name}",
+                f'description: "{description.replace(chr(34), chr(39))}"',
+                "---",
+                "",
+                wrapper_body(name, source_rel, wrapper_type),
+            ]
+        ).rstrip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return True
+
+
+def export_skills() -> tuple[int, int]:
+    created = 0
+    skipped = 0
+
+    for skill_dir in sorted(CLAUDE_SKILLS_DIR.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        source_path = skill_dir / "SKILL.md"
+        if not source_path.exists():
+            continue
+
+        source_text = source_path.read_text(encoding="utf-8")
+        frontmatter_name, _ = parse_frontmatter(source_text)
+        name = normalize_name(frontmatter_name or skill_dir.name)
+        source_rel = source_path.relative_to(ROOT).as_posix()
+        description = default_description(name, source_rel, source_text)
+
+        if write_wrapper(name, description, source_rel, "skill"):
+            created += 1
+        else:
+            skipped += 1
+
+    return created, skipped
+
+
+def export_commands() -> tuple[int, int]:
+    created = 0
+    skipped = 0
+
+    for command_path in sorted(CLAUDE_COMMANDS_DIR.glob("*.md")):
+        name = normalize_name(command_path.stem)
+        source_text = command_path.read_text(encoding="utf-8")
+        source_rel = command_path.relative_to(ROOT).as_posix()
+        description = default_description(name, source_rel, source_text)
+
+        if write_wrapper(
+            name,
+            description,
+            source_rel,
+            "command",
+            overwrite_generated=False,
+        ):
+            created += 1
+        else:
+            skipped += 1
+
+    return created, skipped
+
+
+def main() -> None:
+    CODEX_SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+    created_skills, skipped_skills = export_skills()
+    created_commands, skipped_commands = export_commands()
+    print(
+        "Exported Claude assets to Codex wrappers:",
+        f"skills created={created_skills}",
+        f"skills skipped={skipped_skills}",
+        f"commands created={created_commands}",
+        f"commands skipped={skipped_commands}",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Codex-facing `AGENTS.md` bridge to the existing project guidance
- export Claude skills into Codex-discoverable `.agents/skills/*` wrappers via a generator script
- restore the local Git/GitHub MCP wrapper files referenced by `.mcp.json`

## Testing
- python -m py_compile scripts/export_claude_to_codex.py
- python scripts/export_claude_to_codex.py

## Story
- closes #31