### PR TITLE
fix(deploy): source env file into shell before build

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -58,6 +58,12 @@ ENV_FILE="${ENV_FILE:-/tmp/.candyshop-build.env}"
 if [ -f "$ENV_FILE" ]; then
   log "Loading build env from $ENV_FILE"
   cp "$ENV_FILE" "$DEPLOY_DIR/.env"
+  # Source env vars into the current shell so child processes (pnpm build) inherit them.
+  # This is required for load-env.mjs to detect CI=true and resolve $secret: references.
+  set -o allexport
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  set +o allexport
 else
   warn "No env file found at $ENV_FILE — building with defaults"
 fi


### PR DESCRIPTION
## Summary

- Sources the ephemeral env file into the shell before running \`pnpm run build\`
- This ensures \`CI=true\` and all \`NEXT_PUBLIC_*\` vars are in \`process.env\` when \`scripts/build.mjs\` → \`load-env.mjs\` runs

## Root Cause

\`scripts/load-env.mjs\` checks \`process.env.CI === "true"\` to decide whether to use the CI secret-resolution path (read \`$secret:KEY\` names from \`process.env\`) or the local path (read from a \`.secrets\` file). On the production server there is no \`.secrets\` file, so the build was failing with:

\`\`\`
Error: Missing .secrets file. Run pnpm sync-secrets.
\`\`\`

The env file was being \`cp\`'d to \`.env\` but never sourced, so the shell running \`deploy-production.sh\` had no knowledge of \`CI=true\`. Sourcing the file with \`set -o allexport\` exports all variables to child processes including the \`pnpm run build\` subprocess, matching the same environment that the \`ci-gate\` job provides natively in GitHub Actions.

## Test plan

- [ ] Workflow triggers on merge to main
- [ ] \`pnpm run build\` succeeds on server without \`.secrets\` file
- [ ] All PM2 processes start healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)