### PR TITLE
fix: remove empty API_BASE_URL from deploy workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -53,7 +53,6 @@ jobs:
         env:
           STANDALONE: "true"
           BASE_PATH_PREFIX: ""
-          NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL }}
           NEXT_PUBLIC_API_PREFIX: ${{ secrets.NEXT_PUBLIC_API_PREFIX }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
The empty NEXT_PUBLIC_API_BASE_URL secret caused invalid rewrite destinations during build. Removed it so apps fall through to their default backend URL.