### PR TITLE
fix: no prefill for payment methods + permission tooltips

### DIFF
--- a/apps/admin/src/features/users/presentation/components/PermissionGroupCard.tsx
+++ b/apps/admin/src/features/users/presentation/components/PermissionGroupCard.tsx
@@ -24,6 +24,7 @@ export function PermissionGroupCard({
 }: PermissionGroupCardProps) {
   const t = useTranslations("users");
   const tp = useTranslations("permissions");
+  const th = useTranslations("permissionHints");
 
   return (
     <div
@@ -41,6 +42,7 @@ export function PermissionGroupCard({
             <label
               key={perm}
               className="flex cursor-pointer items-center gap-1.5"
+              title={th(perm)}
             >
               <input
                 type="checkbox"

--- a/apps/admin/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/admin/src/shared/infrastructure/i18n/messages/en.json
@@ -273,6 +273,71 @@
       "update": "Undo Check-ins"
     }
   },
+  "permissionHints": {
+    "products": {
+      "create": "Create new product listings in the store catalog",
+      "read": "View product details, prices, and inventory",
+      "update": "Edit product names, descriptions, prices, and stock",
+      "delete": "Permanently remove products from the catalog"
+    },
+    "product_images": {
+      "create": "Upload images to product galleries",
+      "read": "View product gallery images",
+      "delete": "Remove images from product galleries"
+    },
+    "product_reviews": {
+      "create": "Write reviews on purchased products",
+      "read": "View reviews left by other buyers",
+      "update": "Edit own reviews after posting",
+      "delete": "Remove own reviews"
+    },
+    "orders": {
+      "create": "Place new orders and initiate checkout",
+      "read": "View order history and status",
+      "update": "Approve, reject, or request evidence on orders"
+    },
+    "receipts": {
+      "create": "Upload payment receipts as proof of payment",
+      "read": "View uploaded payment receipts",
+      "delete": "Remove uploaded payment receipts"
+    },
+    "seller_payment_methods": {
+      "create": "Add new payment methods for buyers",
+      "read": "View configured payment methods",
+      "update": "Edit payment method details and fields",
+      "delete": "Remove payment methods"
+    },
+    "payment_settings": {
+      "read": "View platform payment timeout settings",
+      "update": "Change payment timeout and expiration settings"
+    },
+    "templates": {
+      "create": "Create permission templates for quick role assignment",
+      "read": "View available permission templates",
+      "update": "Edit permission template configurations",
+      "delete": "Remove permission templates"
+    },
+    "audit": {
+      "read": "View the audit log of all database changes"
+    },
+    "user_permissions": {
+      "create": "Grant permissions to other users",
+      "read": "View which permissions users have",
+      "update": "Modify existing permission grants",
+      "delete": "Revoke permissions from users"
+    },
+    "events": {
+      "create": "Create new events in the system",
+      "read": "View event details and schedules",
+      "update": "Edit event information and settings",
+      "delete": "Remove events from the system"
+    },
+    "check_ins": {
+      "create": "Check in attendees at events",
+      "read": "View check-in records and attendance",
+      "update": "Undo or modify check-in records"
+    }
+  },
   "common": {
     "loading": "Loading...",
     "error": "An error occurred",

--- a/apps/admin/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/admin/src/shared/infrastructure/i18n/messages/es.json
@@ -275,6 +275,71 @@
       "update": "Deshacer Check-in"
     }
   },
+  "permissionHints": {
+    "products": {
+      "create": "Crear nuevos productos en el catalogo de la tienda",
+      "read": "Ver detalles de productos, precios e inventario",
+      "update": "Editar nombres, descripciones, precios y stock de productos",
+      "delete": "Eliminar productos permanentemente del catalogo"
+    },
+    "product_images": {
+      "create": "Subir imagenes a las galerias de productos",
+      "read": "Ver imagenes de la galeria de productos",
+      "delete": "Eliminar imagenes de las galerias de productos"
+    },
+    "product_reviews": {
+      "create": "Escribir resenas sobre productos comprados",
+      "read": "Ver resenas dejadas por otros compradores",
+      "update": "Editar resenas propias despues de publicarlas",
+      "delete": "Eliminar resenas propias"
+    },
+    "orders": {
+      "create": "Realizar nuevas ordenes e iniciar el pago",
+      "read": "Ver historial de ordenes y estado",
+      "update": "Aprobar, rechazar o solicitar evidencia en ordenes"
+    },
+    "receipts": {
+      "create": "Subir comprobantes de pago como prueba",
+      "read": "Ver comprobantes de pago subidos",
+      "delete": "Eliminar comprobantes de pago subidos"
+    },
+    "seller_payment_methods": {
+      "create": "Agregar nuevos metodos de pago para compradores",
+      "read": "Ver metodos de pago configurados",
+      "update": "Editar detalles y campos de metodos de pago",
+      "delete": "Eliminar metodos de pago"
+    },
+    "payment_settings": {
+      "read": "Ver configuracion de tiempos de pago de la plataforma",
+      "update": "Cambiar tiempos de expiracion y configuracion de pagos"
+    },
+    "templates": {
+      "create": "Crear plantillas de permisos para asignacion rapida de roles",
+      "read": "Ver plantillas de permisos disponibles",
+      "update": "Editar configuraciones de plantillas de permisos",
+      "delete": "Eliminar plantillas de permisos"
+    },
+    "audit": {
+      "read": "Ver el registro de auditoria de todos los cambios en la base de datos"
+    },
+    "user_permissions": {
+      "create": "Otorgar permisos a otros usuarios",
+      "read": "Ver que permisos tienen los usuarios",
+      "update": "Modificar permisos otorgados existentes",
+      "delete": "Revocar permisos de usuarios"
+    },
+    "events": {
+      "create": "Crear nuevos eventos en el sistema",
+      "read": "Ver detalles y horarios de eventos",
+      "update": "Editar informacion y configuracion de eventos",
+      "delete": "Eliminar eventos del sistema"
+    },
+    "check_ins": {
+      "create": "Registrar asistentes en eventos",
+      "read": "Ver registros de asistencia y check-in",
+      "update": "Deshacer o modificar registros de check-in"
+    }
+  },
   "common": {
     "loading": "Cargando...",
     "accessDenied": "Acceso denegado",

--- a/apps/payments/src/features/payment-methods/presentation/pages/PaymentMethodsPage.test.tsx
+++ b/apps/payments/src/features/payment-methods/presentation/pages/PaymentMethodsPage.test.tsx
@@ -140,7 +140,7 @@ describe("PaymentMethodsPage", () => {
     render(<PaymentMethodsPage />);
     fireEvent.click(screen.getByTestId("add-payment-method-button"));
     expect(mockCreate.mutate).toHaveBeenCalledWith(
-      { sellerId: "seller-1", nameEn: "newMethodDefault" },
+      { sellerId: "seller-1", nameEn: "" },
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
   });

--- a/apps/payments/src/features/payment-methods/presentation/pages/PaymentMethodsPageContent.tsx
+++ b/apps/payments/src/features/payment-methods/presentation/pages/PaymentMethodsPageContent.tsx
@@ -53,14 +53,14 @@ export function PaymentMethodsPageContent({
 
   const handleCreate = useCallback(() => {
     createMutation.mutate(
-      { sellerId, nameEn: t("newMethodDefault") },
+      { sellerId, nameEn: "" },
       {
         onSuccess: (method) => {
           setExpandedId(method.id);
         },
       },
     );
-  }, [createMutation, sellerId, t]);
+  }, [createMutation, sellerId]);
 
   const handleDelete = useCallback(
     (id: string) => {


### PR DESCRIPTION
- Payment methods: create with empty name instead of pre-filled default — user fills everything from scratch, placeholders guide them
- Admin permissions: hover tooltip on every permission checkbox showing what it actually controls (35 permissions, EN + ES)