### PR TITLE
fix(store): replace next/image with native img in product detail gallery

### DIFF
--- a/apps/store/src/features/products/presentation/components/ProductDetail/ImageGallery.test.tsx
+++ b/apps/store/src/features/products/presentation/components/ProductDetail/ImageGallery.test.tsx
@@ -21,17 +21,6 @@ vi.mock("shared", () => ({
   tid: (id: string) => ({ "data-testid": id }),
 }));
 
-vi.mock("next/image", () => ({
-  default: ({
-    src,
-    alt,
-  }: {
-    src: string;
-    alt: string;
-    // eslint-disable-next-line @next/next/no-img-element -- test mock
-  }) => <img src={src} alt={alt} data-testid="next-image" />,
-}));
-
 vi.mock("@/features/products/presentation/components/FeaturedRibbon", () => ({
   FeaturedRibbon: ({ label }: { label: string }) => (
     <span data-testid="featured-ribbon">{label}</span>
@@ -136,7 +125,7 @@ describe("ImageGallery", () => {
       <ImageGallery product={makeProduct({ images })} theme={defaultTheme} />,
     );
     expect(screen.getByTestId("image-gallery")).toBeInTheDocument();
-    const imgs = screen.getAllByTestId("next-image");
+    const imgs = screen.getAllByRole("img");
     expect(imgs.length).toBeGreaterThan(0);
   });
 
@@ -184,7 +173,7 @@ describe("ImageGallery", () => {
         theme={defaultTheme}
       />,
     );
-    expect(screen.getAllByTestId("next-image").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("img").length).toBeGreaterThan(0);
   });
 
   it("renders featured ribbon on images when featured", () => {

--- a/apps/store/src/features/products/presentation/components/ProductDetail/ImageGallery.tsx
+++ b/apps/store/src/features/products/presentation/components/ProductDetail/ImageGallery.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string -- Tailwind classes must stay inline per styling policy */
 "use client";
 
-import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
 import { tid } from "shared";
@@ -121,12 +120,13 @@ export function ImageGallery({ product, theme }: ImageGalleryProps) {
                   }
                   {...tid(`image-gallery-thumb-${String(idx)}`)}
                 >
-                  <Image
+                  {/* eslint-disable-next-line @next/next/no-img-element -- user-provided image URLs can come from arbitrary hosts */}
+                  <img
                     src={img.url}
                     alt={img.alt ?? ""}
-                    fill
-                    className="object-cover"
-                    sizes="64px"
+                    className="absolute inset-0 size-full object-cover"
+                    loading="lazy"
+                    decoding="async"
                   />
                 </button>
               );
@@ -140,14 +140,16 @@ export function ImageGallery({ product, theme }: ImageGalleryProps) {
           style={{ backgroundColor: theme.bg }}
           {...tid(TID_GALLERY_MAIN)}
         >
-          <Image
+          {/* eslint-disable-next-line @next/next/no-img-element -- user-provided image URLs can come from arbitrary hosts */}
+          <img
             src={activeImage.url}
             alt={activeImage.alt ?? product.name_en}
-            fill
-            className={
-              activeImage.fit === "contain" ? "object-contain" : "object-cover"
-            }
-            sizes="(min-width: 1024px) 55vw, 100vw"
+            className={cn(
+              "absolute inset-0 size-full",
+              activeImage.fit === "contain" ? "object-contain" : "object-cover",
+            )}
+            loading="eager"
+            decoding="async"
           />
 
           {/* Bottom bar: caption + counter */}
@@ -185,14 +187,16 @@ export function ImageGallery({ product, theme }: ImageGalleryProps) {
           style={{ backgroundColor: theme.bg }}
           {...tid("image-gallery-main-mobile")}
         >
-          <Image
+          {/* eslint-disable-next-line @next/next/no-img-element -- user-provided image URLs can come from arbitrary hosts */}
+          <img
             src={activeImage.url}
             alt={activeImage.alt ?? product.name_en}
-            fill
-            className={
-              activeImage.fit === "contain" ? "object-contain" : "object-cover"
-            }
-            sizes="100vw"
+            className={cn(
+              "absolute inset-0 size-full",
+              activeImage.fit === "contain" ? "object-contain" : "object-cover",
+            )}
+            loading="eager"
+            decoding="async"
           />
 
           {/* Bottom bar: caption + counter */}
@@ -241,12 +245,13 @@ export function ImageGallery({ product, theme }: ImageGalleryProps) {
                   style={isActive ? { backgroundColor: theme.bg } : undefined}
                   aria-label={img.alt ?? String(idx + 1)}
                 >
-                  <Image
+                  {/* eslint-disable-next-line @next/next/no-img-element -- user-provided image URLs can come from arbitrary hosts */}
+                  <img
                     src={img.url}
                     alt={img.alt ?? ""}
-                    fill
-                    className="object-cover"
-                    sizes="20vw"
+                    className="absolute inset-0 size-full object-cover"
+                    loading="lazy"
+                    decoding="async"
                   />
                 </button>
               );

--- a/apps/store/src/features/products/presentation/components/ProductDetail/Sections/GallerySection.test.tsx
+++ b/apps/store/src/features/products/presentation/components/ProductDetail/Sections/GallerySection.test.tsx
@@ -13,13 +13,6 @@ vi.mock("shared", () => ({
     obj[`${field}_${locale}`] ?? obj[`${field}_en`] ?? "",
 }));
 
-vi.mock("next/image", () => ({
-  default: ({ src, alt }: { src: string; alt: string }) => (
-    // eslint-disable-next-line @next/next/no-img-element -- test mock
-    <img src={src} alt={alt} data-testid="next-image" />
-  ),
-}));
-
 const theme = {
   bg: "var(--mint)",
   bgLight: "color-mix(in srgb, var(--mint) 15%, transparent)",
@@ -77,7 +70,7 @@ describe("GallerySection", () => {
     };
     render(<GallerySection section={section as never} theme={theme} />);
     expect(screen.getByTestId("gallery-item-0")).toBeInTheDocument();
-    expect(screen.getByTestId("next-image")).toBeInTheDocument();
+    expect(screen.getByRole("img")).toBeInTheDocument();
   });
 
   it("renders placeholder number when no image_url", () => {

--- a/apps/store/src/features/products/presentation/components/ProductDetail/Sections/GallerySection.tsx
+++ b/apps/store/src/features/products/presentation/components/ProductDetail/Sections/GallerySection.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { useLocale } from "next-intl";
 import { useMemo } from "react";
 import { i18nField, tid } from "shared";
@@ -53,11 +52,13 @@ export function GallerySection({ section, theme }: GallerySectionProps) {
                   style={{ backgroundColor: theme.bg }}
                 >
                   {item.image_url ? (
-                    <Image
+                    // eslint-disable-next-line @next/next/no-img-element -- user-provided image URLs can come from arbitrary hosts
+                    <img
                       src={item.image_url}
                       alt={caption || ""}
-                      fill
-                      className="object-cover"
+                      className="absolute inset-0 size-full object-cover"
+                      loading="lazy"
+                      decoding="async"
                     />
                   ) : (
                     <span className="font-display text-sm font-extrabold uppercase tracking-widest text-foreground/30 select-none">

--- a/apps/store/src/features/products/presentation/components/product-detail/ImageGallery.test.tsx
+++ b/apps/store/src/features/products/presentation/components/product-detail/ImageGallery.test.tsx
@@ -21,17 +21,6 @@ vi.mock("shared", () => ({
   tid: (id: string) => ({ "data-testid": id }),
 }));
 
-vi.mock("next/image", () => ({
-  default: ({
-    src,
-    alt,
-  }: {
-    src: string;
-    alt: string;
-    // eslint-disable-next-line @next/next/no-img-element -- test mock
-  }) => <img src={src} alt={alt} data-testid="next-image" />,
-}));
-
 vi.mock("@/features/products/presentation/components/FeaturedRibbon", () => ({
   FeaturedRibbon: ({ label }: { label: string }) => (
     <span data-testid="featured-ribbon">{label}</span>
@@ -136,7 +125,7 @@ describe("ImageGallery", () => {
       <ImageGallery product={makeProduct({ images })} theme={defaultTheme} />,
     );
     expect(screen.getByTestId("image-gallery")).toBeInTheDocument();
-    const imgs = screen.getAllByTestId("next-image");
+    const imgs = screen.getAllByRole("img");
     expect(imgs.length).toBeGreaterThan(0);
   });
 
@@ -184,7 +173,7 @@ describe("ImageGallery", () => {
         theme={defaultTheme}
       />,
     );
-    expect(screen.getAllByTestId("next-image").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("img").length).toBeGreaterThan(0);
   });
 
   it("renders featured ribbon on images when featured", () => {

--- a/apps/store/src/features/products/presentation/components/product-detail/ImageGallery.tsx
+++ b/apps/store/src/features/products/presentation/components/product-detail/ImageGallery.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string -- Tailwind classes must stay inline per styling policy */
 "use client";
 
-import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
 import { tid } from "shared";
@@ -121,12 +120,13 @@ export function ImageGallery({ product, theme }: ImageGalleryProps) {
                   }
                   {...tid(`image-gallery-thumb-${String(idx)}`)}
                 >
-                  <Image
+                  {/* eslint-disable-next-line @next/next/no-img-element -- user-provided image URLs can come from arbitrary hosts */}
+                  <img
                     src={img.url}
                     alt={img.alt ?? ""}
-                    fill
-                    className="object-cover"
-                    sizes="64px"
+                    className="absolute inset-0 size-full object-cover"
+                    loading="lazy"
+                    decoding="async"
                   />
                 </button>
               );
@@ -140,14 +140,16 @@ export function ImageGallery({ product, theme }: ImageGalleryProps) {
           style={{ backgroundColor: theme.bg }}
           {...tid(TID_GALLERY_MAIN)}
         >
-          <Image
+          {/* eslint-disable-next-line @next/next/no-img-element -- user-provided image URLs can come from arbitrary hosts */}
+          <img
             src={activeImage.url}
             alt={activeImage.alt ?? product.name_en}
-            fill
-            className={
-              activeImage.fit === "contain" ? "object-contain" : "object-cover"
-            }
-            sizes="(min-width: 1024px) 55vw, 100vw"
+            className={cn(
+              "absolute inset-0 size-full",
+              activeImage.fit === "contain" ? "object-contain" : "object-cover",
+            )}
+            loading="eager"
+            decoding="async"
           />
 
           {/* Bottom bar: caption + counter */}
@@ -185,14 +187,16 @@ export function ImageGallery({ product, theme }: ImageGalleryProps) {
           style={{ backgroundColor: theme.bg }}
           {...tid("image-gallery-main-mobile")}
         >
-          <Image
+          {/* eslint-disable-next-line @next/next/no-img-element -- user-provided image URLs can come from arbitrary hosts */}
+          <img
             src={activeImage.url}
             alt={activeImage.alt ?? product.name_en}
-            fill
-            className={
-              activeImage.fit === "contain" ? "object-contain" : "object-cover"
-            }
-            sizes="100vw"
+            className={cn(
+              "absolute inset-0 size-full",
+              activeImage.fit === "contain" ? "object-contain" : "object-cover",
+            )}
+            loading="eager"
+            decoding="async"
           />
 
           {/* Bottom bar: caption + counter */}
@@ -241,12 +245,13 @@ export function ImageGallery({ product, theme }: ImageGalleryProps) {
                   style={isActive ? { backgroundColor: theme.bg } : undefined}
                   aria-label={img.alt ?? String(idx + 1)}
                 >
-                  <Image
+                  {/* eslint-disable-next-line @next/next/no-img-element -- user-provided image URLs can come from arbitrary hosts */}
+                  <img
                     src={img.url}
                     alt={img.alt ?? ""}
-                    fill
-                    className="object-cover"
-                    sizes="20vw"
+                    className="absolute inset-0 size-full object-cover"
+                    loading="lazy"
+                    decoding="async"
                   />
                 </button>
               );

--- a/apps/store/src/features/products/presentation/components/product-detail/sections/GallerySection.test.tsx
+++ b/apps/store/src/features/products/presentation/components/product-detail/sections/GallerySection.test.tsx
@@ -13,13 +13,6 @@ vi.mock("shared", () => ({
     obj[`${field}_${locale}`] ?? obj[`${field}_en`] ?? "",
 }));
 
-vi.mock("next/image", () => ({
-  default: ({ src, alt }: { src: string; alt: string }) => (
-    // eslint-disable-next-line @next/next/no-img-element -- test mock
-    <img src={src} alt={alt} data-testid="next-image" />
-  ),
-}));
-
 const theme = {
   bg: "var(--mint)",
   bgLight: "color-mix(in srgb, var(--mint) 15%, transparent)",
@@ -77,7 +70,7 @@ describe("GallerySection", () => {
     };
     render(<GallerySection section={section as never} theme={theme} />);
     expect(screen.getByTestId("gallery-item-0")).toBeInTheDocument();
-    expect(screen.getByTestId("next-image")).toBeInTheDocument();
+    expect(screen.getByRole("img")).toBeInTheDocument();
   });
 
   it("renders placeholder number when no image_url", () => {

--- a/apps/store/src/features/products/presentation/components/product-detail/sections/GallerySection.tsx
+++ b/apps/store/src/features/products/presentation/components/product-detail/sections/GallerySection.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { useLocale } from "next-intl";
 import { useMemo } from "react";
 import { i18nField, tid } from "shared";
@@ -53,11 +52,13 @@ export function GallerySection({ section, theme }: GallerySectionProps) {
                   style={{ backgroundColor: theme.bg }}
                 >
                   {item.image_url ? (
-                    <Image
+                    // eslint-disable-next-line @next/next/no-img-element -- user-provided image URLs can come from arbitrary hosts
+                    <img
                       src={item.image_url}
                       alt={caption || ""}
-                      fill
-                      className="object-cover"
+                      className="absolute inset-0 size-full object-cover"
+                      loading="lazy"
+                      decoding="async"
                     />
                   ) : (
                     <span className="font-display text-sm font-extrabold uppercase tracking-widest text-foreground/30 select-none">


### PR DESCRIPTION
## Summary

- Replace `next/image` with native `<img>` in `ImageGallery` and `GallerySection` components (both `product-detail/` and `ProductDetail/` variants)
- Product detail page images were not loading because `next/image` requires remote URLs to be whitelisted in `next.config` `remotePatterns`, but user-uploaded images come from arbitrary hosts
- Uses `className="absolute inset-0 size-full object-cover"` to replicate `fill` behavior
- Main images use `loading="eager"`, thumbnails use `loading="lazy"`, all get `decoding="async"`
- Updated 4 test files to remove the `next/image` mock and use `getByRole("img")` instead

## Test plan

- [x] All 402 unit tests pass locally
- [x] Pre-commit hooks (prettier, eslint, secretlint) pass
- [x] Pre-push hooks (unit tests) pass
- [ ] CI quality, build, and E2E checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)