### PR TITLE
fix(deploy): use correct standalone server.js path

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -103,13 +103,15 @@ for APP_ENTRY in "${APPS[@]}"; do
   # Stop existing instance if running
   pm2 delete "$PM2_NAME" 2>/dev/null || true
 
-  # Copy static assets into standalone directory
+  # Copy static assets into standalone directory.
+  # Next.js places server.js directly at standalone/server.js when outputFileTracingRoot
+  # is not set (each app is its own tracing root).
   STANDALONE_DIR="$DEPLOY_DIR/apps/$APP_NAME/.next/standalone"
-  cp -r "$DEPLOY_DIR/apps/$APP_NAME/.next/static" "$STANDALONE_DIR/apps/$APP_NAME/.next/static" 2>/dev/null || true
-  cp -r "$DEPLOY_DIR/apps/$APP_NAME/public" "$STANDALONE_DIR/apps/$APP_NAME/public" 2>/dev/null || true
+  cp -r "$DEPLOY_DIR/apps/$APP_NAME/.next/static" "$STANDALONE_DIR/.next/static" 2>/dev/null || true
+  cp -r "$DEPLOY_DIR/apps/$APP_NAME/public" "$STANDALONE_DIR/public" 2>/dev/null || true
 
   # Start standalone server.js with PM2
-  PORT=$APP_PORT HOSTNAME=0.0.0.0 pm2 start "$STANDALONE_DIR/apps/$APP_NAME/server.js" \
+  PORT=$APP_PORT HOSTNAME=0.0.0.0 pm2 start "$STANDALONE_DIR/server.js" \
     --name "$PM2_NAME"
 done
 


### PR DESCRIPTION
## Summary

- Fixes PM2 failing to start apps after a successful build
- Updates static/public asset copy paths to match the flat standalone structure

## Root Cause

The deploy script expected `server.js` at `.next/standalone/apps/<name>/server.js` — the path Next.js uses when `outputFileTracingRoot` is set to the monorepo root. None of the `next.config.ts` files set `outputFileTracingRoot`, so Next.js outputs `server.js` directly at `.next/standalone/server.js` (each app is its own file-tracing root).

**Before:**
```bash
pm2 start "$STANDALONE_DIR/apps/$APP_NAME/server.js"  # ← not found
cp ... "$STANDALONE_DIR/apps/$APP_NAME/.next/static"   # ← wrong target
```

**After:**
```bash
pm2 start "$STANDALONE_DIR/server.js"                  # ← correct
cp ... "$STANDALONE_DIR/.next/static"                  # ← correct
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)