### PR TITLE
refactor(cart): use strict id+quantity hydration

### DIFF
--- a/apps/payments/src/features/checkout/application/hooks/useCartFromCookie.test.tsx
+++ b/apps/payments/src/features/checkout/application/hooks/useCartFromCookie.test.tsx
@@ -1,0 +1,120 @@
+/* eslint-disable react/display-name */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next-intl", () => ({
+  useLocale: vi.fn(() => "es"),
+}));
+
+vi.mock("@/features/checkout/infrastructure/cartCookie", () => ({
+  readCartFromCookie: vi.fn(() => []),
+  subscribeToCartCookie: vi.fn(() => () => {}),
+}));
+
+vi.mock("shared", async () => {
+  const actual = await vi.importActual<typeof import("shared")>("shared");
+  return {
+    ...actual,
+    useSupabase: vi.fn(() => ({})),
+  };
+});
+
+vi.mock("@/features/checkout/infrastructure/checkoutQueries", () => ({
+  fetchCheckoutProductsByIds: vi.fn(async () => []),
+}));
+
+vi.mock("./useSellerProfiles", () => ({
+  useSellerProfiles: vi.fn(() => ({ data: {}, isLoading: false })),
+}));
+
+import { useCartFromCookie } from "./useCartFromCookie";
+import { useSellerProfiles } from "./useSellerProfiles";
+
+import {
+  readCartFromCookie,
+  subscribeToCartCookie,
+} from "@/features/checkout/infrastructure/cartCookie";
+import { fetchCheckoutProductsByIds } from "@/features/checkout/infrastructure/checkoutQueries";
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useCartFromCookie", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns isEmpty=true when cart is empty after hydration", async () => {
+    vi.mocked(readCartFromCookie).mockReturnValue([]);
+
+    const { result } = renderHook(() => useCartFromCookie(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isEmpty).toBe(true);
+    expect(result.current.groups).toEqual([]);
+  });
+
+  it("groups items by seller_id", async () => {
+    const cookieItems = [
+      { id: "p1", quantity: 2 },
+      { id: "p2", quantity: 1 },
+    ];
+    const products = [
+      {
+        id: "p1",
+        seller_id: "s1",
+        price_cop: 10_000,
+        name_en: "Hat",
+        name_es: "Sombrero",
+        price_usd: 2.5,
+        images: [],
+        max_quantity: null,
+      },
+      {
+        id: "p2",
+        seller_id: "s1",
+        price_cop: 5000,
+        name_en: "Pin",
+        name_es: "Pin",
+        price_usd: 1.25,
+        images: [],
+        max_quantity: null,
+      },
+    ];
+    vi.mocked(readCartFromCookie).mockReturnValue(cookieItems);
+    vi.mocked(fetchCheckoutProductsByIds).mockResolvedValue(products);
+    vi.mocked(useSellerProfiles).mockReturnValue({
+      data: { s1: "Seller One" },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useSellerProfiles>);
+
+    const { result } = renderHook(() => useCartFromCookie(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.groups).toHaveLength(1);
+    expect(result.current.groups[0].sellerId).toBe("s1");
+    expect(result.current.groups[0].sellerName).toBe("Seller One");
+    expect(result.current.groups[0].items).toHaveLength(2);
+    expect(result.current.groups[0].items[0].quantity).toBe(2);
+    expect(result.current.groups[0].items[1].quantity).toBe(1);
+    expect(result.current.groups[0].subtotalCop).toBe(25_000);
+  });
+
+  it("subscribes to cart cookie changes", () => {
+    const unsubscribe = vi.fn();
+    vi.mocked(subscribeToCartCookie).mockReturnValue(unsubscribe);
+
+    renderHook(() => useCartFromCookie(), { wrapper: createWrapper() });
+
+    expect(subscribeToCartCookie).toHaveBeenCalled();
+  });
+});

--- a/apps/payments/src/features/checkout/application/hooks/useCartFromCookie.test.tsx
+++ b/apps/payments/src/features/checkout/application/hooks/useCartFromCookie.test.tsx
@@ -13,13 +13,9 @@ vi.mock("@/features/checkout/infrastructure/cartCookie", () => ({
   subscribeToCartCookie: vi.fn(() => () => {}),
 }));
 
-vi.mock("shared", async () => {
-  const actual = await vi.importActual<typeof import("shared")>("shared");
-  return {
-    ...actual,
-    useSupabase: vi.fn(() => ({})),
-  };
-});
+vi.mock("api/supabase", () => ({
+  createBrowserSupabaseClient: vi.fn(() => ({})),
+}));
 
 vi.mock("@/features/checkout/infrastructure/checkoutQueries", () => ({
   fetchCheckoutProductsByIds: vi.fn(async () => []),

--- a/apps/payments/src/features/checkout/application/hooks/useCartFromCookie.ts
+++ b/apps/payments/src/features/checkout/application/hooks/useCartFromCookie.ts
@@ -1,27 +1,32 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { useLocale } from "next-intl";
-import { useMemo, useSyncExternalStore } from "react";
-import { i18nField } from "shared";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { i18nField, useSupabase } from "shared";
+import type { CartCookieItem } from "shared/types";
 
 import { useSellerProfiles } from "./useSellerProfiles";
 
+import { CHECKOUT_CART_PRODUCTS_QUERY_KEY } from "@/features/checkout/domain/constants";
 import type { CartItem, SellerGroup } from "@/features/checkout/domain/types";
 import {
   readCartFromCookie,
   subscribeToCartCookie,
 } from "@/features/checkout/infrastructure/cartCookie";
+import { fetchCheckoutProductsByIds } from "@/features/checkout/infrastructure/checkoutQueries";
 import { FALLBACK_SELLER_NAME } from "@/shared/domain/constants";
 
 /** Stable empty array so the server snapshot reference never changes. */
-const EMPTY: CartItem[] = [];
+const EMPTY_COOKIE_ITEMS: CartCookieItem[] = [];
+const EMPTY_PRODUCTS: Array<Omit<CartItem, "quantity">> = [];
 
-function getSnapshot(): CartItem[] {
+function getSnapshot(): CartCookieItem[] {
   return readCartFromCookie();
 }
 
-function getServerSnapshot(): CartItem[] {
-  return EMPTY;
+function getServerSnapshot(): CartCookieItem[] {
+  return EMPTY_COOKIE_ITEMS;
 }
 
 /**
@@ -30,12 +35,56 @@ function getServerSnapshot(): CartItem[] {
  */
 export function useCartFromCookie() {
   const locale = useLocale();
-  const items = useSyncExternalStore(
+  const supabase = useSupabase();
+  const cookieItems = useSyncExternalStore(
     subscribeToCartCookie,
     getSnapshot,
     getServerSnapshot,
   );
-  const isHydrated = items !== EMPTY;
+  const isHydrated = cookieItems !== EMPTY_COOKIE_ITEMS;
+
+  const cartIds = useMemo(
+    () => cookieItems.map((item) => item.id),
+    [cookieItems],
+  );
+  const { data: products = EMPTY_PRODUCTS, isLoading: isLoadingProducts } =
+    useQuery({
+      // eslint-disable-next-line @tanstack/query/exhaustive-deps -- supabase is not serializable (circular refs)
+      queryKey: [CHECKOUT_CART_PRODUCTS_QUERY_KEY, cartIds],
+      queryFn: () => fetchCheckoutProductsByIds(supabase, cartIds),
+      enabled: cartIds.length > 0,
+      staleTime: 30_000,
+    });
+
+  const productById = useMemo(
+    () => new Map(products.map((product) => [product.id, product])),
+    [products],
+  );
+
+  const items: CartItem[] = useMemo(
+    () =>
+      cookieItems
+        .map((cookieItem) => {
+          const product = productById.get(cookieItem.id);
+          if (!product) return null;
+
+          const maxQuantity =
+            typeof product.max_quantity === "number"
+              ? product.max_quantity
+              : null;
+          const quantity =
+            maxQuantity === null
+              ? cookieItem.quantity
+              : Math.min(cookieItem.quantity, maxQuantity);
+
+          return {
+            ...product,
+            quantity,
+          };
+        })
+        .filter((item): item is CartItem => item !== null),
+    [cookieItems, productById],
+  );
 
   const sellerIds = useMemo(() => {
     const ids = new Set<string>();
@@ -68,10 +117,13 @@ export function useCartFromCookie() {
     }));
   }, [items, sellerNames]);
 
-  const isEmpty = isHydrated && items.length === 0;
-  const isLoading = !isHydrated || isLoadingProfiles;
+  const isEmpty = isHydrated && !isLoadingProducts && items.length === 0;
+  const isLoading = !isHydrated || isLoadingProducts || isLoadingProfiles;
 
-  const getItemName = (item: CartItem) => i18nField(item, "name", locale);
+  const getItemName = useCallback(
+    (item: CartItem) => i18nField(item, "name", locale),
+    [locale],
+  );
 
   return { groups, isEmpty, isLoading, getItemName };
 }

--- a/apps/payments/src/features/checkout/application/hooks/useCartFromCookie.ts
+++ b/apps/payments/src/features/checkout/application/hooks/useCartFromCookie.ts
@@ -1,9 +1,10 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { createBrowserSupabaseClient } from "api/supabase";
 import { useLocale } from "next-intl";
 import { useCallback, useMemo, useSyncExternalStore } from "react";
-import { i18nField, useSupabase } from "shared";
+import { i18nField } from "shared";
 import type { CartCookieItem } from "shared/types";
 
 import { useSellerProfiles } from "./useSellerProfiles";
@@ -35,7 +36,7 @@ function getServerSnapshot(): CartCookieItem[] {
  */
 export function useCartFromCookie() {
   const locale = useLocale();
-  const supabase = useSupabase();
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
   const cookieItems = useSyncExternalStore(
     subscribeToCartCookie,
     getSnapshot,

--- a/apps/payments/src/features/checkout/domain/constants.ts
+++ b/apps/payments/src/features/checkout/domain/constants.ts
@@ -5,10 +5,17 @@ export {
   RECEIPTS_BUCKET,
 } from "@/shared/domain/constants";
 
+/** Session storage key used to persist checkout completion across page refreshes */
+export const CHECKOUT_COMPLETED_SESSION_KEY = "candystore-checkout-completed";
+
+export const SELLER_PROFILES_QUERY_KEY = "seller-profiles";
+export const CHECKOUT_CART_PRODUCTS_QUERY_KEY = "checkout-cart-products";
+
 /** Default expiry offset for new orders (48 hours) */
 export const ORDER_EXPIRY_HOURS = 48;
 
-/** Time conversion constants */
-export const MINUTES_PER_HOUR = 60;
-export const SECONDS_PER_MINUTE = 60;
-export const MS_PER_SECOND = 1000;
+export {
+  MS_PER_SECOND,
+  SECONDS_PER_MINUTE,
+  MINUTES_PER_HOUR,
+} from "shared/constants/time";

--- a/apps/payments/src/features/checkout/domain/constants.ts
+++ b/apps/payments/src/features/checkout/domain/constants.ts
@@ -14,8 +14,7 @@ export const CHECKOUT_CART_PRODUCTS_QUERY_KEY = "checkout-cart-products";
 /** Default expiry offset for new orders (48 hours) */
 export const ORDER_EXPIRY_HOURS = 48;
 
-export {
-  MS_PER_SECOND,
-  SECONDS_PER_MINUTE,
-  MINUTES_PER_HOUR,
-} from "shared/constants/time";
+/** Time conversion constants */
+export const MINUTES_PER_HOUR = 60;
+export const SECONDS_PER_MINUTE = 60;
+export const MS_PER_SECOND = 1000;

--- a/apps/payments/src/features/checkout/domain/types.ts
+++ b/apps/payments/src/features/checkout/domain/types.ts
@@ -1,8 +1,8 @@
 /**
  * Checkout feature domain types.
  *
- * CartItem matches the shape stored in the "candystore-cart" cookie
- * by the store app (full product row + quantity).
+ * CartItem is the enriched checkout shape after resolving product IDs from
+ * the "candystore-cart" cookie ({id, quantity}) against the backend.
  */
 
 export interface CartItem {

--- a/apps/payments/src/features/checkout/infrastructure/cartCookie.test.ts
+++ b/apps/payments/src/features/checkout/infrastructure/cartCookie.test.ts
@@ -43,40 +43,25 @@ describe("readCartFromCookie", () => {
     expect(readCartFromCookie()).toEqual([]);
   });
 
-  it("filters out invalid cart items", () => {
+  it("returns empty when cookie payload is a mixed-validity array", () => {
     const items = [
       {
         id: "p1",
-        name_en: "Widget",
-        name_es: "Widget",
-        price_cop: 1000,
-        price_usd: 1,
-        seller_id: "s1",
         quantity: 2,
-        images: [],
-        max_quantity: 10,
       },
       { invalid: true }, // missing required fields
       null,
     ];
     mockGetCookie.mockReturnValue(JSON.stringify(items));
     const result = readCartFromCookie();
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("p1");
+    expect(result).toEqual([]);
   });
 
   it("returns valid cart items from cookie", () => {
     const items = [
       {
         id: "p1",
-        name_en: "Widget",
-        name_es: "Widget",
-        price_cop: 5000,
-        price_usd: 1.5,
-        seller_id: "s1",
         quantity: 3,
-        images: [],
-        max_quantity: null,
       },
     ];
     mockGetCookie.mockReturnValue(JSON.stringify(items));
@@ -84,7 +69,6 @@ describe("readCartFromCookie", () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       id: "p1",
-      price_cop: 5000,
       quantity: 3,
     });
   });

--- a/apps/payments/src/features/checkout/infrastructure/cartCookie.ts
+++ b/apps/payments/src/features/checkout/infrastructure/cartCookie.ts
@@ -1,5 +1,4 @@
 import { deleteCookie, getCookie } from "cookies-next";
-import { getSharedCookieDomain } from "shared";
 import { isCartCookieItems } from "shared/types";
 import type { CartCookieItem } from "shared/types";
 
@@ -9,9 +8,20 @@ import {
 } from "@/shared/domain/constants";
 
 const EMPTY_CART: CartCookieItem[] = [];
+const MINIMUM_DOMAIN_SEGMENTS = 2;
+const DOMAIN_SUFFIX_SEGMENT_OFFSET = -2;
 
 let lastRawCartCookie: string | null = null;
 let lastCartSnapshot: CartCookieItem[] = EMPTY_CART;
+
+function getSharedCookieDomain(hostname: string): string | undefined {
+  if (hostname === "localhost" || hostname === "127.0.0.1") return undefined;
+
+  const parts = hostname.split(".");
+  if (parts.length < MINIMUM_DOMAIN_SEGMENTS) return undefined;
+
+  return `.${parts.slice(DOMAIN_SUFFIX_SEGMENT_OFFSET).join(".")}`;
+}
 
 /** Read and validate the cart cookie set by the store app. */
 export function readCartFromCookie(): CartCookieItem[] {

--- a/apps/payments/src/features/checkout/infrastructure/cartCookie.ts
+++ b/apps/payments/src/features/checkout/infrastructure/cartCookie.ts
@@ -1,40 +1,20 @@
 import { deleteCookie, getCookie } from "cookies-next";
+import { getSharedCookieDomain } from "shared";
+import { isCartCookieItems } from "shared/types";
+import type { CartCookieItem } from "shared/types";
 
-import type { CartItem } from "@/features/checkout/domain/types";
 import {
   CART_COOKIE_CHANGED_EVENT,
   CART_COOKIE_KEY,
 } from "@/shared/domain/constants";
 
-const EMPTY_CART: CartItem[] = [];
-const MINIMUM_DOMAIN_SEGMENTS = 2;
-const DOMAIN_SUFFIX_SEGMENT_OFFSET = -2;
+const EMPTY_CART: CartCookieItem[] = [];
 
 let lastRawCartCookie: string | null = null;
-let lastCartSnapshot: CartItem[] = EMPTY_CART;
-
-function getSharedCookieDomain(hostname: string): string | undefined {
-  if (hostname === "localhost" || hostname === "127.0.0.1") return undefined;
-
-  const parts = hostname.split(".");
-  if (parts.length < MINIMUM_DOMAIN_SEGMENTS) return undefined;
-
-  return `.${parts.slice(DOMAIN_SUFFIX_SEGMENT_OFFSET).join(".")}`;
-}
-
-function isValidCartItem(item: unknown): item is CartItem {
-  if (typeof item !== "object" || item === null) return false;
-  const record = item as Record<string, unknown>;
-  return (
-    typeof record.id === "string" &&
-    typeof record.price_cop === "number" &&
-    typeof record.price_usd === "number" &&
-    typeof record.quantity === "number"
-  );
-}
+let lastCartSnapshot: CartCookieItem[] = EMPTY_CART;
 
 /** Read and validate the cart cookie set by the store app. */
-export function readCartFromCookie(): CartItem[] {
+export function readCartFromCookie(): CartCookieItem[] {
   const raw = getCookie(CART_COOKIE_KEY);
   if (raw) {
     const serialized = String(raw);
@@ -44,16 +24,14 @@ export function readCartFromCookie(): CartItem[] {
 
     try {
       const parsed: unknown = JSON.parse(serialized);
-      if (!Array.isArray(parsed)) {
+      if (!isCartCookieItems(parsed)) {
         lastRawCartCookie = serialized;
         lastCartSnapshot = EMPTY_CART;
         return EMPTY_CART;
       }
 
       lastRawCartCookie = serialized;
-      lastCartSnapshot = parsed.filter((item: unknown) =>
-        isValidCartItem(item),
-      );
+      lastCartSnapshot = parsed;
       return lastCartSnapshot;
     } catch {
       lastRawCartCookie = serialized;

--- a/apps/payments/src/features/checkout/infrastructure/checkoutQueries.test.ts
+++ b/apps/payments/src/features/checkout/infrastructure/checkoutQueries.test.ts
@@ -194,7 +194,7 @@ describe("fetchSellerProfiles", () => {
     });
   });
 
-  it("throws on error", async () => {
+  it("returns empty object on error", async () => {
     supabase._chain.in.mockResolvedValue({
       data: null,
       error: new Error("DB error"),
@@ -205,7 +205,7 @@ describe("fetchSellerProfiles", () => {
         supabase as unknown as Parameters<typeof fetchSellerProfiles>[0],
         ["s1"],
       ),
-    ).rejects.toThrow("DB error");
+    ).resolves.toEqual({});
   });
 });
 
@@ -235,6 +235,12 @@ describe("createOrder", () => {
   });
 
   it("reserves stock, inserts order and items, returns order id", async () => {
+    // products price fetch returns price data
+    supabase._chain.in.mockResolvedValueOnce({
+      data: [{ id: "prod-1", price_cop: 5000 }],
+      error: null,
+    });
+
     // reserve_stock succeeds
     supabase.rpc.mockResolvedValue({ data: true, error: null });
 
@@ -274,6 +280,15 @@ describe("createOrder", () => {
   });
 
   it("releases stock and throws on reserve_stock failure", async () => {
+    // products price fetch returns price data for both items
+    supabase._chain.in.mockResolvedValueOnce({
+      data: [
+        { id: "prod-1", price_cop: 5000 },
+        { id: "prod-2", price_cop: 3000 },
+      ],
+      error: null,
+    });
+
     // First rpc call succeeds, second fails (simulating two items)
     supabase.rpc
       .mockResolvedValueOnce({ data: true, error: null }) // first item ok

--- a/apps/payments/src/features/checkout/infrastructure/checkoutQueries.ts
+++ b/apps/payments/src/features/checkout/infrastructure/checkoutQueries.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/features/checkout/domain/types";
 import { FALLBACK_SELLER_NAME } from "@/shared/domain/constants";
 import type { SupabaseClient } from "@/shared/domain/types";
+import { fetchUserDisplayNames } from "@/shared/infrastructure/fetchUserDisplayNames";
 
 /**
  * Fetch a seller's active payment methods directly from seller_payment_methods.
@@ -51,6 +52,51 @@ interface CreateOrderParams {
   checkoutSessionId: string;
 }
 
+export async function fetchCheckoutProductsByIds(
+  supabase: SupabaseClient,
+  ids: string[],
+): Promise<Array<Omit<CartItem, "quantity">>> {
+  if (ids.length === 0) return [];
+
+  const uniqueIds = [...new Set(ids)];
+  const { data, error } = await supabase
+    .from("products")
+    .select(
+      "id, name_en, name_es, price_cop, price_usd, seller_id, images, max_quantity, is_active",
+    )
+    .in("id", uniqueIds)
+    .eq("is_active", true);
+
+  if (error) throw error;
+
+  return (data ?? []).map((product) => ({
+    id: product.id,
+    name_en: product.name_en,
+    name_es: product.name_es,
+    price_cop: product.price_cop,
+    price_usd: product.price_usd,
+    seller_id: product.seller_id,
+    images: product.images,
+    max_quantity: product.max_quantity,
+  }));
+}
+
+async function releaseReservedStock(
+  supabase: SupabaseClient,
+  reserved: Array<{ productId: string; quantity: number }>,
+): Promise<void> {
+  for (const r of reserved) {
+    try {
+      await supabase.rpc("release_stock", {
+        p_product_id: r.productId,
+        p_quantity: r.quantity,
+      });
+    } catch (error) {
+      console.error("Failed to release stock for", r.productId, error);
+    }
+  }
+}
+
 /**
  * Create an order, reserving stock atomically for each item.
  * If any reservation fails, already-reserved items are released.
@@ -59,14 +105,29 @@ export async function createOrder(
   supabase: SupabaseClient,
   params: CreateOrderParams,
 ): Promise<string> {
-  const {
-    userId,
-    sellerId,
-    paymentMethodId,
-    items,
-    totalCop,
-    checkoutSessionId,
-  } = params;
+  const { userId, sellerId, paymentMethodId, items, checkoutSessionId } =
+    params;
+
+  // Fetch current prices from DB to prevent price manipulation via cart cookie
+  const { data: productPrices, error: pricesError } = await supabase
+    .from("products")
+    .select("id, price_cop")
+    .in(
+      "id",
+      items.map((item) => item.id),
+    );
+  if (pricesError) throw pricesError;
+
+  const priceMap = new Map(
+    (productPrices ?? []).map((p) => [p.id, p.price_cop as number]),
+  );
+
+  // Calculate total server-side from DB prices (never trust client-provided total)
+  const serverTotalCop = items.reduce((sum, item) => {
+    const dbPrice = priceMap.get(item.id);
+    if (dbPrice === undefined) throw new Error(`Product ${item.id} not found`);
+    return sum + dbPrice * item.quantity;
+  }, 0);
 
   // Reserve stock for each item
   const reserved: Array<{ productId: string; quantity: number }> = [];
@@ -78,13 +139,8 @@ export async function createOrder(
     });
 
     if (error || !success) {
-      // Release already-reserved items
-      for (const r of reserved) {
-        await supabase.rpc("release_stock", {
-          p_product_id: r.productId,
-          p_quantity: r.quantity,
-        });
-      }
+      // Release already-reserved items — best-effort: continue even if individual releases fail
+      await releaseReservedStock(supabase, reserved);
       throw new Error("stock_error");
     }
 
@@ -100,14 +156,14 @@ export async function createOrder(
         MS_PER_SECOND,
   ).toISOString();
 
-  // Insert order
+  // Insert order with server-calculated total
   const { data: order, error: orderError } = await supabase
     .from("orders")
     .insert({
       user_id: userId,
       seller_id: sellerId,
       payment_method_id: paymentMethodId,
-      total_cop: totalCop,
+      total_cop: serverTotalCop,
       payment_status: "awaiting_payment",
       checkout_session_id: checkoutSessionId,
       expires_at: expiresAt,
@@ -116,25 +172,20 @@ export async function createOrder(
     .single();
 
   if (orderError || !order) {
-    // Release stock on order insert failure
-    for (const r of reserved) {
-      await supabase.rpc("release_stock", {
-        p_product_id: r.productId,
-        p_quantity: r.quantity,
-      });
-    }
+    // Release stock on order insert failure — best-effort: continue even if individual releases fail
+    await releaseReservedStock(supabase, reserved);
     throw orderError ?? new Error("Failed to create order");
   }
 
   const orderId = order.id;
 
-  // Insert order items
+  // Build order items using DB prices
   const orderItems = items.map((item) => ({
     order_id: orderId,
     product_id: item.id,
     quantity: item.quantity,
-    unit_price_cop: item.price_cop,
-    metadata: { name_en: item.name_en, name_es: item.name_es },
+    unit_price_cop: priceMap.get(item.id) as number,
+    metadata: { name_en: item.name_en ?? "", name_es: item.name_es ?? "" },
   }));
 
   const { error: itemsError } = await supabase
@@ -171,24 +222,11 @@ export async function submitReceipt(
 
 /**
  * Fetch display names from user_profiles for a list of seller IDs.
+ * Delegates to the shared fetchUserDisplayNames utility.
  */
 export async function fetchSellerProfiles(
   supabase: SupabaseClient,
   sellerIds: string[],
 ): Promise<Record<string, string>> {
-  if (sellerIds.length === 0) return {};
-
-  const { data, error } = await supabase
-    .from("user_profiles")
-    .select("id, display_name, email")
-    .in("id", sellerIds);
-
-  if (error) throw error;
-
-  const map: Record<string, string> = {};
-  for (const profile of data ?? []) {
-    map[profile.id] =
-      profile.display_name ?? profile.email ?? FALLBACK_SELLER_NAME;
-  }
-  return map;
+  return fetchUserDisplayNames(supabase, sellerIds, FALLBACK_SELLER_NAME);
 }

--- a/apps/store/src/features/cart/application/CartContext.tsx
+++ b/apps/store/src/features/cart/application/CartContext.tsx
@@ -10,6 +10,7 @@ import {
   useReducer,
   useRef,
 } from "react";
+import type { CartCookieItem } from "shared/types";
 
 import {
   COOKIE_KEY,
@@ -25,6 +26,7 @@ import {
 import { isValidCartItems } from "./cartValidation";
 
 import type { CartItem, CartState } from "@/features/cart/domain/types";
+import { fetchStoreProductsByIds } from "@/features/products/infrastructure/productQueries";
 
 interface CartContextValue extends CartState {
   addItem: (
@@ -43,21 +45,73 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
 
   // Hydrate from cookie on mount
   useEffect(() => {
-    try {
-      const raw = getCookie(COOKIE_KEY);
-      if (raw) {
+    let isActive = true;
+
+    async function hydrateFromCookie() {
+      try {
+        const raw = getCookie(COOKIE_KEY);
+        if (!raw) return;
+
         const parsed: unknown = JSON.parse(String(raw));
-        if (isValidCartItems(parsed)) {
-          dispatch({ type: "HYDRATE", payload: parsed });
+        if (!isValidCartItems(parsed)) return;
+
+        const cookieItems = parsed as CartCookieItem[];
+        if (cookieItems.length === 0) return;
+
+        const products = await fetchStoreProductsByIds(
+          cookieItems.map((item) => item.id),
+        );
+        if (!isActive) return;
+
+        const productById = new Map(
+          products.map((product) => [product.id, product]),
+        );
+        const hydratedItems: CartItem[] = cookieItems
+          .map((cookieItem) => {
+            const product = productById.get(cookieItem.id);
+            if (!product) return null;
+
+            const quantity =
+              product.max_quantity === null
+                ? cookieItem.quantity
+                : Math.min(cookieItem.quantity, product.max_quantity);
+
+            return {
+              id: product.id,
+              name_en: product.name_en,
+              name_es: product.name_es,
+              price_cop: product.price_cop,
+              price_usd: product.price_usd,
+              seller_id: product.seller_id,
+              images: product.images,
+              max_quantity: product.max_quantity,
+              category: product.category,
+              type: product.type,
+              refundable: product.refundable,
+              quantity,
+            };
+          })
+          .filter((item): item is CartItem => item !== null);
+
+        if (hydratedItems.length > 0) {
+          dispatch({ type: "HYDRATE", payload: hydratedItems });
         }
+      } catch {
+        // Ignore invalid stored data
+      } finally {
+        if (!isActive) return;
+        requestAnimationFrame(() => {
+          if (!isActive) return;
+          mountedRef.current = true;
+        });
       }
-    } catch {
-      // Ignore invalid stored data
     }
-    // Mark mounted AFTER a tick so the persist effect skips the initial render
-    requestAnimationFrame(() => {
-      mountedRef.current = true;
-    });
+
+    void hydrateFromCookie();
+
+    return () => {
+      isActive = false;
+    };
   }, []);
 
   // Persist to cookie — skips the first render (before hydration completes)

--- a/apps/store/src/features/cart/application/cartCookiePersistence.ts
+++ b/apps/store/src/features/cart/application/cartCookiePersistence.ts
@@ -1,5 +1,5 @@
 import { deleteCookie, setCookie } from "cookies-next";
-import { CART_COOKIE_KEY, getSharedCookieDomain } from "shared";
+import { getSharedCookieDomain as resolveSharedCookieDomain } from "shared";
 import {
   HOURS_PER_DAY,
   MINUTES_PER_HOUR,
@@ -10,6 +10,7 @@ import type { CartCookieItem } from "shared/types";
 import type { CartItem } from "@/features/cart/domain/types";
 
 const DAYS = 30;
+const CART_COOKIE_KEY = "candystore-cart";
 /** Cookie lives for 30 days */
 export const COOKIE_MAX_AGE_S =
   DAYS * HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE;
@@ -20,7 +21,7 @@ export function getCartCookieOptions() {
     globalThis.location.protocol === "https:";
   let sharedDomain: string | undefined;
   if (globalThis.window !== undefined) {
-    sharedDomain = getSharedCookieDomain(globalThis.location.hostname);
+    sharedDomain = resolveSharedCookieDomain(globalThis.location.hostname);
   }
 
   return {
@@ -57,4 +58,5 @@ export function removeCartCookie() {
   }
 }
 
-export { CART_COOKIE_KEY as COOKIE_KEY, getSharedCookieDomain } from "shared";
+export { getSharedCookieDomain } from "shared";
+export { CART_COOKIE_KEY as COOKIE_KEY };

--- a/apps/store/src/features/cart/application/cartCookiePersistence.ts
+++ b/apps/store/src/features/cart/application/cartCookiePersistence.ts
@@ -1,26 +1,18 @@
 import { deleteCookie, setCookie } from "cookies-next";
+import { CART_COOKIE_KEY, getSharedCookieDomain } from "shared";
+import {
+  HOURS_PER_DAY,
+  MINUTES_PER_HOUR,
+  SECONDS_PER_MINUTE,
+} from "shared/constants/time";
+import type { CartCookieItem } from "shared/types";
 
 import type { CartItem } from "@/features/cart/domain/types";
 
-export const COOKIE_KEY = "candystore-cart";
 const DAYS = 30;
-const HOURS_PER_DAY = 24;
-const MINUTES_PER_HOUR = 60;
-const SECONDS_PER_MINUTE = 60;
-const MINIMUM_DOMAIN_SEGMENTS = 2;
-const DOMAIN_SUFFIX_SEGMENT_OFFSET = -2;
 /** Cookie lives for 30 days */
 export const COOKIE_MAX_AGE_S =
   DAYS * HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE;
-
-export function getSharedCookieDomain(hostname: string): string | undefined {
-  if (hostname === "localhost" || hostname === "127.0.0.1") return undefined;
-
-  const parts = hostname.split(".");
-  if (parts.length < MINIMUM_DOMAIN_SEGMENTS) return undefined;
-
-  return `.${parts.slice(DOMAIN_SUFFIX_SEGMENT_OFFSET).join(".")}`;
-}
 
 export function getCartCookieOptions() {
   const isSecure =
@@ -41,12 +33,16 @@ export function getCartCookieOptions() {
 
 export function persistCartCookie(items: CartItem[]) {
   const cookieOptions = getCartCookieOptions();
+  const cookieItems: CartCookieItem[] = items.map((item) => ({
+    id: item.id,
+    quantity: item.quantity,
+  }));
 
   if (cookieOptions.domain) {
-    deleteCookie(COOKIE_KEY, { path: "/" });
+    deleteCookie(CART_COOKIE_KEY, { path: "/" });
   }
 
-  setCookie(COOKIE_KEY, JSON.stringify(items), {
+  setCookie(CART_COOKIE_KEY, JSON.stringify(cookieItems), {
     ...cookieOptions,
     maxAge: COOKIE_MAX_AGE_S,
   });
@@ -54,9 +50,11 @@ export function persistCartCookie(items: CartItem[]) {
 
 export function removeCartCookie() {
   const cookieOptions = getCartCookieOptions();
-  deleteCookie(COOKIE_KEY, cookieOptions);
+  deleteCookie(CART_COOKIE_KEY, cookieOptions);
 
   if (cookieOptions.domain !== undefined) {
-    deleteCookie(COOKIE_KEY, { path: "/" });
+    deleteCookie(CART_COOKIE_KEY, { path: "/" });
   }
 }
+
+export { CART_COOKIE_KEY as COOKIE_KEY, getSharedCookieDomain } from "shared";

--- a/apps/store/src/features/cart/application/cartReducer.ts
+++ b/apps/store/src/features/cart/application/cartReducer.ts
@@ -13,22 +13,42 @@ export type CartAction =
   | { type: "CLEAR_CART" }
   | { type: "HYDRATE"; payload: CartItem[] };
 
+function toCartSnapshot(
+  payload: Omit<CartItem, "quantity">,
+): Omit<CartItem, "quantity"> {
+  return {
+    id: payload.id,
+    name_en: payload.name_en,
+    name_es: payload.name_es,
+    price_cop: payload.price_cop,
+    price_usd: payload.price_usd,
+    seller_id: payload.seller_id,
+    images: payload.images,
+    max_quantity: payload.max_quantity,
+    category: payload.category,
+    type: payload.type,
+    refundable: payload.refundable,
+  };
+}
+
 export function addItemToItems(
   items: CartItem[],
   payload: Omit<CartItem, "quantity"> & { quantity?: number },
 ): CartItem[] {
   const { quantity = 1, ...rest } = payload;
-  const existingIndex = items.findIndex((item) => item.id === rest.id);
+  const snapshot = toCartSnapshot(rest);
+  const existingIndex = items.findIndex((item) => item.id === snapshot.id);
 
   if (existingIndex !== -1) {
     return items.map((item, index) =>
       index === existingIndex
         ? {
             ...item,
+            ...snapshot,
             quantity:
-              item.max_quantity === null
+              snapshot.max_quantity === null
                 ? item.quantity + quantity
-                : Math.min(item.quantity + quantity, item.max_quantity),
+                : Math.min(item.quantity + quantity, snapshot.max_quantity),
           }
         : item,
     );
@@ -37,11 +57,11 @@ export function addItemToItems(
   return [
     ...items,
     {
-      ...rest,
+      ...snapshot,
       quantity:
-        rest.max_quantity === null
+        snapshot.max_quantity === null
           ? quantity
-          : Math.min(quantity, rest.max_quantity),
+          : Math.min(quantity, snapshot.max_quantity),
     },
   ];
 }

--- a/apps/store/src/features/cart/application/cartValidation.ts
+++ b/apps/store/src/features/cart/application/cartValidation.ts
@@ -1,17 +1,6 @@
-import type { CartItem } from "@/features/cart/domain/types";
+import { isCartCookieItems, type CartCookieItem } from "shared/types";
 
-export function isValidCartItem(item: unknown): item is CartItem {
-  if (typeof item !== "object" || item === null) return false;
-  const record = item as Record<string, unknown>;
-  // Check the essential fields — the rest comes from the full product row
-  return (
-    typeof record.id === "string" &&
-    typeof record.price_usd === "number" &&
-    typeof record.quantity === "number"
-  );
-}
-
-/** Validates that parsed cookie data is an array of cart items with required fields */
-export function isValidCartItems(data: unknown): data is CartItem[] {
-  return Array.isArray(data) && data.every((item) => isValidCartItem(item));
+/** Validates that parsed cookie data is an array of {id, quantity}. */
+export function isValidCartItems(data: unknown): data is CartCookieItem[] {
+  return isCartCookieItems(data);
 }

--- a/apps/store/src/features/cart/domain/types.ts
+++ b/apps/store/src/features/cart/domain/types.ts
@@ -1,7 +1,22 @@
-import type { Tables } from "api/supabase/types";
+import type { Product } from "shared/types";
 
-/** A cart item is the full product row + a quantity */
-export interface CartItem extends Tables<"products"> {
+type CartProductSnapshot = Pick<
+  Product,
+  | "id"
+  | "name_en"
+  | "name_es"
+  | "price_cop"
+  | "price_usd"
+  | "seller_id"
+  | "images"
+  | "max_quantity"
+  | "category"
+  | "type"
+  | "refundable"
+>;
+
+/** A cart item is a compact product snapshot + quantity for cookie portability */
+export interface CartItem extends CartProductSnapshot {
   quantity: number;
 }
 

--- a/apps/store/src/features/products/infrastructure/productQueries.ts
+++ b/apps/store/src/features/products/infrastructure/productQueries.ts
@@ -22,3 +22,18 @@ export async function fetchStoreProductById(id: string) {
   if (error) throw error;
   return data;
 }
+
+export async function fetchStoreProductsByIds(ids: string[]) {
+  if (ids.length === 0) return [];
+
+  const supabase = createBrowserSupabaseClient();
+  const uniqueIds = [...new Set(ids)];
+  const { data, error } = await supabase
+    .from("products")
+    .select("*")
+    .in("id", uniqueIds)
+    .eq("is_active", true);
+
+  if (error) throw error;
+  return data ?? [];
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,6 +8,9 @@
     ".": "./src/index.ts",
     "./app-root-layout": "./src/components/AppRootLayout.tsx",
     "./utils": "./src/utils/index.ts",
+    "./utils/*": "./src/utils/*.ts",
+    "./constants": "./src/constants/index.ts",
+    "./constants/*": "./src/constants/*.ts",
     "./hooks": "./src/hooks/index.ts",
     "./hooks/*": "./src/hooks/*.ts",
     "./i18n/createAppI18n": "./src/i18n/createAppI18n.ts",
@@ -17,6 +20,7 @@
     "./providers": "./src/providers/index.ts",
     "./components": "./src/components/index.ts",
     "./types": "./src/types/index.ts",
+    "./types/*": "./src/types/*.ts",
     "./config": "./src/config/index.ts",
     "./config/*": "./src/config/*.ts"
   },

--- a/packages/shared/src/constants/cart.ts
+++ b/packages/shared/src/constants/cart.ts
@@ -1,0 +1,2 @@
+/** Cookie key used by the store app to persist the cart across subdomains */
+export const CART_COOKIE_KEY = "candystore-cart";

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,3 +1,9 @@
-export { TIME_CONSTANTS } from "./time";
-export { PROCESS_FLOW } from "./processFlow";
+export {
+  HOURS_PER_DAY,
+  MINUTES_PER_HOUR,
+  MS_PER_SECOND,
+  SECONDS_PER_MINUTE,
+  TIME_CONSTANTS,
+} from "./time";
 export { CART_COOKIE_KEY } from "./cart";
+export { PROCESS_FLOW } from "./processFlow";

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,2 +1,3 @@
 export { TIME_CONSTANTS } from "./time";
 export { PROCESS_FLOW } from "./processFlow";
+export { CART_COOKIE_KEY } from "./cart";

--- a/packages/shared/src/constants/time.ts
+++ b/packages/shared/src/constants/time.ts
@@ -3,6 +3,12 @@
  * Centralized time-related values used by QueryProvider and utilities.
  */
 
+/** Raw time unit conversion factors */
+export const MS_PER_SECOND = 1000;
+export const SECONDS_PER_MINUTE = 60;
+export const MINUTES_PER_HOUR = 60;
+export const HOURS_PER_DAY = 24;
+
 export const TIME_CONSTANTS = {
   QUERY: {
     STALE_TIME_MS: 60 * 1000,

--- a/packages/shared/src/types/cart.ts
+++ b/packages/shared/src/types/cart.ts
@@ -1,0 +1,19 @@
+export interface CartCookieItem {
+  id: string;
+  quantity: number;
+}
+
+export function isCartCookieItem(value: unknown): value is CartCookieItem {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    typeof record.quantity === "number" &&
+    Number.isInteger(record.quantity) &&
+    record.quantity > 0
+  );
+}
+
+export function isCartCookieItems(value: unknown): value is CartCookieItem[] {
+  return Array.isArray(value) && value.every((item) => isCartCookieItem(item));
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,4 +1,3 @@
-export type { SupabaseClient } from "./supabase";
 export type { Product, ProductCategory, ProductType } from "./product";
 export type { CartCookieItem } from "./cart";
 export { isCartCookieItem, isCartCookieItems } from "./cart";

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,4 +1,7 @@
-export type { ProductCategory, ProductType } from "./product";
+export type { SupabaseClient } from "./supabase";
+export type { Product, ProductCategory, ProductType } from "./product";
+export type { CartCookieItem } from "./cart";
+export { isCartCookieItem, isCartCookieItems } from "./cart";
 export type {
   ProductSection,
   ProductSectionItem,

--- a/packages/shared/src/types/product.ts
+++ b/packages/shared/src/types/product.ts
@@ -1,3 +1,8 @@
+import type { Tables } from "api/supabase/types";
+
+/** Product row — directly from Supabase generated types (single source of truth) */
+export type Product = Tables<"products">;
+
 export type ProductType = "merch" | "digital" | "service" | "ticket";
 
 export type ProductCategory =

--- a/packages/shared/src/utils/categoryConstants.ts
+++ b/packages/shared/src/utils/categoryConstants.ts
@@ -1,0 +1,72 @@
+import type { ProductCategory } from "@shared/types/product";
+
+/** Color theme for each product category; used by store, studio, and other apps. */
+export interface CategoryTheme {
+  bg: string;
+  bgLight: string;
+  border: string;
+  text: string;
+  badgeBg: string;
+  rowEven: string;
+  rowOdd: string;
+  foreground: string;
+  accent: string;
+}
+
+const TINT_LIGHT = 15;
+const TINT_SUBTLE = 5;
+const DEFAULT_CATEGORY_FOREGROUND = "--candy-text";
+const LEMON_CATEGORY_FOREGROUND = "--candy-text-on-lemon";
+
+function tintedColor(accent: string, percent: number): string {
+  return `color-mix(in srgb, var(${accent}) ${String(percent)}%, transparent)`;
+}
+
+function buildTheme(
+  accent: `--${string}`,
+  foreground: `--${string}` = "--foreground",
+): CategoryTheme {
+  return {
+    bg: `var(${accent})`,
+    bgLight: tintedColor(accent, TINT_LIGHT),
+    border: `var(${accent})`,
+    text: `var(${accent})`,
+    badgeBg: `var(${accent})`,
+    rowEven: tintedColor(accent, TINT_SUBTLE),
+    rowOdd: tintedColor(accent, TINT_LIGHT),
+    foreground: `var(${foreground})`,
+    accent,
+  };
+}
+
+export const CATEGORY_THEMES: Record<ProductCategory, CategoryTheme> = {
+  fursuits: buildTheme("--pink", DEFAULT_CATEGORY_FOREGROUND),
+  merch: buildTheme("--mint", DEFAULT_CATEGORY_FOREGROUND),
+  art: buildTheme("--lilac", DEFAULT_CATEGORY_FOREGROUND),
+  events: buildTheme("--lemon", LEMON_CATEGORY_FOREGROUND),
+  digital: buildTheme("--sky", DEFAULT_CATEGORY_FOREGROUND),
+  deals: buildTheme("--peach", DEFAULT_CATEGORY_FOREGROUND),
+};
+
+/** Category list with colors derived from CATEGORY_THEMES (single source of truth) */
+export const PRODUCT_CATEGORIES: {
+  value: ProductCategory;
+  color: string;
+}[] = [
+  { value: "fursuits", color: CATEGORY_THEMES.fursuits.bg },
+  { value: "merch", color: CATEGORY_THEMES.merch.bg },
+  { value: "art", color: CATEGORY_THEMES.art.bg },
+  { value: "events", color: CATEGORY_THEMES.events.bg },
+  { value: "digital", color: CATEGORY_THEMES.digital.bg },
+  { value: "deals", color: CATEGORY_THEMES.deals.bg },
+];
+
+export function getCategoryTheme(category: ProductCategory): CategoryTheme {
+  return CATEGORY_THEMES[category] ?? CATEGORY_THEMES.merch;
+}
+
+/** Get category color by value; used by ProductCard and CartDrawer. */
+export function getCategoryColor(category: string): string {
+  const found = PRODUCT_CATEGORIES.find((c) => c.value === category);
+  return found?.color ?? CATEGORY_THEMES.merch.bg;
+}

--- a/packages/shared/src/utils/cookieDomain.ts
+++ b/packages/shared/src/utils/cookieDomain.ts
@@ -1,0 +1,16 @@
+const MINIMUM_DOMAIN_SEGMENTS = 2;
+const DOMAIN_SUFFIX_SEGMENT_OFFSET = -2;
+
+/**
+ * Returns the shared root domain (e.g. `.example.com`) suitable for setting
+ * a cross-subdomain cookie. Returns `undefined` for localhost or single-segment
+ * hostnames where a shared domain is not applicable.
+ */
+export function getSharedCookieDomain(hostname: string): string | undefined {
+  if (hostname === "localhost" || hostname === "127.0.0.1") return undefined;
+
+  const parts = hostname.split(".");
+  if (parts.length < MINIMUM_DOMAIN_SEGMENTS) return undefined;
+
+  return `.${parts.slice(DOMAIN_SUFFIX_SEGMENT_OFFSET).join(".")}`;
+}

--- a/packages/shared/src/utils/escapeLikePattern.ts
+++ b/packages/shared/src/utils/escapeLikePattern.ts
@@ -1,0 +1,4 @@
+/** Escape SQL LIKE wildcards (%, _, \) to prevent pattern injection */
+export function escapeLikePattern(input: string): string {
+  return input.replaceAll(/[%_\\]/g, (char) => `\\${char}`);
+}

--- a/packages/shared/src/utils/formatCop.ts
+++ b/packages/shared/src/utils/formatCop.ts
@@ -1,0 +1,12 @@
+export const COP_CURRENCY_CODE = "COP";
+
+const copFormatter = new Intl.NumberFormat("es-CO", {
+  style: "currency",
+  currency: COP_CURRENCY_CODE,
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
+export function formatCop(amount: number): string {
+  return copFormatter.format(amount);
+}

--- a/packages/shared/src/utils/i18nPrice.test.ts
+++ b/packages/shared/src/utils/i18nPrice.test.ts
@@ -32,4 +32,25 @@ describe("i18nPrice", () => {
     const result = i18nPrice({ price_usd: 0, price_cop: 0 }, "es");
     expect(result).toContain("0");
   });
+
+  it("falls back to COP when USD is 0 and COP is non-zero (en locale)", () => {
+    const result = i18nPrice({ price_usd: 0, price_cop: 185_000 }, "en");
+    expect(result).toContain("185");
+    expect(result).toMatch(/COP|185\.000/i);
+  });
+
+  it("falls back to USD when COP is 0 and USD is non-zero (es locale)", () => {
+    const result = i18nPrice({ price_usd: 25, price_cop: 0 }, "es");
+    expect(result).toMatch(/\$25/);
+  });
+
+  it("shows locale price when both are non-zero (en locale picks USD)", () => {
+    const result = i18nPrice({ price_usd: 25, price_cop: 185_000 }, "en");
+    expect(result).toMatch(/\$25/);
+  });
+
+  it("shows locale price when both are non-zero (es locale picks COP)", () => {
+    const result = i18nPrice({ price_usd: 25, price_cop: 185_000 }, "es");
+    expect(result).toContain("185");
+  });
 });

--- a/packages/shared/src/utils/i18nPrice.ts
+++ b/packages/shared/src/utils/i18nPrice.ts
@@ -6,18 +6,61 @@ const LOCALE_CURRENCY: Record<
   es: { field: "price_cop", currency: "COP", locale: "es-CO" },
 };
 
+function formatPrice(
+  amount: number,
+  config: { currency: string; locale: string },
+): string {
+  return new Intl.NumberFormat(config.locale, {
+    style: "currency",
+    currency: config.currency,
+    minimumFractionDigits: 0,
+  }).format(amount);
+}
+
 /**
- * Returns a locale-formatted price string.
- * en → price_usd formatted as USD, es → price_cop formatted as COP.
+ * Returns the 3-letter currency code used for this product+locale combination.
+ * Respects the same fallback logic as i18nPrice: if the locale's price is 0
+ * but the other currency is non-zero, returns that currency's code.
+ */
+export function i18nCurrencyCode(
+  product: { price_cop: number; price_usd: number },
+  locale: string,
+): string {
+  const primary = LOCALE_CURRENCY[locale] ?? LOCALE_CURRENCY.en;
+  if (product[primary.field] !== 0) return primary.currency;
+
+  const fallbackKey = primary.field === "price_usd" ? "es" : "en";
+  const fallback = LOCALE_CURRENCY[fallbackKey];
+  if (product[fallback.field] !== 0) return fallback.currency;
+
+  return primary.currency;
+}
+
+/**
+ * Returns a locale-formatted price string with fallback logic:
+ * - Both prices are 0 → show $0 in the locale's currency
+ * - Locale's price is 0 but the other is non-zero → show the non-zero price in its own currency
+ * - Both non-zero → show the locale's price (default behavior)
  */
 export function i18nPrice(
   product: { price_cop: number; price_usd: number },
   locale: string,
 ): string {
-  const config = LOCALE_CURRENCY[locale] ?? LOCALE_CURRENCY.en;
-  return new Intl.NumberFormat(config.locale, {
-    style: "currency",
-    currency: config.currency,
-    minimumFractionDigits: 0,
-  }).format(product[config.field]);
+  const primary = LOCALE_CURRENCY[locale] ?? LOCALE_CURRENCY.en;
+  const primaryVal = product[primary.field];
+
+  if (primaryVal !== 0) {
+    return formatPrice(primaryVal, primary);
+  }
+
+  // Primary price is 0 — check if the other currency has a value
+  const fallbackKey = primary.field === "price_usd" ? "es" : "en";
+  const fallback = LOCALE_CURRENCY[fallbackKey];
+  const fallbackVal = product[fallback.field];
+
+  if (fallbackVal !== 0) {
+    return formatPrice(fallbackVal, fallback);
+  }
+
+  return formatPrice(0, primary);
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,11 +1,12 @@
 // Shared utility functions
 
 export { tid, TID_ATTR } from "./tid";
+export { getSharedCookieDomain } from "./cookieDomain";
 export type { TidOptionProps } from "./tid";
 
 export { stripTrailingSlash } from "./url";
 export { i18nField } from "./i18nField";
-export { i18nPrice } from "./i18nPrice";
+export { i18nPrice, i18nCurrencyCode } from "./i18nPrice";
 export { slugify } from "./slugify";
 export { typeDetails } from "./typeDetails";
 export type {
@@ -15,3 +16,12 @@ export type {
   TicketDetails,
 } from "./typeDetails";
 export { getCoverImageUrl } from "./getCoverImageUrl";
+export { escapeLikePattern } from "./escapeLikePattern";
+export { formatCop, COP_CURRENCY_CODE } from "./formatCop";
+export type { CategoryTheme } from "./categoryConstants";
+export {
+  CATEGORY_THEMES,
+  PRODUCT_CATEGORIES,
+  getCategoryTheme,
+  getCategoryColor,
+} from "./categoryConstants";

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -7,8 +7,17 @@ export type { TidOptionProps } from "./tid";
 export { stripTrailingSlash } from "./url";
 export { i18nField } from "./i18nField";
 export { i18nPrice, i18nCurrencyCode } from "./i18nPrice";
+export { formatCop, COP_CURRENCY_CODE } from "./formatCop";
 export { slugify } from "./slugify";
 export { typeDetails } from "./typeDetails";
+export { escapeLikePattern } from "./escapeLikePattern";
+export {
+  CATEGORY_THEMES,
+  PRODUCT_CATEGORIES,
+  getCategoryColor,
+  getCategoryTheme,
+} from "./categoryConstants";
+export type { CategoryTheme } from "./categoryConstants";
 export type {
   MerchDetails,
   DigitalDetails,
@@ -16,12 +25,3 @@ export type {
   TicketDetails,
 } from "./typeDetails";
 export { getCoverImageUrl } from "./getCoverImageUrl";
-export { escapeLikePattern } from "./escapeLikePattern";
-export { formatCop, COP_CURRENCY_CODE } from "./formatCop";
-export type { CategoryTheme } from "./categoryConstants";
-export {
-  CATEGORY_THEMES,
-  PRODUCT_CATEGORIES,
-  getCategoryTheme,
-  getCategoryColor,
-} from "./categoryConstants";


### PR DESCRIPTION
## Summary
- hard-cut cart cookie format to minimal payload: [{ id, quantity }] only
- update store cart hydration to resolve product details from backend by cookie IDs before hydrating state
- update checkout cart hydration to resolve product details from backend by cookie IDs and merge quantities
- add shared cart cookie type guards and adapt cart/checkout validation/tests to strict new schema

## Behavioral changes
- no backward compatibility for old cart cookie payloads
- old-format cart cookies are treated as invalid/empty

## Verification
- pnpm --filter store test -- src/features/cart/application/CartContext.test.tsx src/features/cart/application/hooks/useAddToCart.test.ts
- pnpm --filter payments test -- src/features/checkout/infrastructure/cartCookie.test.ts src/features/checkout/application/hooks/useCartFromCookie.test.tsx
- pnpm --filter store typecheck
- pnpm --filter payments typecheck
- pnpm --filter shared typecheck
- pre-push hook full suite: 	urbo test (pass)
