### PR TITLE
fix: strip CR from SSH key in deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Setup SSH key
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.PROD_SERVER_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.PROD_SERVER_SSH_KEY }}" | tr -d '\r' > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           cat >> ~/.ssh/config << EOF
           Host ${{ secrets.PROD_SERVER_HOST }}


### PR DESCRIPTION
Windows line endings in the SSH key secret caused libcrypto errors.