### PR TITLE
feat: production CI/CD pipeline and infrastructure

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,138 @@
+name: Deploy Production
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  # ============================================
+  # Run CI checks before deploying
+  # ============================================
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm run typecheck
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Unit tests
+        run: pnpm run test
+
+      - name: Build (validates secrets work)
+        run: pnpm run build
+        env:
+          STANDALONE: "true"
+          BASE_PATH_PREFIX: ""
+          NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL }}
+          NEXT_PUBLIC_API_PREFIX: ${{ secrets.NEXT_PUBLIC_API_PREFIX }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_AUTH_HOST_URL: ${{ secrets.NEXT_PUBLIC_AUTH_HOST_URL }}
+          NEXT_PUBLIC_AUTH_URL: ${{ secrets.NEXT_PUBLIC_AUTH_URL }}
+          NEXT_PUBLIC_STORE_URL: ${{ secrets.NEXT_PUBLIC_STORE_URL }}
+          NEXT_PUBLIC_ADMIN_URL: ${{ secrets.NEXT_PUBLIC_ADMIN_URL }}
+          NEXT_PUBLIC_LANDING_URL: ${{ secrets.NEXT_PUBLIC_LANDING_URL }}
+          NEXT_PUBLIC_PAYMENTS_URL: ${{ secrets.NEXT_PUBLIC_PAYMENTS_URL }}
+          NEXT_PUBLIC_PLAYGROUND_URL: ${{ secrets.NEXT_PUBLIC_PLAYGROUND_URL }}
+          NEXT_PUBLIC_STUDIO_URL: ${{ secrets.NEXT_PUBLIC_STUDIO_URL }}
+          NEXT_PUBLIC_ENABLE_MOCKS: ${{ secrets.NEXT_PUBLIC_ENABLE_MOCKS }}
+
+  # ============================================
+  # Deploy to production server via SSH
+  # ============================================
+  deploy:
+    name: Deploy to Server
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: ci-gate
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.PROD_SERVER_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.PROD_SERVER_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Write ephemeral env file on server
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            ${{ secrets.PROD_SERVER_USER }}@${{ secrets.PROD_SERVER_HOST }} \
+            'cat > /tmp/.candyshop-build.env << ENVEOF
+          STANDALONE=true
+          BASE_PATH_PREFIX=
+          NEXT_PUBLIC_API_PREFIX=${{ secrets.NEXT_PUBLIC_API_PREFIX }}
+          NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_STORE_URL=${{ secrets.NEXT_PUBLIC_STORE_URL }}
+          NEXT_PUBLIC_ADMIN_URL=${{ secrets.NEXT_PUBLIC_ADMIN_URL }}
+          NEXT_PUBLIC_AUTH_HOST_URL=${{ secrets.NEXT_PUBLIC_AUTH_HOST_URL }}
+          NEXT_PUBLIC_AUTH_URL=${{ secrets.NEXT_PUBLIC_AUTH_URL }}
+          NEXT_PUBLIC_LANDING_URL=${{ secrets.NEXT_PUBLIC_LANDING_URL }}
+          NEXT_PUBLIC_PAYMENTS_URL=${{ secrets.NEXT_PUBLIC_PAYMENTS_URL }}
+          NEXT_PUBLIC_STUDIO_URL=${{ secrets.NEXT_PUBLIC_STUDIO_URL }}
+          NEXT_PUBLIC_PLAYGROUND_URL=${{ secrets.NEXT_PUBLIC_PLAYGROUND_URL }}
+          NEXT_PUBLIC_ENABLE_MOCKS=false
+          ENVEOF'
+
+      - name: Copy deploy script to server
+        run: |
+          scp -i ~/.ssh/deploy_key \
+            scripts/deploy-production.sh \
+            ${{ secrets.PROD_SERVER_USER }}@${{ secrets.PROD_SERVER_HOST }}:/tmp/deploy-production.sh
+
+      - name: Run deployment
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            ${{ secrets.PROD_SERVER_USER }}@${{ secrets.PROD_SERVER_HOST }} \
+            "REPO_URL='https://github.com/${{ github.repository }}.git' \
+             BRANCH='${{ github.ref_name }}' \
+             ENV_FILE='/tmp/.candyshop-build.env' \
+             bash /tmp/deploy-production.sh"
+
+      - name: Verify deployment
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            ${{ secrets.PROD_SERVER_USER }}@${{ secrets.PROD_SERVER_HOST }} \
+            'export NVM_DIR="$HOME/.nvm" && source "$NVM_DIR/nvm.sh" && pm2 list'
+
+      - name: Cleanup
+        if: always()
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            ${{ secrets.PROD_SERVER_USER }}@${{ secrets.PROD_SERVER_HOST }} \
+            'rm -f /tmp/.candyshop-build.env /tmp/deploy-production.sh' 2>/dev/null || true
+          rm -f ~/.ssh/deploy_key

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,9 @@ specs/*
 .claude/version.json
 coverage-report.json
 .superpowers/
+
+# SSH credentials
+.ssh-credentials.json
+
+# Production env (contains secrets)
+scripts/server/production.env

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -1,0 +1,415 @@
+# Infrastructure & Deployment Guide
+
+> Everything needed to reproduce the production environment from scratch — whether migrating servers, recovering from failure, or moving to cloud.
+
+## Architecture Overview
+
+```
+GitHub (main branch)
+  │
+  ├─ CI Gate (lint, typecheck, test, build)
+  │
+  └─ Deploy via SSH ──► hestia.local (192.168.2.71)
+                            │
+                            ├─ Nginx (port 9090) ── reverse proxy
+                            │   ├─ /          → landing  :5004
+                            │   ├─ /store     → store    :5001
+                            │   ├─ /admin     → admin    :5002
+                            │   ├─ /auth      → auth     :5000
+                            │   ├─ /payments  → payments :5005
+                            │   ├─ /playground→ playground:5003
+                            │   └─ /studio    → studio   :5006
+                            │
+                            ├─ PM2 (process manager, 7 Next.js apps)
+                            │
+                            └─ Hestia CP (port 8083)
+                                ├─ store.furrycolombia.com → proxy to :9090
+                                └─ SSL via Let's Encrypt
+```
+
+All apps are served under a single domain: `https://store.furrycolombia.com`
+
+## Server Specs
+
+| Property      | Value                             |
+| ------------- | --------------------------------- |
+| Hostname      | hestia.local                      |
+| LAN IP        | 192.168.2.71                      |
+| OS            | Ubuntu 24.04 (Linux 6.8)          |
+| RAM           | 8 GB                              |
+| Disk          | 915 GB (SSD)                      |
+| Control Panel | Hestia CP                         |
+| SSH User      | furrycolombia                     |
+| SSH Auth      | ED25519 key (`candystore-deploy`) |
+
+## Software Stack (on server)
+
+| Tool    | Version | Install method             |
+| ------- | ------- | -------------------------- |
+| Node.js | 22.x    | nvm (userspace)            |
+| pnpm    | 10.x    | npm global (via nvm)       |
+| PM2     | 6.x     | npm global (via nvm)       |
+| Nginx   | 1.29.x  | System (managed by Hestia) |
+| Git     | 2.43    | System                     |
+
+## Port Map
+
+| App        | Port | Path        | PM2 Name             |
+| ---------- | ---- | ----------- | -------------------- |
+| auth       | 5000 | /auth       | candyshop-auth       |
+| store      | 5001 | /store      | candyshop-store      |
+| admin      | 5002 | /admin      | candyshop-admin      |
+| playground | 5003 | /playground | candyshop-playground |
+| landing    | 5004 | / (root)    | candyshop-landing    |
+| payments   | 5005 | /payments   | candyshop-payments   |
+| studio     | 5006 | /studio     | candyshop-studio     |
+
+## CI/CD Pipeline
+
+### Trigger
+
+Push to `main` branch (paths: `apps/**`, `packages/**`, `package.json`, `pnpm-lock.yaml`)
+Also available via manual `workflow_dispatch`.
+
+### Workflow: `.github/workflows/deploy-production.yml`
+
+1. **CI Gate** — typecheck, lint, unit tests, build (with `STANDALONE=true`)
+2. **Deploy** — SSH into server, run `scripts/deploy-production.sh`
+   - Pulls latest code
+   - `pnpm install --frozen-lockfile`
+   - Builds all apps with `STANDALONE=true` (enables path-based routing)
+   - Restarts all PM2 processes
+   - Runs health checks
+
+### GitHub Secrets Required
+
+| Secret                          | Description                    | Example                                      |
+| ------------------------------- | ------------------------------ | -------------------------------------------- |
+| `PROD_SERVER_HOST`              | Server IP                      | `192.168.2.71`                               |
+| `PROD_SERVER_USER`              | SSH username                   | `furrycolombia`                              |
+| `PROD_SERVER_SSH_KEY`           | ED25519 private key (full PEM) | `-----BEGIN OPENSSH...`                      |
+| `NEXT_PUBLIC_STORE_URL`         | Store app URL                  | `https://store.furrycolombia.com/store`      |
+| `NEXT_PUBLIC_ADMIN_URL`         | Admin app URL                  | `https://store.furrycolombia.com/admin`      |
+| `NEXT_PUBLIC_AUTH_HOST_URL`     | Auth app URL                   | `https://store.furrycolombia.com/auth`       |
+| `NEXT_PUBLIC_AUTH_URL`          | Auth app URL (alias)           | `https://store.furrycolombia.com/auth`       |
+| `NEXT_PUBLIC_LANDING_URL`       | Landing app URL                | `https://store.furrycolombia.com`            |
+| `NEXT_PUBLIC_PAYMENTS_URL`      | Payments app URL               | `https://store.furrycolombia.com/payments`   |
+| `NEXT_PUBLIC_STUDIO_URL`        | Studio app URL                 | `https://store.furrycolombia.com/studio`     |
+| `NEXT_PUBLIC_PLAYGROUND_URL`    | Playground app URL             | `https://store.furrycolombia.com/playground` |
+| `NEXT_PUBLIC_API_PREFIX`        | API route prefix               | `/api`                                       |
+| `NEXT_PUBLIC_API_BASE_URL`      | API base URL                   | (empty for same-origin)                      |
+| `NEXT_PUBLIC_ENABLE_MOCKS`      | Disable mocks in prod          | `false`                                      |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Supabase project URL           | `https://xxx.supabase.co`                    |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon key              | `eyJ...`                                     |
+
+---
+
+## Fresh Server Setup (Migration Runbook)
+
+Follow these steps to reproduce the environment on a new server.
+
+### 1. OS & Prerequisites
+
+```bash
+# Ubuntu 22.04+ recommended
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y git curl nginx
+```
+
+### 2. Create deploy user
+
+```bash
+sudo adduser furrycolombia
+sudo usermod -aG sudo furrycolombia
+```
+
+### 3. SSH Key Auth
+
+From your local machine:
+
+```bash
+# Generate key (if you don't have one)
+ssh-keygen -t ed25519 -C "candystore-deploy"
+
+# Copy public key to server
+type %USERPROFILE%\.ssh\id_ed25519.pub | ssh furrycolombia@<SERVER_IP> "mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys && chmod 700 ~/.ssh"
+```
+
+### 4. Install Node.js via nvm
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+source ~/.bashrc
+nvm install 22
+```
+
+### 5. Install pnpm & PM2
+
+```bash
+npm install -g pnpm pm2
+```
+
+### 6. Configure PM2 auto-startup
+
+```bash
+pm2 startup
+# Copy and run the sudo command it outputs, e.g.:
+# sudo env PATH=$PATH:/home/furrycolombia/.nvm/versions/node/v22.22.2/bin \
+#   /home/furrycolombia/.nvm/versions/node/v22.22.2/lib/node_modules/pm2/bin/pm2 \
+#   startup systemd -u furrycolombia --hp /home/furrycolombia
+```
+
+### 7. Deploy the application
+
+```bash
+# Clone the repo
+git clone --branch main --depth 1 https://github.com/furrycolombia-sys/candyshop.git /home/furrycolombia/candyshop
+
+cd /home/furrycolombia/candyshop
+
+# Install deps
+pnpm install --frozen-lockfile --prod=false
+
+# Write production .env (deleted after build)
+cat > .env << EOF
+STANDALONE=true
+BASE_PATH_PREFIX=
+NEXT_PUBLIC_SUPABASE_URL=<your-supabase-url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+NEXT_PUBLIC_STORE_URL=https://store.furrycolombia.com/store
+NEXT_PUBLIC_ADMIN_URL=https://store.furrycolombia.com/admin
+NEXT_PUBLIC_AUTH_HOST_URL=https://store.furrycolombia.com/auth
+NEXT_PUBLIC_AUTH_URL=https://store.furrycolombia.com/auth
+NEXT_PUBLIC_LANDING_URL=https://store.furrycolombia.com
+NEXT_PUBLIC_PAYMENTS_URL=https://store.furrycolombia.com/payments
+NEXT_PUBLIC_STUDIO_URL=https://store.furrycolombia.com/studio
+NEXT_PUBLIC_PLAYGROUND_URL=https://store.furrycolombia.com/playground
+NEXT_PUBLIC_API_PREFIX=/api
+NEXT_PUBLIC_ENABLE_MOCKS=false
+EOF
+
+# Build in standalone mode
+STANDALONE=true pnpm run build
+
+# Delete .env (secrets must not persist)
+rm .env
+
+# Copy static assets into standalone dirs + start with PM2
+for app in auth store admin playground landing payments studio; do
+  STANDALONE_DIR="apps/$app/.next/standalone"
+  cp -r "apps/$app/.next/static" "$STANDALONE_DIR/apps/$app/.next/static"
+  cp -r "apps/$app/public" "$STANDALONE_DIR/apps/$app/public" 2>/dev/null || true
+done
+
+# Start all apps (standalone server.js, NOT pnpm start)
+PORT=5000 HOSTNAME=0.0.0.0 pm2 start apps/auth/.next/standalone/apps/auth/server.js --name candyshop-auth
+PORT=5001 HOSTNAME=0.0.0.0 pm2 start apps/store/.next/standalone/apps/store/server.js --name candyshop-store
+PORT=5002 HOSTNAME=0.0.0.0 pm2 start apps/admin/.next/standalone/apps/admin/server.js --name candyshop-admin
+PORT=5003 HOSTNAME=0.0.0.0 pm2 start apps/playground/.next/standalone/apps/playground/server.js --name candyshop-playground
+PORT=5004 HOSTNAME=0.0.0.0 pm2 start apps/landing/.next/standalone/apps/landing/server.js --name candyshop-landing
+PORT=5005 HOSTNAME=0.0.0.0 pm2 start apps/payments/.next/standalone/apps/payments/server.js --name candyshop-payments
+PORT=5006 HOSTNAME=0.0.0.0 pm2 start apps/studio/.next/standalone/apps/studio/server.js --name candyshop-studio
+
+pm2 save
+```
+
+**IMPORTANT:** Apps must be started with `node server.js` (standalone output), NOT `pnpm start` / `next start`. The standalone server properly handles `basePath` for path-based routing.
+
+### 8. Nginx Reverse Proxy
+
+The deploy script writes two files:
+
+- `/home/furrycolombia/candyshop-nginx.conf` — server block listening on port 9090
+- `/home/furrycolombia/candyshop-proxy.inc` — shared proxy headers
+
+To activate manually (if not using Hestia):
+
+```bash
+sudo ln -sf /home/furrycolombia/candyshop-nginx.conf /etc/nginx/conf.d/candyshop.conf
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+If using Hestia CP, configure the domain `store.furrycolombia.com` to proxy to `127.0.0.1:9090`.
+
+### 9. Cloudflare Tunnel (replaces traditional DNS + SSL)
+
+```bash
+# Install cloudflared
+curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg -o /tmp/cloudflare-main.gpg
+sudo cp /tmp/cloudflare-main.gpg /usr/share/keyrings/cloudflare-main.gpg
+echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
+sudo apt-get update && sudo apt-get install -y cloudflared
+
+# Login (opens browser — select furrycolombia.com)
+cloudflared tunnel login
+
+# Create tunnel
+cloudflared tunnel create candyshop-prod
+# Note the tunnel ID from the output
+
+# Route DNS (ONLY store.furrycolombia.com — do NOT touch other subdomains)
+cloudflared tunnel route dns candyshop-prod store.furrycolombia.com
+
+# Write config
+cat > ~/.cloudflared/config.yml << EOF
+tunnel: <TUNNEL_ID>
+credentials-file: /home/furrycolombia/.cloudflared/<TUNNEL_ID>.json
+protocol: http2
+
+ingress:
+  - hostname: store.furrycolombia.com
+    service: http://127.0.0.1:9090
+  - service: http_status:404
+EOF
+
+# Install as system service
+sudo mkdir -p /etc/cloudflared
+sudo cp ~/.cloudflared/config.yml /etc/cloudflared/config.yml
+sudo cp ~/.cloudflared/<TUNNEL_ID>.json /etc/cloudflared/<TUNNEL_ID>.json
+sudo cloudflared service install
+```
+
+**⚠️ WARNING: Only `store.furrycolombia.com` belongs to this project. `furrycolombia.com` and `moonfest.furrycolombia.com` are separate sites. Never modify their DNS records.**
+
+### 11. GitHub Secrets
+
+Update all secrets listed in the "GitHub Secrets Required" table above.
+Use the GitHub CLI:
+
+```bash
+gh secret set PROD_SERVER_HOST --body "<NEW_SERVER_IP>"
+gh secret set PROD_SERVER_SSH_KEY < ~/.ssh/id_ed25519
+# ... etc for all NEXT_PUBLIC_* vars
+```
+
+---
+
+## Operational Commands
+
+### PM2
+
+```bash
+# View all processes
+pm2 list
+
+# View logs (all apps)
+pm2 logs
+
+# View logs for one app
+pm2 logs candyshop-store
+
+# Restart all
+pm2 restart all
+
+# Restart one app
+pm2 restart candyshop-store
+
+# Monitor (live dashboard)
+pm2 monit
+```
+
+### Manual deploy (without CI)
+
+```bash
+ssh furrycolombia@192.168.2.71
+cd ~/candyshop
+git pull origin main
+pnpm install --frozen-lockfile --prod=false
+STANDALONE=true BASE_PATH_PREFIX="" pnpm run build
+pm2 restart all
+```
+
+### Nginx
+
+```bash
+# Test config
+sudo nginx -t
+
+# Reload after config change
+sudo systemctl reload nginx
+
+# View error logs
+sudo tail -f /var/log/nginx/error.log
+```
+
+---
+
+## Cloudflare Tunnel
+
+| Property    | Value                                                        |
+| ----------- | ------------------------------------------------------------ |
+| Tunnel name | candyshop-prod                                               |
+| Tunnel ID   | af85209b-fcfb-477a-9b95-81180f6901f2                         |
+| Hostname    | store.furrycolombia.com                                      |
+| Routes to   | http://127.0.0.1:9090 (Nginx reverse proxy)                  |
+| SSL         | Automatic via Cloudflare (no Let's Encrypt needed)           |
+| Service     | systemd (`cloudflared.service`), auto-starts on boot         |
+| Config      | `/etc/cloudflared/config.yml`                                |
+| Credentials | `/etc/cloudflared/af85209b-fcfb-477a-9b95-81180f6901f2.json` |
+
+**IMPORTANT: Only `store.furrycolombia.com` is managed by this tunnel. Do NOT modify DNS records for `furrycolombia.com`, `moonfest.furrycolombia.com`, or any other subdomain — those are separate sites.**
+
+Traffic flow:
+
+```
+Browser → Cloudflare CDN (SSL) → cloudflared tunnel → 127.0.0.1:9090 (Nginx) → app ports
+```
+
+## Supabase (Cloud)
+
+| Property  | Value                                                         |
+| --------- | ------------------------------------------------------------- |
+| Provider  | Supabase Cloud (free tier)                                    |
+| Project   | candyshop-prod                                                |
+| Region    | South America (São Paulo)                                     |
+| URL       | `https://olafyajipvsltohagiah.supabase.co`                    |
+| Dashboard | `https://supabase.com/dashboard/project/olafyajipvsltohagiah` |
+| RLS       | Enabled (automatic)                                           |
+
+**What's included (free tier):**
+
+- 500 MB database
+- 1 GB file storage
+- 50K monthly active users
+- 2 GB bandwidth
+- Auto backups (7-day retention)
+
+**Migrations:** Run against the cloud project with:
+
+```bash
+supabase link --project-ref olafyajipvsltohagiah
+supabase db push
+```
+
+---
+
+## Cloud Migration Path
+
+When ready to move from the local server to cloud, the main changes are:
+
+1. **Compute**: Provision a VM (AWS EC2 t3.medium, DigitalOcean 4GB, etc.)
+2. **Run the migration runbook** above on the new VM
+3. **DNS**: Update `store.furrycolombia.com` A record to the new public IP
+4. **GitHub Secrets**: Update `PROD_SERVER_HOST` and `PROD_SERVER_SSH_KEY`
+5. **SSL**: Let's Encrypt works the same way on any server
+6. **Optional upgrades**:
+   - Add a load balancer (ALB, Cloudflare) in front
+   - Use Docker/containers instead of bare PM2
+   - Add a CDN for static assets
+   - Move to container orchestration (ECS, Kubernetes) for auto-scaling
+
+The CI/CD pipeline (`deploy-production.yml`) works identically — it just SSHs into whatever IP is in the secrets.
+
+---
+
+## Troubleshooting
+
+| Symptom                    | Check                                            |
+| -------------------------- | ------------------------------------------------ |
+| App not responding         | `pm2 logs candyshop-<app>`                       |
+| 502 Bad Gateway            | Is the app running? `pm2 list`                   |
+| Build fails on server      | Check Node version: `node --version` (needs 22+) |
+| SSH connection refused     | Check `~/.ssh/authorized_keys` on server         |
+| Nginx config error         | `sudo nginx -t`                                  |
+| PM2 not starting on reboot | Re-run `pm2 startup` and `pm2 save`              |
+| Disk full                  | `df -h` and clean old builds: `git clean -fdx`   |

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+set -euo pipefail
+
+# =============================================================================
+# Production Deployment Script for hestia.local
+# Runs ON the server via SSH from GitHub Actions
+# =============================================================================
+
+DEPLOY_DIR="/home/furrycolombia/candyshop"
+REPO_URL="${REPO_URL:-}"
+BRANCH="${BRANCH:-main}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[DEPLOY]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+err()  { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+# Load nvm
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
+nvm use 22 --silent || err "Node 22 not available via nvm"
+
+log "Node $(node --version) | pnpm $(pnpm --version) | PM2 $(pm2 --version)"
+
+# =============================================================================
+# Clone or pull
+# =============================================================================
+if [ ! -d "$DEPLOY_DIR/.git" ]; then
+  log "First deploy — cloning repository..."
+  git clone --branch "$BRANCH" --depth 1 "$REPO_URL" "$DEPLOY_DIR"
+else
+  log "Pulling latest from $BRANCH..."
+  cd "$DEPLOY_DIR"
+  git fetch origin "$BRANCH" --depth 1
+  git reset --hard "origin/$BRANCH"
+  git clean -fd
+fi
+
+cd "$DEPLOY_DIR"
+log "Checked out $(git log --oneline -1)"
+
+# =============================================================================
+# Install dependencies
+# =============================================================================
+log "Installing dependencies..."
+pnpm install --frozen-lockfile --prod=false
+
+# =============================================================================
+# Load build env vars (written by CI, deleted after deploy)
+# =============================================================================
+ENV_FILE="${ENV_FILE:-/tmp/.candyshop-build.env}"
+if [ -f "$ENV_FILE" ]; then
+  log "Loading build env from $ENV_FILE"
+  cp "$ENV_FILE" "$DEPLOY_DIR/.env"
+else
+  warn "No env file found at $ENV_FILE — building with defaults"
+fi
+
+# =============================================================================
+# Build all apps (standalone mode for path-based routing)
+# =============================================================================
+log "Building all applications in standalone mode..."
+export STANDALONE=true
+pnpm run build
+
+# Clean up env file (secrets should not persist on disk)
+rm -f "$ENV_FILE" "$DEPLOY_DIR/.env"
+
+# =============================================================================
+# Start/restart apps with PM2
+# =============================================================================
+log "Starting applications with PM2..."
+
+APPS=(
+  "auth:5000"
+  "store:5001"
+  "admin:5002"
+  "playground:5003"
+  "landing:5004"
+  "payments:5005"
+  "studio:5006"
+)
+
+for APP_ENTRY in "${APPS[@]}"; do
+  APP_NAME="${APP_ENTRY%%:*}"
+  APP_PORT="${APP_ENTRY##*:}"
+  PM2_NAME="candyshop-${APP_NAME}"
+
+  log "Starting $PM2_NAME on port $APP_PORT..."
+
+  # Stop existing instance if running
+  pm2 delete "$PM2_NAME" 2>/dev/null || true
+
+  # Copy static assets into standalone directory
+  STANDALONE_DIR="$DEPLOY_DIR/apps/$APP_NAME/.next/standalone"
+  cp -r "$DEPLOY_DIR/apps/$APP_NAME/.next/static" "$STANDALONE_DIR/apps/$APP_NAME/.next/static" 2>/dev/null || true
+  cp -r "$DEPLOY_DIR/apps/$APP_NAME/public" "$STANDALONE_DIR/apps/$APP_NAME/public" 2>/dev/null || true
+
+  # Start standalone server.js with PM2
+  PORT=$APP_PORT HOSTNAME=0.0.0.0 pm2 start "$STANDALONE_DIR/apps/$APP_NAME/server.js" \
+    --name "$PM2_NAME"
+done
+
+# Save PM2 process list for auto-restart on reboot
+pm2 save
+
+log "All applications started!"
+pm2 list
+
+# =============================================================================
+# Deploy Nginx config
+# =============================================================================
+log "Configuring Nginx reverse proxy..."
+
+NGINX_CONF="/home/furrycolombia/candyshop-nginx.conf"
+cat > "$NGINX_CONF" << 'NGINX_EOF'
+# Candyshop production reverse proxy
+# Included by Hestia's nginx config for store.furrycolombia.com
+
+upstream cs_auth    { server 127.0.0.1:5000; }
+upstream cs_store   { server 127.0.0.1:5001; }
+upstream cs_admin   { server 127.0.0.1:5002; }
+upstream cs_play    { server 127.0.0.1:5003; }
+upstream cs_landing { server 127.0.0.1:5004; }
+upstream cs_pay     { server 127.0.0.1:5005; }
+upstream cs_studio  { server 127.0.0.1:5006; }
+
+map $http_upgrade $allowed_upgrade {
+    default "";
+    "websocket" "websocket";
+}
+map $http_upgrade $connection_upgrade {
+    default "";
+    "websocket" "upgrade";
+}
+
+server {
+    listen 9090;
+    server_name _;
+
+    proxy_buffer_size          16k;
+    proxy_buffers              8 16k;
+    proxy_busy_buffers_size    32k;
+    large_client_header_buffers 8 32k;
+
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+
+    location /store   { proxy_pass http://cs_store;   include /home/furrycolombia/candyshop-proxy.inc; }
+    location /admin   { proxy_pass http://cs_admin;   include /home/furrycolombia/candyshop-proxy.inc; }
+    location /auth    { proxy_pass http://cs_auth;    include /home/furrycolombia/candyshop-proxy.inc; }
+    location /payments { proxy_pass http://cs_pay;    include /home/furrycolombia/candyshop-proxy.inc; }
+    location /playground { proxy_pass http://cs_play; include /home/furrycolombia/candyshop-proxy.inc; }
+    location /studio  { proxy_pass http://cs_studio;  include /home/furrycolombia/candyshop-proxy.inc; }
+    location /        { proxy_pass http://cs_landing; include /home/furrycolombia/candyshop-proxy.inc; }
+
+    location = /health {
+        access_log off;
+        return 200 'OK';
+        add_header Content-Type text/plain;
+    }
+}
+NGINX_EOF
+
+# Shared proxy headers snippet
+cat > /home/furrycolombia/candyshop-proxy.inc << 'PROXY_EOF'
+proxy_http_version 1.1;
+proxy_set_header Upgrade $allowed_upgrade;
+proxy_set_header Connection $connection_upgrade;
+proxy_set_header Host $http_host;
+proxy_set_header X-Forwarded-Host $http_host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_cache_bypass $http_upgrade;
+PROXY_EOF
+
+log "Nginx config written to $NGINX_CONF"
+log "NOTE: Hestia domain config for store.furrycolombia.com must proxy to port 9090"
+
+# =============================================================================
+# Health check
+# =============================================================================
+log "Running health checks..."
+sleep 5
+
+FAILED=0
+for APP_ENTRY in "${APPS[@]}"; do
+  APP_NAME="${APP_ENTRY%%:*}"
+  APP_PORT="${APP_ENTRY##*:}"
+
+  if curl -sf "http://localhost:${APP_PORT}" > /dev/null 2>&1; then
+    log "  ✓ $APP_NAME (port $APP_PORT) — healthy"
+  else
+    warn "  ✗ $APP_NAME (port $APP_PORT) — not responding yet"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+if [ "$FAILED" -gt 0 ]; then
+  warn "$FAILED app(s) not responding yet. They may still be starting up."
+  warn "Check with: pm2 logs"
+else
+  log "All apps healthy!"
+fi
+
+log "Deployment complete!"

--- a/scripts/server/candyshop-nginx.conf
+++ b/scripts/server/candyshop-nginx.conf
@@ -1,0 +1,46 @@
+upstream cs_auth    { server 127.0.0.1:5000; }
+upstream cs_store   { server 127.0.0.1:5001; }
+upstream cs_admin   { server 127.0.0.1:5002; }
+upstream cs_play    { server 127.0.0.1:5003; }
+upstream cs_landing { server 127.0.0.1:5004; }
+upstream cs_pay     { server 127.0.0.1:5005; }
+upstream cs_studio  { server 127.0.0.1:5006; }
+
+map $http_upgrade $allowed_upgrade {
+    default "";
+    "websocket" "websocket";
+}
+map $http_upgrade $connection_upgrade {
+    default "";
+    "websocket" "upgrade";
+}
+
+server {
+    listen 9090;
+    server_name _;
+
+    proxy_buffer_size          16k;
+    proxy_buffers              8 16k;
+    proxy_busy_buffers_size    32k;
+    large_client_header_buffers 8 32k;
+
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+
+    location /store      { proxy_pass http://cs_store;   include /home/furrycolombia/candyshop-proxy.inc; }
+    location /admin      { proxy_pass http://cs_admin;   include /home/furrycolombia/candyshop-proxy.inc; }
+    location /auth       { proxy_pass http://cs_auth;    include /home/furrycolombia/candyshop-proxy.inc; }
+    location /payments   { proxy_pass http://cs_pay;     include /home/furrycolombia/candyshop-proxy.inc; }
+    location /playground { proxy_pass http://cs_play;    include /home/furrycolombia/candyshop-proxy.inc; }
+    location /studio     { proxy_pass http://cs_studio;  include /home/furrycolombia/candyshop-proxy.inc; }
+    location /           { proxy_pass http://cs_landing; include /home/furrycolombia/candyshop-proxy.inc; }
+
+    location = /health {
+        access_log off;
+        return 200 'OK';
+        add_header Content-Type text/plain;
+    }
+}

--- a/scripts/server/candyshop-proxy.inc
+++ b/scripts/server/candyshop-proxy.inc
@@ -1,0 +1,9 @@
+proxy_http_version 1.1;
+proxy_set_header Upgrade $allowed_upgrade;
+proxy_set_header Connection $connection_upgrade;
+proxy_set_header Host $http_host;
+proxy_set_header X-Forwarded-Host $http_host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_cache_bypass $http_upgrade;

--- a/scripts/server/candyshop.stpl
+++ b/scripts/server/candyshop.stpl
@@ -1,0 +1,49 @@
+server {
+        listen      %ip%:%proxy_ssl_port% ssl;
+        server_name %domain_idn% %alias_idn%;
+        error_log   /var/log/%web_system%/domains/%domain%.error.log error;
+
+        ssl_certificate     %ssl_pem%;
+        ssl_certificate_key %ssl_key%;
+        ssl_stapling        on;
+        ssl_stapling_verify on;
+
+        if ($anti_replay = 307) { return 307 https://$host$request_uri; }
+        if ($anti_replay = 425) { return 425; }
+
+        include %home%/%user%/conf/web/%domain%/nginx.hsts.conf*;
+
+        location ~ /\.(?!well-known\/|file) {
+                deny all;
+                return 404;
+        }
+
+        location / {
+                proxy_pass http://127.0.0.1:9090;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Forwarded-Host $http_host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_cache_bypass $http_upgrade;
+                proxy_buffer_size 16k;
+                proxy_buffers 8 16k;
+                proxy_busy_buffers_size 32k;
+        }
+
+        location = /health {
+                access_log off;
+                proxy_pass http://127.0.0.1:9090/health;
+        }
+
+        location /error/ {
+                alias %home%/%user%/web/%domain%/document_errors/;
+        }
+
+        proxy_hide_header Upgrade;
+
+        include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
+}

--- a/scripts/server/candyshop.tpl
+++ b/scripts/server/candyshop.tpl
@@ -1,0 +1,39 @@
+server {
+        listen      %ip%:%proxy_port%;
+        server_name %domain_idn% %alias_idn%;
+        error_log   /var/log/%web_system%/domains/%domain%.error.log error;
+
+        include %home%/%user%/conf/web/%domain%/nginx.forcessl.conf*;
+
+        location ~ /\.(?!well-known\/|file) {
+                deny all;
+                return 404;
+        }
+
+        location / {
+                proxy_pass http://127.0.0.1:9090;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Forwarded-Host $http_host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_cache_bypass $http_upgrade;
+                proxy_buffer_size 16k;
+                proxy_buffers 8 16k;
+                proxy_busy_buffers_size 32k;
+        }
+
+        location = /health {
+                access_log off;
+                proxy_pass http://127.0.0.1:9090/health;
+        }
+
+        location /error/ {
+                alias %home%/%user%/web/%domain%/document_errors/;
+        }
+
+        include %home%/%user%/conf/web/%domain%/nginx.conf_*;
+}


### PR DESCRIPTION
## What this does

Adds a complete production deployment pipeline for **store.furrycolombia.com**.

### Changes
- **GitHub Actions workflow** (`deploy-production.yml`) — CI gate (typecheck, lint, test, build) then deploy via SSH on push to `main`
- **Deploy script** (`deploy-production.sh`) — clones/pulls, builds with `STANDALONE=true`, starts 7 Next.js apps via PM2 using standalone `server.js`
- **Nginx config** — reverse proxy on port 9090 routing paths to each app
- **Hestia CP templates** — custom nginx templates for the domain
- **Infrastructure docs** — full migration runbook, architecture diagram, operational commands, troubleshooting

### Architecture
```
Cloudflare CDN (SSL) → cloudflared tunnel → Nginx :9090 → PM2 apps
  /          → landing  :5004
  /store     → store    :5001
  /admin     → admin    :5002
  /auth      → auth     :5000
  /payments  → payments :5005
  /playground→ playground:5003
  /studio    → studio   :5006
```

### Server setup (already done)
- Node 22 via nvm, pnpm, PM2 with auto-startup
- Cloudflare tunnel `candyshop-prod` routing `store.furrycolombia.com`
- Supabase Cloud linked and migrations pushed
- All GitHub secrets configured