### PR TITLE
feat(ci): add develop cloud deployment environment

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -17,6 +17,7 @@ APP_INTERNAL_ORIGIN=http://localhost:8088
 
 # ─── Supabase ─────────────────────────────────────────────────────
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_URL_INTERNAL=N/A
 NEXT_PUBLIC_SUPABASE_ANON_KEY=$secret:DEV_SUPABASE_ANON_KEY
 SUPABASE_SERVICE_ROLE_KEY=$secret:DEV_SUPABASE_SERVICE_ROLE_KEY
 

--- a/.env.develop
+++ b/.env.develop
@@ -1,0 +1,59 @@
+# =============================================================================
+# Develop cloud environment — Docker app + Supabase Cloud (non-production)
+# =============================================================================
+TARGET_ENV=develop
+
+# --- Topology ---------------------------------------------------------------
+APPS_MODE=docker
+SUPABASE_MODE=cloud
+
+# --- Container identity -----------------------------------------------------
+SITE_PROD_CONTAINER_NAME=candyshop-develop
+SITE_PROD_IMAGE_NAME=candyshop-develop
+HOST_PORT=9092
+
+# --- App origins ------------------------------------------------------------
+APP_INTERNAL_ORIGIN=http://candyshop-develop:80
+
+# --- Supabase Cloud ---------------------------------------------------------
+NEXT_PUBLIC_SUPABASE_URL=$secret:DEVELOP_SUPABASE_URL
+SUPABASE_URL_INTERNAL=N/A
+NEXT_PUBLIC_SUPABASE_ANON_KEY=$secret:DEVELOP_SUPABASE_ANON_KEY
+SUPABASE_SERVICE_ROLE_KEY=$secret:DEVELOP_SUPABASE_SERVICE_ROLE_KEY
+SUPABASE_PORT=N/A
+STAGING_JWT_SECRET=
+STAGING_POSTGRES_PASSWORD=
+
+# --- Auth -------------------------------------------------------------------
+AUTH_PROVIDER_MODE=supabase
+
+# --- Cross-app navigation ---------------------------------------------------
+NEXT_PUBLIC_AUTH_URL=https://develop-store.furrycolombia.com/auth
+NEXT_PUBLIC_AUTH_HOST_URL=https://develop-store.furrycolombia.com/auth
+NEXT_PUBLIC_STORE_URL=https://develop-store.furrycolombia.com/store
+NEXT_PUBLIC_ADMIN_URL=https://develop-store.furrycolombia.com/admin
+NEXT_PUBLIC_PLAYGROUND_URL=https://develop-store.furrycolombia.com/playground
+NEXT_PUBLIC_LANDING_URL=https://develop-store.furrycolombia.com
+NEXT_PUBLIC_PAYMENTS_URL=https://develop-store.furrycolombia.com/payments
+NEXT_PUBLIC_STUDIO_URL=https://develop-store.furrycolombia.com/studio
+
+# --- OAuth providers --------------------------------------------------------
+SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=$secret:SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID
+SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET=$secret:SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET
+SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID=$secret:SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID
+SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET=$secret:SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET
+SUPABASE_AUTH_EXTERNAL_REDIRECT_URI=$secret:DEVELOP_SUPABASE_URL/auth/v1/callback
+SUPABASE_AUTH_SITE_URL=https://develop-store.furrycolombia.com/auth/callback
+
+# --- Build flags ------------------------------------------------------------
+NEXT_PUBLIC_ENABLE_TEST_IDS=true
+NEXT_PUBLIC_BUILD_HASH=develop
+ENV_DEBUG=true
+
+# --- Cloudflare tunnels -----------------------------------------------------
+CLOUDFLARE_TUNNEL_APP_ENABLED=false
+CLOUDFLARE_TUNNEL_APP_TOKEN=
+
+# --- E2E test account -------------------------------------------------------
+GOOGLE_TEST_EMAIL=$secret:GOOGLE_TEST_EMAIL
+GOOGLE_TEST_PASSWORD=$secret:GOOGLE_TEST_PASSWORD

--- a/.env.prod
+++ b/.env.prod
@@ -17,6 +17,7 @@ APP_INTERNAL_ORIGIN=http://candyshop-prod:80
 
 # ─── Supabase Cloud ───────────────────────────────────────────────
 NEXT_PUBLIC_SUPABASE_URL=https://olafyajipvsltohagiah.supabase.co
+SUPABASE_URL_INTERNAL=N/A
 NEXT_PUBLIC_SUPABASE_ANON_KEY=$secret:PROD_SUPABASE_ANON_KEY
 SUPABASE_SERVICE_ROLE_KEY=$secret:PROD_SUPABASE_SERVICE_ROLE_KEY
 SUPABASE_PORT=N/A

--- a/.github/workflows/deploy-develop-cloud.yml
+++ b/.github/workflows/deploy-develop-cloud.yml
@@ -1,0 +1,136 @@
+name: Deploy Develop Cloud
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - "apps/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "docker/**"
+      - "scripts/server/**"
+      - ".github/workflows/deploy-develop-cloud.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-develop-cloud
+  cancel-in-progress: false
+
+jobs:
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm run typecheck
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Unit tests
+        run: pnpm run test
+
+  deploy:
+    name: Deploy Develop to Cloud
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: ci-gate
+    environment: develop-cloud
+    env:
+      DEVELOP_HOST_PORT: ${{ vars.DEVELOP_HOST_PORT || '9092' }}
+      DEVELOP_DEPLOY_DIR: ${{ vars.DEVELOP_DEPLOY_DIR || '/home/furrycolombia/candyshop-develop' }}
+      DEVELOP_CONTAINER_NAME: ${{ vars.DEVELOP_CONTAINER_NAME || 'candyshop-develop' }}
+      DEVELOP_IMAGE_NAME: ${{ vars.DEVELOP_IMAGE_NAME || 'candyshop-develop' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
+          sudo apt-get update -qq && sudo apt-get install -y -qq cloudflared
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEVELOP_SERVER_SSH_KEY }}" | tr -d '\r' > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          cat >> ~/.ssh/config << EOF
+          Host ${{ secrets.DEVELOP_SERVER_HOST }}
+            HostName ${{ secrets.DEVELOP_SERVER_HOST }}
+            User ${{ secrets.DEVELOP_SERVER_USER }}
+            IdentityFile ~/.ssh/deploy_key
+            StrictHostKeyChecking no
+            ProxyCommand cloudflared access ssh --hostname %h
+          EOF
+
+      - name: Write ephemeral env file on server
+        run: |
+          ssh ${{ secrets.DEVELOP_SERVER_HOST }} \
+            'cat > /tmp/.candyshop-develop.env << ENVEOF
+          SITE_PROD_CONTAINER_NAME=${{ env.DEVELOP_CONTAINER_NAME }}
+          SITE_PROD_IMAGE_NAME=${{ env.DEVELOP_IMAGE_NAME }}
+          HOST_PORT=${{ env.DEVELOP_HOST_PORT }}
+          APP_INTERNAL_ORIGIN=http://${{ env.DEVELOP_CONTAINER_NAME }}:80
+          TARGET_ENV=develop
+          STANDALONE=true
+          BASE_PATH_PREFIX=
+          NEXT_PUBLIC_SUPABASE_URL=${{ secrets.DEVELOP_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.DEVELOP_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY=${{ secrets.DEVELOP_SUPABASE_SERVICE_ROLE_KEY }}
+          NEXT_PUBLIC_STORE_URL=${{ secrets.DEVELOP_BASE_URL }}/store
+          NEXT_PUBLIC_ADMIN_URL=${{ secrets.DEVELOP_BASE_URL }}/admin
+          NEXT_PUBLIC_AUTH_URL=${{ secrets.DEVELOP_BASE_URL }}/auth
+          NEXT_PUBLIC_AUTH_HOST_URL=${{ secrets.DEVELOP_BASE_URL }}/auth
+          NEXT_PUBLIC_LANDING_URL=${{ secrets.DEVELOP_BASE_URL }}
+          NEXT_PUBLIC_PAYMENTS_URL=${{ secrets.DEVELOP_BASE_URL }}/payments
+          NEXT_PUBLIC_PLAYGROUND_URL=${{ secrets.DEVELOP_BASE_URL }}/playground
+          NEXT_PUBLIC_STUDIO_URL=${{ secrets.DEVELOP_BASE_URL }}/studio
+          NEXT_PUBLIC_ENABLE_MOCKS=true
+          ENVEOF'
+
+      - name: Copy deploy script to server
+        run: |
+          cat scripts/server/deploy.sh | ssh ${{ secrets.DEVELOP_SERVER_HOST }} \
+            'cat > /tmp/deploy-cloud.sh && chmod +x /tmp/deploy-cloud.sh'
+
+      - name: Run deployment
+        run: |
+          ssh ${{ secrets.DEVELOP_SERVER_HOST }} \
+            "REPO_URL='https://github.com/${{ github.repository }}.git' \
+             BRANCH='develop' \
+             ENV_FILE='/tmp/.candyshop-develop.env' \
+             DEPLOY_DIR='${{ env.DEVELOP_DEPLOY_DIR }}' \
+             HEALTH_PATH='/health' \
+             bash /tmp/deploy-cloud.sh"
+
+      - name: Verify deployment
+        run: |
+          ssh ${{ secrets.DEVELOP_SERVER_HOST }} \
+            'curl -sf http://localhost:${{ env.DEVELOP_HOST_PORT }}/health'
+
+      - name: Cleanup
+        if: always()
+        run: |
+          ssh ${{ secrets.DEVELOP_SERVER_HOST }} \
+            'rm -f /tmp/.candyshop-develop.env /tmp/deploy-cloud.sh' 2>/dev/null || true
+          rm -f ~/.ssh/deploy_key

--- a/README.md
+++ b/README.md
@@ -392,13 +392,14 @@ The site will be live at `https://store.ffxivbe.org` once the tunnel connects.
 
 ## Environment files
 
-| File           | Purpose                                    | Committed |
-| -------------- | ------------------------------------------ | --------- |
-| `.env.dev`     | Local dev — Supabase CLI on port 54321     | ✅        |
-| `.env.test`    | Isolated test — Supabase CLI on port 64321 | ✅        |
-| `.env.staging` | Staging — Docker app + Docker Supabase     | ✅        |
-| `.env.prod`    | Production — Docker app + Supabase Cloud   | ✅        |
-| `.secrets`     | Resolved secret values (never committed)   | ❌        |
+| File           | Purpose                                     | Committed |
+| -------------- | ------------------------------------------- | --------- |
+| `.env.dev`     | Local dev — Supabase CLI on port 54321      | ✅        |
+| `.env.develop` | Develop cloud — Docker app + Supabase Cloud | ✅        |
+| `.env.test`    | Isolated test — Supabase CLI on port 64321  | ✅        |
+| `.env.staging` | Staging — Docker app + Docker Supabase      | ✅        |
+| `.env.prod`    | Production — Docker app + Supabase Cloud    | ✅        |
+| `.secrets`     | Resolved secret values (never committed)    | ❌        |
 
 Secrets in env files use `$secret:KEY_NAME` syntax and are resolved at runtime by `scripts/load-env.mjs`. Run `pnpm sync-secrets` to pull them from GitHub.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A multi-seller store and payment platform for selling products, services, ticket
 - [Quick Start](#quick-start)
 - [Development](#development)
 - [Staging](#staging)
+- [Cloud Develop Environment](#cloud-develop-environment)
 - [E2E Testing](#e2e-testing)
 - [Supabase](#supabase)
 - [Secrets](#secrets)
@@ -122,6 +123,49 @@ The Supabase stack is defined in `docker/compose.staging.yml`. On first start it
 ```bash
 docker volume rm candyshop-staging_db-data
 ```
+
+---
+
+## Cloud Develop Environment
+
+`develop` is now wired to a dedicated cloud deployment workflow so collaborators can test from a browser without local installs.
+
+### Deploy trigger
+
+- Automatic on push to `develop` (workflow: `Deploy Develop Cloud`)
+- Manual run from Actions (`workflow_dispatch`)
+
+### Required GitHub environment
+
+Create a GitHub environment named `develop-cloud` and set these secrets:
+
+| Secret                              | Purpose                                                              |
+| ----------------------------------- | -------------------------------------------------------------------- |
+| `DEVELOP_SERVER_HOST`               | SSH hostname through Cloudflare Access                               |
+| `DEVELOP_SERVER_USER`               | SSH username on the server                                           |
+| `DEVELOP_SERVER_SSH_KEY`            | private key used by the deploy workflow                              |
+| `DEVELOP_SUPABASE_URL`              | Supabase Cloud project URL for develop                               |
+| `DEVELOP_SUPABASE_ANON_KEY`         | Supabase anon key for develop                                        |
+| `DEVELOP_SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key for develop                                |
+| `DEVELOP_BASE_URL`                  | Public base URL (example: `https://develop-store.furrycolombia.com`) |
+
+Optional GitHub environment variables (with defaults):
+
+| Variable                 | Default                                 |
+| ------------------------ | --------------------------------------- |
+| `DEVELOP_HOST_PORT`      | `9092`                                  |
+| `DEVELOP_DEPLOY_DIR`     | `/home/furrycolombia/candyshop-develop` |
+| `DEVELOP_CONTAINER_NAME` | `candyshop-develop`                     |
+| `DEVELOP_IMAGE_NAME`     | `candyshop-develop`                     |
+
+### Resulting runtime
+
+- Deploy path on server: from `DEVELOP_DEPLOY_DIR`
+- Container: from `DEVELOP_CONTAINER_NAME`
+- Port: from `DEVELOP_HOST_PORT`
+- Health check: `http://localhost:<DEVELOP_HOST_PORT>/health`
+
+Point a Cloudflare tunnel hostname to `http://127.0.0.1:9092` so the environment is reachable from anywhere.
 
 ---
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -35,13 +35,14 @@ Every script in this project reads configuration from a single `.env.<name>` fil
 
 ### Available environments
 
-| File           | Purpose                                    | Committed |
-| -------------- | ------------------------------------------ | --------- |
-| `.env.dev`     | Local dev — Supabase CLI on port 54321     | ✅        |
-| `.env.test`    | Isolated test — Supabase CLI on port 64321 | ✅        |
-| `.env.staging` | Staging — Docker app + Docker Supabase     | ✅        |
-| `.env.prod`    | Production — Docker app + Supabase Cloud   | ✅        |
-| `.secrets`     | Resolved secret values (never committed)   | ❌        |
+| File           | Purpose                                     | Committed |
+| -------------- | ------------------------------------------- | --------- |
+| `.env.dev`     | Local dev — Supabase CLI on port 54321      | ✅        |
+| `.env.develop` | Develop cloud — Docker app + Supabase Cloud | ✅        |
+| `.env.test`    | Isolated test — Supabase CLI on port 64321  | ✅        |
+| `.env.staging` | Staging — Docker app + Docker Supabase      | ✅        |
+| `.env.prod`    | Production — Docker app + Supabase Cloud    | ✅        |
+| `.secrets`     | Resolved secret values (never committed)    | ❌        |
 
 ### Key groups in every env file
 
@@ -336,11 +337,11 @@ pnpm lint:env
 
 ### Topology keys
 
-| Key             | Values                           | Purpose                      |
-| --------------- | -------------------------------- | ---------------------------- |
-| `APPS_MODE`     | `local`, `docker`                | How apps run                 |
-| `SUPABASE_MODE` | `local`, `docker`, `cloud`       | How Supabase runs            |
-| `TARGET_ENV`    | `dev`, `test`, `staging`, `prod` | Set automatically by loadEnv |
+| Key             | Values                                      | Purpose                      |
+| --------------- | ------------------------------------------- | ---------------------------- |
+| `APPS_MODE`     | `local`, `docker`                           | How apps run                 |
+| `SUPABASE_MODE` | `local`, `docker`, `cloud`                  | How Supabase runs            |
+| `TARGET_ENV`    | `dev`, `develop`, `test`, `staging`, `prod` | Set automatically by loadEnv |
 
 ### Container keys
 

--- a/scripts/server/deploy.sh
+++ b/scripts/server/deploy.sh
@@ -7,11 +7,12 @@ set -euo pipefail
 # Limits build to half the CPU cores to keep the running site responsive.
 # ==============================================================================
 
-DEPLOY_DIR="/home/furrycolombia/candyshop"
+DEPLOY_DIR="${DEPLOY_DIR:-/home/furrycolombia/candyshop}"
 REPO_URL="${REPO_URL:-https://github.com/furrycolombia-sys/candyshop.git}"
 BRANCH="${BRANCH:-main}"
 ENV_FILE="${ENV_FILE:-/home/furrycolombia/.env.prod}"
-COMPOSE_FILE="$DEPLOY_DIR/docker/compose.yml"
+COMPOSE_FILE="${COMPOSE_FILE:-$DEPLOY_DIR/docker/compose.yml}"
+HEALTH_PATH="${HEALTH_PATH:-/health}"
 LOCKFILE="/tmp/candyshop-deploy.lock"
 MAX_BUILD_CPUS=4
 
@@ -36,7 +37,13 @@ trap 'rm -f "$LOCKFILE"' EXIT
 
 log "Starting deploy at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-# Pull latest code
+# Pull latest code (clone on first deploy)
+if [ ! -d "$DEPLOY_DIR/.git" ]; then
+  log "First deploy - cloning repository..."
+  mkdir -p "$(dirname "$DEPLOY_DIR")"
+  git clone --branch "$BRANCH" --depth 1 "$REPO_URL" "$DEPLOY_DIR"
+fi
+
 cd "$DEPLOY_DIR"
 git remote set-url origin "$REPO_URL" 2>/dev/null || true
 git fetch origin "$BRANCH" --depth 1
@@ -50,6 +57,9 @@ set -o allexport
 # shellcheck disable=SC1090
 source "$ENV_FILE"
 set +o allexport
+
+CONTAINER_NAME="${SITE_PROD_CONTAINER_NAME:-candyshop-prod}"
+HEALTH_PORT="${HOST_PORT:-9090}"
 
 BUILD_ARG_KEYS=(
   NEXT_PUBLIC_SUPABASE_URL
@@ -89,13 +99,13 @@ docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d
 # Wait for health
 log "Waiting for health check..."
 for i in $(seq 1 60); do
-  if curl -sf http://localhost:9090/health > /dev/null 2>&1; then
+  if curl -sf "http://localhost:${HEALTH_PORT}${HEALTH_PATH}" > /dev/null 2>&1; then
     log "Container healthy after ${i}s"
     break
   fi
   if [ "$i" -eq 60 ]; then
     warn "Container not healthy after 60s"
-    docker logs candyshop-prod --tail 20
+    docker logs "$CONTAINER_NAME" --tail 20
   fi
   sleep 1
 done


### PR DESCRIPTION
## Summary
- add a dedicated Deploy Develop Cloud workflow triggered by develop
- deploy to a separate container/runtime so develop is cloud-accessible without local installs
- make server deploy script reusable for multiple environments (clone-on-first-run + configurable health port/container)
- document required develop-cloud secrets and optional vars in README

## Notes
- I could not create the GitHub environment via API from this token (403, admin rights required).
- After merge, create environment develop-cloud and add the listed secrets/vars.