### PR TITLE
fix(ci): include PROD_SUPABASE_DB_PASSWORD in sync workflow

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -33,6 +33,7 @@ jobs:
           E2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
           PROD_SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
           PROD_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
+          PROD_SUPABASE_DB_PASSWORD: ${{ secrets.PROD_SUPABASE_DB_PASSWORD }}
           SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
           SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
           SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID }}
@@ -54,7 +55,8 @@ jobs:
             STAGING_SUPABASE_ANON_KEY STAGING_SUPABASE_SERVICE_ROLE_KEY \
             STAGING_JWT_SECRET STAGING_POSTGRES_PASSWORD \
             E2E_SUPABASE_ANON_KEY E2E_SUPABASE_SERVICE_ROLE_KEY \
-            PROD_SUPABASE_ANON_KEY PROD_SUPABASE_SERVICE_ROLE_KEY; do
+            PROD_SUPABASE_ANON_KEY PROD_SUPABASE_SERVICE_ROLE_KEY
+            PROD_SUPABASE_DB_PASSWORD; do
             VAL=$(printenv "$KEY" || true)
             if [ -z "$VAL" ]; then
               MISSING="$MISSING $KEY"
@@ -90,6 +92,7 @@ jobs:
             echo "# ─── Prod (Supabase Cloud) ───────────────────────────────────────"
             echo "PROD_SUPABASE_ANON_KEY=${PROD_SUPABASE_ANON_KEY}"
             echo "PROD_SUPABASE_SERVICE_ROLE_KEY=${PROD_SUPABASE_SERVICE_ROLE_KEY}"
+            echo "PROD_SUPABASE_DB_PASSWORD=${PROD_SUPABASE_DB_PASSWORD}"
             echo ""
             echo "# ─── Shared OAuth ────────────────────────────────────────────────"
             echo "SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=${SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID}"
@@ -127,3 +130,5 @@ jobs:
       - name: Clean up unencrypted file
         if: always()
         run: rm -f secrets-plain.txt
+
+


### PR DESCRIPTION
## Summary
- add PROD_SUPABASE_DB_PASSWORD to sync-secrets workflow env export
- include it in required-secret validation
- include it in generated .secrets payload

## Why
Keep GitHub as source-of-truth for secrets and prevent pnpm sync-secrets from dropping the prod DB password locally.