### PR TITLE
fix: replace scp with ssh pipe for deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -123,9 +123,8 @@ jobs:
 
       - name: Copy deploy script to server
         run: |
-          scp -F ~/.ssh/config \
-            scripts/deploy-production.sh \
-            ${{ secrets.PROD_SERVER_HOST }}:/tmp/deploy-production.sh
+          cat scripts/deploy-production.sh | ssh ${{ secrets.PROD_SERVER_HOST }} \
+            'cat > /tmp/deploy-production.sh && chmod +x /tmp/deploy-production.sh'
 
       - name: Run deployment
         run: |


### PR DESCRIPTION
scp doesn't use SSH config ProxyCommand. Pipe through ssh instead.