### PR TITLE
chore(tools): add Claude MCP tools, docs, and env templates

### DIFF
--- a/.claude/tools/.env.local.example
+++ b/.claude/tools/.env.local.example
@@ -1,8 +1,76 @@
-# MCP tokens for local wrapper scripts.
+﻿# MCP Server Tokens
 #
-# Copy to .claude/tools/.env.local or place the same variables in the project
-# root .env.local file.
+# This file contains environment variables for MCP (Model Context Protocol) servers.
+# These tokens are used by the GitHub, Vercel, Linear, and LogRocket MCP wrapper scripts.
+#
+# Setup Instructions:
+# 1. Copy this file to .env.local: cp .env.local.example .env.local
+# 2. Replace the placeholder values below with your actual tokens
+# 3. Restart Claude Code after adding/changing tokens
+#
+# Token locations checked (in order):
+# - Project root: .env.local
+# - Script directory: .claude/tools/.env.local
+#
+# Note: Tokens can be quoted or unquoted (both formats are supported)
+#
 
 # GitHub Personal Access Token
-# Required by: github-unified-mcp.mjs, git-mcp.mjs
+# Get your token from: https://github.com/settings/tokens
+# Required scopes: 'repo' (for full repository access)
+# For fine-grained tokens, ensure repository access is configured
+# Token format: ghp_xxxxxxxxxxxx (starts with 'ghp_')
 GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_TOKEN_HERE
+
+# Vercel API Token
+# Get your token from: https://vercel.com/account/tokens
+# Click 'Create' and give it a descriptive name (e.g., 'Claude Code MCP')
+# Token format: xxxxxxxxxxxx (alphanumeric string)
+VERCEL_TOKEN=YOUR_VERCEL_TOKEN_HERE
+
+# Linear API Key
+# Get your API key from: https://linear.app/settings/api
+# Click 'Create key' and give it a descriptive label
+# Token format: lin_api_xxxxxxxxxxxx (starts with 'lin_api_')
+LINEAR_API_KEY=YOUR_LINEAR_API_KEY_HERE
+
+# LogRocket API Key
+# Get your API key from: LogRocket Settings > API Keys
+# Format: org_id:app_id:secret_key (colon-separated, three parts)
+# Example: abc123:my-app:secretkey456
+LOGROCKET_API_KEY=YOUR_ORG_ID:YOUR_APP_ID:YOUR_SECRET_KEY
+
+# Slack Bot Token and Team ID
+# Get these from your team's secrets manager (1Password, etc.)
+# Bot token format: xoxb-xxxxxxxxxxxx (starts with 'xoxb-')
+# Team ID format: Txxxxxxxxx (starts with 'T')
+# See .claude/docs/SLACK_MCP_SETUP.md for full setup instructions
+SLACK_BOT_TOKEN=xoxb-your-token-here
+SLACK_TEAM_ID=T01234567
+
+# ============================================================================
+# Git MCP Configuration (Optional)
+# ============================================================================
+# These environment variables customize git operations via the Git MCP server.
+# All are optional - the server will use your global git config if not set.
+#
+# Git MCP uses GITHUB_PERSONAL_ACCESS_TOKEN (configured above) for authentication
+# via secure GIT_ASKPASS method - token never exposed in command line.
+#
+# For authenticated operations (push, pull, fetch, clone):
+# - Token authentication is handled automatically
+# - No additional configuration needed
+# - Works with HTTPS remotes (https://github.com/...)
+#
+# Optional: Override git identity for commits
+# GIT_AUTHOR_NAME=Your Name
+# GIT_AUTHOR_EMAIL=your.email@example.com
+#
+# Optional: Enable GPG/SSH commit signing
+# GIT_SIGN_COMMITS=false
+#
+# Optional: Restrict operations to specific directory (security sandboxing)
+# GIT_BASE_DIR=/path/to/your/projects
+#
+# Optional: Set log level for git MCP (error, warn, info, debug)
+# MCP_LOG_LEVEL=error

--- a/.claude/tools/CLAUDE.md
+++ b/.claude/tools/CLAUDE.md
@@ -1,0 +1,706 @@
+# MCP Server Development Guide (Zero-Dependency)
+
+This guide explains how to create new MCP (Model Context Protocol) servers for Claude Code integration.
+
+## Overview
+
+MCP servers in this directory provide tools that Claude can use during development. Each server is a **single `.mjs` file** that is **completely self-contained** with **zero external dependencies**.
+
+**Key Principle**: All MCP servers use only Node.js built-in modules (`fs`, `path`, `readline`, native `fetch`). No npm packages required. No `node_modules` folder. No installation needed.
+
+## File Structure
+
+```
+.claude/tools/
+├── .env.local              # API tokens and credentials (gitignored)
+├── .env.local.example      # Template for credentials
+├── github-unified-mcp.mjs  # GitHub API integration (zero-dependency)
+├── vercel-lite-mcp.mjs     # Vercel API integration (zero-dependency)
+├── logrocket-mcp.mjs       # LogRocket session replay (zero-dependency)
+├── linear-mcp.mjs          # Linear issue tracking (zero-dependency)
+├── CLAUDE.md               # This file
+└── README.md               # General MCP server information
+```
+
+## MCP Server Pattern
+
+All MCP servers in this directory follow the same structure:
+
+### 1. File Header
+
+```javascript
+#!/usr/bin/env node
+/**
+ * [Name] MCP Server
+ *
+ * [Brief description of what this server does]
+ *
+ * Tools Provided:
+ * - tool_name_1: Description
+ * - tool_name_2: Description
+ * - tool_name_3: Description
+ *
+ * Requires [ENV_VAR_1], [ENV_VAR_2]
+ * in .env.local or .claude/tools/.env.local
+ */
+/* global process */
+```
+
+### 2. Imports (Built-ins Only)
+
+```javascript
+// ONLY use Node.js built-in modules - no npm packages!
+import { existsSync, readFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import { createInterface } from "readline";
+// Native fetch is available in Node 18+
+```
+
+### 3. Environment Variable Loading
+
+Use this standard pattern to load `.env.local` files:
+
+```javascript
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..", "..");
+
+// Load environment variables
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) return;
+  const content = fs.readFileSync(filePath, "utf-8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    // Match your specific env var pattern
+    const match = trimmed.match(/^(YOUR_PREFIX_[A-Z_]+)=(.+)$/);
+    if (match) {
+      let value = match[2].trim();
+      // Handle quoted values
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      process.env[match[1]] = value;
+    }
+  }
+}
+
+// Load from both project root and tools directory
+loadEnvFile(path.join(projectRoot, ".env.local"));
+loadEnvFile(path.join(__dirname, ".env.local"));
+
+// Validate required variables
+const API_KEY = process.env.YOUR_API_KEY;
+if (!API_KEY) {
+  console.error("Error: YOUR_API_KEY not found");
+  console.error("Please set it in .env.local or .claude/tools/.env.local");
+  process.exit(1);
+}
+```
+
+**Key points:**
+
+- Check both project root and `.claude/tools/` for `.env.local`
+- Handle both quoted and unquoted values
+- Exit with clear error messages if credentials are missing
+- Use regex to match specific variable patterns
+
+### 4. API Helper Function
+
+Create a reusable function for API calls:
+
+```javascript
+async function apiFetch(method, endpoint, body = null) {
+  const url = `${API_BASE_URL}${endpoint}`;
+  const options = {
+    method,
+    headers: {
+      Authorization: `Bearer ${API_KEY}`,
+      "Content-Type": "application/json",
+    },
+  };
+
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url, options);
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`API error (${response.status}): ${errorText}`);
+  }
+
+  return response.json();
+}
+```
+
+### 5. Tool Definitions
+
+Define tools as an array following MCP schema:
+
+```javascript
+const TOOLS = [
+  {
+    name: "tool_name",
+    description:
+      "Clear, concise description of what this tool does. Be specific about what it returns.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        paramName: {
+          type: "string", // or "number", "boolean", "object"
+          description: "What this parameter is for",
+        },
+        optionalParam: {
+          type: "number",
+          description: "Optional parameter (omit from required array)",
+        },
+      },
+      required: ["paramName"], // List required parameters
+    },
+  },
+  // ... more tools
+];
+```
+
+**Tool naming conventions:**
+
+- Use `service_action` format (e.g., `github_create_issue`, `vercel_get_deployment`)
+- Be descriptive and consistent
+- Group related tools with the same prefix
+
+### 6. JSON-RPC Helpers (Zero-Dependency)
+
+Instead of using the MCP SDK, implement JSON-RPC 2.0 directly:
+
+```javascript
+// JSON-RPC response helpers
+function jsonRpcResponse(id, result) {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function jsonRpcError(id, code, message) {
+  return JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+}
+```
+
+### 7. Message Handler (Zero-Dependency)
+
+```javascript
+// Handle MCP protocol messages
+async function handleMessage(message) {
+  const { id, method, params } = message;
+
+  try {
+    switch (method) {
+      case "initialize":
+        return jsonRpcResponse(id, {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {} },
+          serverInfo: { name: "your-mcp-server", version: "1.0.0" },
+        });
+
+      case "notifications/initialized":
+        return null; // No response needed
+
+      case "tools/list":
+        return jsonRpcResponse(id, { tools: TOOLS });
+
+      case "tools/call": {
+        const { name, arguments: args } = params;
+        try {
+          const result = await handleTool(name, args || {});
+          return jsonRpcResponse(id, {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          });
+        } catch (error) {
+          return jsonRpcResponse(id, {
+            content: [{ type: "text", text: `Error: ${error.message}` }],
+            isError: true,
+          });
+        }
+      }
+
+      default:
+        return jsonRpcError(id, -32601, `Method not found: ${method}`);
+    }
+  } catch (error) {
+    return jsonRpcError(id, -32603, error.message);
+  }
+}
+```
+
+### 8. Tool Handler
+
+```javascript
+async function handleTool(name, args) {
+  switch (name) {
+    case "tool_name": {
+      const { paramName, optionalParam } = args;
+
+      if (!paramName) {
+        throw new Error("paramName is required");
+      }
+
+      const result = await apiFetch("GET", `/endpoint/${paramName}`);
+      return result;
+    }
+
+    // ... more cases
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+```
+
+### 9. Main: stdio Loop (Zero-Dependency)
+
+```javascript
+// Main: Read JSON-RPC messages from stdin, write responses to stdout
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", async (line) => {
+  if (!line.trim()) return;
+
+  try {
+    const message = JSON.parse(line);
+    const response = await handleMessage(message);
+    if (response) {
+      process.stdout.write(response + "\n");
+    }
+  } catch (error) {
+    const errorResponse = jsonRpcError(null, -32700, "Parse error");
+    process.stdout.write(errorResponse + "\n");
+  }
+});
+
+rl.on("close", () => process.exit(0));
+```
+
+**Key points:**
+
+- Uses `readline.createInterface` to read line-by-line from stdin
+- Parses each line as JSON-RPC message
+- Writes JSON-RPC response to stdout with newline
+- No external dependencies!
+
+## Configuration Files
+
+### .mcp.json (Project Root)
+
+Add your server to `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "your-service": {
+      "command": "node",
+      "args": [".claude/tools/your-service-mcp.mjs"],
+      "env": {},
+      "_note": "Brief description of what this MCP provides"
+    }
+  }
+}
+```
+
+### .env.local.example
+
+Update `.claude/tools/.env.local.example` with your new credentials:
+
+```bash
+# Your Service API Credentials
+# Get your API key from: [URL to get credentials]
+# Additional instructions if needed
+YOUR_API_KEY=YOUR_API_KEY_HERE
+YOUR_OTHER_VAR=YOUR_VALUE_HERE
+```
+
+## Development Workflow
+
+### 1. Research the API
+
+- Find official API documentation
+- Identify authentication method (Bearer token, API key, OAuth, etc.)
+- List available endpoints and their capabilities
+- Note rate limits and restrictions
+
+### 2. Design Your Tools
+
+- Choose 3-10 most useful operations (avoid creating 100+ tools)
+- Name tools consistently with `service_action` pattern
+- Write clear descriptions focusing on "what" not "how"
+- Define input schemas with helpful descriptions
+
+### 3. Create the MCP File
+
+```bash
+# Create the file
+touch .claude/tools/your-service-mcp.mjs
+chmod +x .claude/tools/your-service-mcp.mjs
+```
+
+Follow the pattern outlined above.
+
+### 4. Add Environment Variables
+
+```bash
+# Edit .env.local.example
+nano .claude/tools/.env.local.example
+
+# Add your actual credentials to .env.local
+nano .claude/tools/.env.local
+```
+
+### 5. Configure MCP
+
+```bash
+# Edit .mcp.json in project root
+nano .mcp.json
+```
+
+### 6. Test the Server
+
+```bash
+# Test directly
+node .claude/tools/your-service-mcp.mjs
+
+# Or restart Claude Code and ask it to list tools
+```
+
+## Best Practices
+
+### Tool Design
+
+1. **Keep it focused**: 3-10 tools is ideal. More tools = more context used per request
+2. **Clear descriptions**: Users should know exactly what a tool does without reading code
+3. **Predictable naming**: Use `service_action` format consistently
+4. **Required vs optional**: Mark parameters correctly in the schema
+
+### Error Messages
+
+Good error messages:
+
+```javascript
+throw new Error("API key not found. Set GITHUB_TOKEN in .env.local");
+throw new Error("Issue #123 not found in repository owner/repo");
+throw new Error("Deployment failed: invalid project ID");
+```
+
+Bad error messages:
+
+```javascript
+throw new Error("Error"); // Too vague
+throw new Error(JSON.stringify(apiError)); // Not human-readable
+throw new Error("Failed"); // No context
+```
+
+### Response Format
+
+Always return JSON for structured data:
+
+```javascript
+return {
+  content: [
+    {
+      type: "text",
+      text: JSON.stringify(result, null, 2), // Pretty-print JSON
+    },
+  ],
+};
+```
+
+For simple confirmations, plain text is fine:
+
+```javascript
+return {
+  content: [
+    {
+      type: "text",
+      text: "Successfully updated user preferences",
+    },
+  ],
+};
+```
+
+### Security
+
+1. **Never commit credentials**: Use `.env.local` (already gitignored)
+2. **Validate inputs**: Check required parameters before API calls
+3. **Handle sensitive data**: Don't log API keys or tokens
+4. **Use HTTPS**: Always use secure API endpoints
+
+### File Size
+
+- Target: 200-400 lines
+- Maximum: ~500 lines
+- If larger, consider splitting into multiple MCP servers
+
+## Examples
+
+### Minimal Example (Zero-Dependency)
+
+```javascript
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import { createInterface } from "readline";
+
+const __toolsDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__toolsDir, "..", "..");
+
+// Load API key from .env.local
+function loadEnvFile(filePath) {
+  if (!existsSync(filePath)) return;
+  const content = readFileSync(filePath, "utf-8");
+  for (const line of content.split("\n")) {
+    const match = line.trim().match(/^MY_API_KEY=(.+)$/);
+    if (match) {
+      process.env.MY_API_KEY = match[1].replace(/^["']|["']$/g, "");
+      break;
+    }
+  }
+}
+
+loadEnvFile(join(projectRoot, ".env.local"));
+loadEnvFile(join(__toolsDir, ".env.local"));
+
+const API_KEY = process.env.MY_API_KEY;
+if (!API_KEY) {
+  console.error("Error: MY_API_KEY not found");
+  process.exit(1);
+}
+
+const TOOLS = [
+  {
+    name: "my_get_data",
+    description: "Fetch data from the API",
+    inputSchema: {
+      type: "object",
+      properties: { id: { type: "string", description: "Data ID" } },
+      required: ["id"],
+    },
+  },
+];
+
+async function handleTool(name, args) {
+  if (name === "my_get_data") {
+    const response = await fetch(`https://api.example.com/data/${args.id}`, {
+      headers: { Authorization: `Bearer ${API_KEY}` },
+    });
+    if (!response.ok) throw new Error(`API error: ${response.status}`);
+    return await response.json();
+  }
+  throw new Error(`Unknown tool: ${name}`);
+}
+
+function jsonRpcResponse(id, result) {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function jsonRpcError(id, code, message) {
+  return JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+async function handleMessage(message) {
+  const { id, method, params } = message;
+  switch (method) {
+    case "initialize":
+      return jsonRpcResponse(id, {
+        protocolVersion: "2024-11-05",
+        capabilities: { tools: {} },
+        serverInfo: { name: "my-mcp", version: "1.0.0" },
+      });
+    case "notifications/initialized":
+      return null;
+    case "tools/list":
+      return jsonRpcResponse(id, { tools: TOOLS });
+    case "tools/call": {
+      const { name, arguments: args } = params;
+      try {
+        const result = await handleTool(name, args || {});
+        return jsonRpcResponse(id, {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        });
+      } catch (error) {
+        return jsonRpcResponse(id, {
+          content: [{ type: "text", text: `Error: ${error.message}` }],
+          isError: true,
+        });
+      }
+    }
+    default:
+      return jsonRpcError(id, -32601, `Method not found: ${method}`);
+  }
+}
+
+const rl = createInterface({ input: process.stdin });
+rl.on("line", async (line) => {
+  if (!line.trim()) return;
+  try {
+    const response = await handleMessage(JSON.parse(line));
+    if (response) process.stdout.write(response + "\n");
+  } catch {
+    process.stdout.write(jsonRpcError(null, -32700, "Parse error") + "\n");
+  }
+});
+rl.on("close", () => process.exit(0));
+```
+
+## Reference Implementations
+
+Study these existing **zero-dependency** MCP servers in this directory:
+
+- **`github-unified-mcp.mjs`**: ~770 lines, 22 GitHub API tools (PRs, issues, search)
+- **`linear-mcp.mjs`**: ~515 lines, 9 Linear API tools (issues, projects, teams)
+- **`vercel-lite-mcp.mjs`**: ~430 lines, 10 Vercel API tools (deployments, projects)
+- **`logrocket-mcp.mjs`**: ~330 lines, 3 LogRocket API tools (sessions, users)
+
+All implementations follow the same pattern:
+
+1. Load env vars from `.env.local` files
+2. Define TOOLS array with JSON Schema
+3. Implement handleTool() with switch statement
+4. Implement handleMessage() for MCP protocol
+5. readline loop reading JSON-RPC from stdin
+
+## Common Patterns
+
+### Pagination
+
+```javascript
+const TOOLS = [
+  {
+    name: "list_items",
+    inputSchema: {
+      properties: {
+        limit: { type: "number", description: "Items per page (default: 10)" },
+        page: { type: "number", description: "Page number (default: 1)" },
+      },
+    },
+  },
+];
+
+// In handler:
+const limit = args.limit || 10;
+const page = args.page || 1;
+const offset = (page - 1) * limit;
+```
+
+### Webhook Support
+
+```javascript
+const TOOLS = [
+  {
+    name: "create_webhook",
+    inputSchema: {
+      properties: {
+        webhookURL: { type: "string", description: "URL to receive webhook" },
+      },
+      required: ["webhookURL"],
+    },
+  },
+];
+```
+
+### Multiple Required Credentials
+
+```javascript
+const API_KEY = process.env.SERVICE_API_KEY;
+const API_SECRET = process.env.SERVICE_API_SECRET;
+const ORG_ID = process.env.SERVICE_ORG_ID;
+
+if (!API_KEY || !API_SECRET || !ORG_ID) {
+  console.error("Error: Missing required credentials:");
+  if (!API_KEY) console.error("  - SERVICE_API_KEY");
+  if (!API_SECRET) console.error("  - SERVICE_API_SECRET");
+  if (!ORG_ID) console.error("  - SERVICE_ORG_ID");
+  process.exit(1);
+}
+```
+
+## Troubleshooting
+
+### Server Not Loading
+
+1. Check file is executable: `chmod +x .claude/tools/your-service-mcp.mjs`
+2. Verify `.mcp.json` path is correct
+3. Test server directly: `node .claude/tools/your-service-mcp.mjs`
+4. Restart Claude Code
+
+### Environment Variables Not Found
+
+1. Check `.env.local` exists in `.claude/tools/` or project root
+2. Verify variable names match exactly (case-sensitive)
+3. Check for quotes in values (both `"value"` and `value` should work)
+4. Restart Claude Code after changing `.env.local`
+
+### API Errors
+
+1. Verify API key is correct and active
+2. Check API endpoint URLs
+3. Review API rate limits
+4. Test with curl/Postman first
+
+### Tools Not Appearing
+
+1. Verify tool names in `TOOLS` array match cases in handler
+2. Check `inputSchema` is valid JSON Schema
+3. Ensure `ListToolsRequestSchema` handler returns `{ tools: TOOLS }`
+4. Restart Claude Code
+
+## Resources
+
+- [Model Context Protocol Docs](https://modelcontextprotocol.io)
+- [MCP SDK on npm](https://www.npmjs.com/package/@modelcontextprotocol/sdk)
+- [JSON Schema Reference](https://json-schema.org/understanding-json-schema/)
+- [Example MCP servers](https://github.com/modelcontextprotocol/servers)
+
+## Checklist for New MCP Servers
+
+- [ ] Research API documentation
+- [ ] Design 3-10 focused tools
+- [ ] Create `.mjs` file following pattern
+- [ ] Implement environment variable loading
+- [ ] Add API helper function
+- [ ] Define tool schemas
+- [ ] Implement tool handlers with error handling
+- [ ] Update `.env.local.example`
+- [ ] Add to `.mcp.json`
+- [ ] Test with actual API calls
+- [ ] Verify error messages are clear
+- [ ] Make file executable (`chmod +x`)
+- [ ] Test in Claude Code
+- [ ] Document credentials in `.env.local.example`
+
+## Need Help?
+
+When asking Claude to create a new MCP server, provide:
+
+1. **Service name**: What API/service to integrate
+2. **API documentation URL**: Link to official API docs
+3. **Authentication**: How to authenticate (API key, token, OAuth)
+4. **Desired tools**: What operations you want (list 3-10 specific actions)
+5. **Credentials**: Where to get API keys/tokens
+
+Example prompt:
+
+```
+Create an MCP server for [Service Name]. I want these tools:
+1. [action]: [description]
+2. [action]: [description]
+3. [action]: [description]
+
+API docs: [URL]
+Auth: [Bearer token / API key / etc]
+Get credentials from: [URL]
+```
+
+Claude will create the single-file `.mjs` wrapper following this guide.

--- a/.claude/tools/README.md
+++ b/.claude/tools/README.md
@@ -1,33 +1,669 @@
-# Claude Tools Configuration
+# Claude Code Tools
 
-This folder contains local MCP wrapper scripts and token templates used by `.mcp.json`.
+Scripts and MCP server wrappers used by Claude Code hooks and automation.
 
-## Setup
+## MCP Server Configuration
 
-1. Copy `.env.local.example` to `.env.local`
-2. Fill in your personal tokens
-3. Restart Claude or any MCP-aware client
+The project uses `.mcp.json` to configure MCP (Model Context Protocol) servers. These provide Claude Code with additional capabilities like browser automation, issue tracking, and deployment management.
 
-## Available Local Wrappers
+### Configured Servers
 
-The repository currently ships local wrappers for:
+| Server            | Purpose                                                | Authentication         |
+| ----------------- | ------------------------------------------------------ | ---------------------- |
+| `shadcn`          | shadcn/ui component registry                           | None                   |
+| `next-devtools`   | Next.js DevTools integration                           | None                   |
+| `playwright`      | Browser automation testing                             | None                   |
+| `chrome-devtools` | Chrome DevTools Protocol                               | None                   |
+| `linear`          | Linear issue tracking (9 tools)                        | Token via `.env.local` |
+| `github`          | Unified GitHub MCP (28 tools: 27 official + PR update) | Token via `.env.local` |
+| `vercel`          | Vercel deployment management                           | Token via `.env.local` |
+| `vercel-lite`     | Lightweight Vercel (10 essential tools only)           | Token via `.env.local` |
+| `logrocket`       | LogRocket session replay and bug tracking (3 tools)    | Token via `.env.local` |
 
-- `github-unified-mcp.mjs`
-- `git-mcp.mjs`
+### Token Setup
 
-`.mcp.json` also includes a disabled `github-setup` entry, but that wrapper is not shipped in this repo.
+For Linear, GitHub, Vercel, and LogRocket MCP servers, you need to provide API tokens:
 
-## Token Files
+1. Copy the example file:
 
-Wrappers look for tokens in this order:
+   ```bash
+   cp .claude/tools/.env.local.example .claude/tools/.env.local
+   ```
 
-1. Project root `.env.local`
-2. `.claude/tools/.env.local`
+2. Edit `.claude/tools/.env.local` and add your tokens:
 
-The local `.env.local` file in this directory is gitignored. Keep secrets there or in the project root, not in tracked files.
+   ```bash
+   # Linear API Key
+   # Get from: https://linear.app/settings/api
+   LINEAR_API_KEY=lin_api_xxxxxxxxxxxx
+
+   # GitHub Personal Access Token
+   # Get from: https://github.com/settings/tokens
+   # Required scopes: 'repo' (for full repository access)
+   GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxxxxxxxxxxx
+
+   # Vercel API Token
+   # Get from: https://vercel.com/account/tokens
+   VERCEL_TOKEN=xxxxxxxxxxxx
+
+   # LogRocket API Key
+   # Format: org_id:app_id:secret_key
+   # Get from: LogRocket Settings > API Keys
+   LOGROCKET_API_KEY=org_id:app_id:secret_key
+   ```
+
+3. Restart Claude Code after adding tokens.
+
+## MCP Wrapper Scripts
+
+All wrapper scripts are cross-platform (Windows, macOS, Linux) and automatically load tokens from environment files before starting the MCP servers.
+
+### Custom MCP Servers
+
+#### github-unified-mcp.mjs
+
+**Purpose:** Unified GitHub MCP server that combines the official GitHub MCP (26 tools) with custom PR update capabilities (1 tool).
+
+**Why it exists:** The official `@modelcontextprotocol/server-github` package provides comprehensive GitHub functionality but is missing a tool to update pull request titles, bodies, or base branches. Rather than running two separate servers, this unified server spawns the official MCP as a child process and extends it with the missing functionality.
+
+**Architecture:**
+
+- Spawns official GitHub MCP via npx as a child process
+- Intercepts and proxies MCP protocol messages
+- Adds custom `github_update_pull_request` tool to the official tool list
+- Routes custom tool calls locally, forwards others to official MCP
+
+**All tools provided (27 total):**
+
+Official GitHub MCP tools (26):
+
+**File Operations (3):**
+
+- `create_or_update_file` - Create or update a single file in a repository
+  - Use when: Making single file changes via API instead of git commands
+- `push_files` - Push multiple files in a single commit
+  - Use when: Batch updating multiple files at once
+- `get_file_contents` - Read file contents from a repository
+  - Use when: Inspecting files in other repos or branches without cloning
+
+**Repository Management (4):**
+
+- `create_repository` - Create a new GitHub repository
+  - Use when: Programmatically creating repos
+- `fork_repository` - Fork an existing repository
+  - Use when: Contributing to external projects
+- `create_branch` - Create a new branch
+  - Use when: Creating feature branches via API
+- `list_commits` - List commits with filters
+  - Use when: Analyzing commit history, finding specific commits
+
+**Issue Management (5):**
+
+- `create_issue` - Create a new issue
+  - Use when: Reporting bugs or creating tasks programmatically
+- `list_issues` - List issues with filters (state, labels, assignee)
+  - Use when: Querying issues for reporting or automation
+- `update_issue` - Update issue details (title, body, state, labels, assignees)
+  - Use when: Modifying existing issues
+- `add_issue_comment` - Add a comment to an issue
+  - Use when: Adding notes, updates, or responses to issues
+- `get_issue` - Get detailed issue information
+  - Use when: Retrieving full issue context
+
+**Pull Request Operations (10):**
+
+- `create_pull_request` - Create a new pull request
+  - Use when: Opening PRs programmatically (use with `/submit-pr` skill)
+- `list_pull_requests` - List PRs with filters (state, base branch, head branch)
+  - Use when: Finding PRs for review or analysis
+- `get_pull_request` - Get detailed PR information
+  - Use when: Inspecting PR details, status, or metadata
+- `get_pull_request_files` - Get list of changed files in a PR
+  - Use when: Analyzing PR diff, checking which files changed
+- `get_pull_request_comments` - Get PR review comments
+  - Use when: Reading feedback on PRs (use with `/review-pr-comments` skill)
+- `get_pull_request_reviews` - Get PR reviews and their states
+  - Use when: Checking review status (approved, changes requested)
+- `get_pull_request_status` - Get CI/CD checks and their results
+  - Use when: Verifying build status, linting, or tests
+- `create_pull_request_review` - Add a review to a PR
+  - Use when: Providing code review feedback programmatically
+- `merge_pull_request` - Merge a pull request
+  - Use when: Automating PR merges (ensure checks pass first)
+- `update_pull_request_branch` - Update PR branch with latest base
+  - Use when: Syncing PR branch with main/dev (rebase/merge)
+
+**Search (4):**
+
+- `search_repositories` - Search for repositories
+  - Use when: Finding repos by name, topic, or language
+- `search_code` - Search code across repositories
+  - Use when: Finding usage patterns, API examples, or implementations
+- `search_issues` - Search issues and pull requests
+  - Use when: Finding related issues, tracking patterns
+- `search_users` - Search for GitHub users
+  - Use when: Finding contributors or team members
+
+Custom tool (1):
+
+- `github_update_pull_request` - Update PR title, body, base branch, or state
+  - Use when: Editing PR details after creation (missing from official MCP)
+  - Common use cases: Fixing PR title/description, changing target branch, closing PRs
+
+**Authentication:** Uses `GITHUB_PERSONAL_ACCESS_TOKEN` from `.env.local` or `.claude/tools/.env.local`.
+
+**Usage example:**
+
+```javascript
+mcp__github__github_update_pull_request({
+  owner: "claimangel",
+  repo: "frontend",
+  pull_number: 123,
+  title: "Updated PR title",
+  body: "Updated PR description",
+  base: "dev", // Optional: change target branch
+  state: "open", // Optional: open or closed
+});
+```
+
+**GitHub API Reference:** https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request
+
+**Manual execution:**
+
+```bash
+node .claude/tools/github-unified-mcp.mjs
+```
+
+#### linear-mcp.mjs
+
+**Purpose:** Custom Linear MCP server using the official `@linear/sdk` for issue tracking and project management.
+
+**Why it exists:** Provides token-based authentication (no browser OAuth needed) and includes specialized tools for downloading embedded images from issues and comments, which is essential for visual context when working on UI tasks.
+
+**Tools provided (9 total):**
+
+**Issue Operations (4):**
+
+- `linear_get_issue` - Get detailed information about a specific Linear issue
+  - Use when: Fetching task details, requirements, acceptance criteria
+  - Returns: Title, description, state, assignee, labels, priority, timestamps
+  - Example: `mcp__linear__linear_get_issue({ id: "CLA-4168" })`
+
+- `linear_list_issues` - List and search issues with optional filters
+  - Use when: Finding available tasks, querying by assignee or state
+  - Filters: query, assigneeId, state, teamId, limit
+  - Example: `mcp__linear__linear_list_issues({ assigneeId: "me", state: "Tasks in Progress" })`
+
+- `linear_update_issue` - Update an existing Linear issue
+  - Use when: Changing issue status, assignee, priority, or labels
+  - Can update: title, description, stateId, assigneeId, priority
+  - Example: `mcp__linear__linear_update_issue({ id: "CLA-4168", stateId: "state-id" })`
+
+- `linear_get_issue_images` - Get issue details with embedded images downloaded
+  - Use when: Analyzing screenshots or mockups in issue descriptions
+  - Downloads: All markdown images from issue description to local files
+  - Returns: Issue details + array of downloaded image paths with metadata
+  - Example: `mcp__linear__linear_get_issue_images({ id: "CLA-4168", outputDir: ".ai-context/task-outputs/CLA-4168/images" })`
+
+**Comment Operations (3):**
+
+- `linear_get_comments` - Get all comments on a specific Linear issue
+  - Use when: Reading discussion, clarifications, or updates on a task
+  - Returns: Array of comments with author, timestamp, and body (markdown)
+  - Example: `mcp__linear__linear_get_comments({ issueId: "CLA-4168" })`
+
+- `linear_create_comment` - Add a comment to a Linear issue
+  - Use when: Posting updates, asking questions, or documenting progress
+  - Supports: Full markdown formatting
+  - Example: `mcp__linear__linear_create_comment({ issueId: "CLA-4168", body: "Started work on this task" })`
+
+- `linear_get_comments_images` - Get comments with embedded images downloaded
+  - Use when: Analyzing screenshots or context shared in comment threads
+  - Downloads: All markdown images from all comments to local files
+  - Returns: Array of comments with downloaded image paths, sizes, and metadata
+  - Example: `mcp__linear__linear_get_comments_images({ issueId: "CLA-4168", outputDir: ".ai-context/task-outputs/CLA-4168/comments-images" })`
+
+**Workspace Operations (2):**
+
+- `linear_list_projects` - List all projects in the workspace
+  - Use when: Querying available projects for reporting or automation
+  - Example: `mcp__linear__linear_list_projects({ limit: 20 })`
+
+- `linear_list_teams` - List all teams in the workspace
+  - Use when: Finding team IDs for filtering or organization
+  - Example: `mcp__linear__linear_list_teams()`
+
+**MCP Tool Naming Convention:**
+
+The Linear MCP server defines tools with names like `linear_get_issue`, `linear_list_issues`, etc. When exposed through Claude Code's MCP system, these become:
+
+```
+mcp__[server-name]__[tool-name]
+```
+
+Since the server is named `"linear"` in `.mcp.json` and the tools are named `"linear_*"`, the final tool names are:
+
+```
+mcp__linear__linear_get_issue
+mcp__linear__linear_list_issues
+mcp__linear__linear_get_issue_images
+...etc
+```
+
+**Why the double "linear"?** This is intentional to maintain consistency:
+
+- First `linear`: The MCP server name from `.mcp.json`
+- Second `linear_`: The tool name prefix in the MCP server code
+- This pattern helps identify both the server source AND the tool purpose
+
+**Authentication:** Uses `LINEAR_API_KEY` from `.env.local` or `.claude/tools/.env.local`.
+
+**API Key Format:** `lin_api_xxxxxxxxxxxx` (Personal API Key from Linear settings)
+
+**Usage examples:**
+
+```javascript
+// Get issue details
+mcp__linear__linear_get_issue({ id: "CLA-4168" });
+
+// Download all images from issue and comments for visual context
+mcp__linear__linear_get_issue_images({
+  id: "CLA-4168",
+  outputDir: ".ai-context/task-outputs/CLA-4168/images",
+});
+
+mcp__linear__linear_get_comments_images({
+  issueId: "CLA-4168",
+  outputDir: ".ai-context/task-outputs/CLA-4168/comments-images",
+});
+
+// Update issue status
+mcp__linear__linear_update_issue({
+  id: "CLA-4168",
+  stateId: "state-id-for-in-progress",
+});
+
+// Post a comment
+mcp__linear__linear_create_comment({
+  issueId: "CLA-4168",
+  body: "## Status Update\n\nCompleted initial implementation. Ready for review.",
+});
+```
+
+**Linear API Reference:** https://developers.linear.app/docs/graphql/working-with-the-graphql-api
+
+**Manual execution:**
+
+```bash
+node .claude/tools/linear-mcp.mjs
+```
+
+#### vercel-lite-mcp.mjs
+
+**Purpose:** Lightweight custom Vercel MCP server with ~10 essential tools.
+
+**Why it exists:** The official Vercel SDK exposes 100+ tools which consumes excessive context window space. This custom server provides only the essential deployment and project management tools.
+
+**Tools provided:**
+
+- `vercel_list_deployments` - List recent deployments
+- `vercel_get_deployment` - Get deployment details
+- `vercel_get_deployment_events` - Get build logs/events
+- `vercel_list_projects` - List projects
+- `vercel_get_project` - Get project details
+- `vercel_get_project_domains` - Get project domains
+- `vercel_get_project_env` - Get environment variables (names only)
+- `vercel_cancel_deployment` - Cancel a deployment
+- `vercel_redeploy` - Redeploy an existing deployment
+- `vercel_get_latest_deployment` - Get latest deployment for a project
+
+**Authentication:** Uses `VERCEL_TOKEN` from `.env.local` or `.claude/tools/.env.local`.
+
+**Manual execution:**
+
+```bash
+node .claude/tools/vercel-lite-mcp.mjs
+```
+
+#### logrocket-mcp.mjs
+
+**Purpose:** Custom LogRocket MCP server for session replay and bug tracking integration.
+
+**Why it exists:** LogRocket provides session replay, error tracking, and user analytics. This MCP enables Claude to query user sessions, retrieve AI-generated highlights, and update user metadata directly from the codebase.
+
+**Tools provided (3):**
+
+- `logrocket_get_session_highlights` - Get AI-generated summaries of user sessions with errors
+  - Use when: Investigating user-reported bugs, analyzing error patterns
+  - Returns: Request ID for webhook delivery of highlights
+  - Note: Requires webhook URL for async results delivery
+
+- `logrocket_export_sessions` - Export raw session data with events, errors, network requests
+  - Use when: Deep debugging, analyzing session data programmatically
+  - Note: **Deprecated API for SaaS customers** - may return empty results
+  - Recommendation: Use Streaming Data Export service instead if available
+
+- `logrocket_update_user` - Update user information and custom traits
+  - Use when: Adding context about users (subscription tier, account type, etc.)
+  - Use cases: Enriching user profiles for better debugging context
+
+**Authentication:** Uses `LOGROCKET_API_KEY` from `.env.local` or `.claude/tools/.env.local`.
+
+**API Key Format:** `org_id:app_id:secret_key` (e.g., `abc123:my-app:secretkey456`)
+
+**Usage example:**
+
+```javascript
+// Get session highlights for a user
+mcp__logrocket__logrocket_get_session_highlights({
+  userEmail: "user@example.com",
+  startMs: 1704067200000, // Unix timestamp
+  endMs: 1704153600000,
+  webhookURL: "https://your-webhook-url.com/highlights",
+});
+
+// Update user metadata
+mcp__logrocket__logrocket_update_user({
+  userId: "user-123",
+  name: "John Doe",
+  email: "john@example.com",
+  traits: {
+    subscription: "premium",
+    accountType: "enterprise",
+  },
+});
+```
+
+**LogRocket API Reference:** https://docs.logrocket.com/reference/api-overview
+
+**Manual execution:**
+
+```bash
+node .claude/tools/logrocket-mcp.mjs
+```
+
+### Official MCP Server Wrappers
+
+#### vercel-mcp.mjs
+
+Cross-platform wrapper that loads `VERCEL_TOKEN` and runs the official `@vercel/sdk` MCP server.
+
+**Token locations checked (in order):**
+
+1. Project root: `.env.local`
+2. Script directory: `.claude/tools/.env.local`
+
+**Features:**
+
+- Uses the official `@vercel/sdk` package (GitHub: https://github.com/vercel/sdk)
+- Provides ~95+ tools covering the full Vercel REST API
+- Automatically validates token presence before starting
+- Cross-platform compatibility (Windows, macOS, Linux)
+- Requires Node.js v20 or greater
+- Proper error handling with helpful error messages
+
+**Manual execution:**
+
+```bash
+node .claude/tools/vercel-mcp.mjs
+```
+
+**Note:** If `VERCEL_TOKEN` is not found, the script will exit with an error message pointing you to where to get a token.
+
+## SessionStart Hook
+
+The `SessionStart` hook runs when Claude Code starts a new session.
+
+### Purpose
+
+Check if `.cursor/mcp.json` exists. If it doesn't, run `Create-McpSymlink.ps1` to create a symlink so both Claude Code and Cursor share the same MCP configuration.
+
+### Hook Logic
+
+```
+IF .cursor/mcp.json does NOT exist
+    THEN run Create-McpSymlink.ps1
+    (ignore script output - script handles everything internally)
+ELSE
+    do nothing
+```
+
+### Configuration
+
+In `.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"if (process.platform === 'win32' && !require('fs').existsSync('.cursor/mcp.json')) { require('child_process').execSync('powershell -ExecutionPolicy Bypass -File .claude/tools/Create-McpSymlink.ps1', {stdio: 'inherit'}) }\""
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Key Points
+
+- Windows-only: Uses Node.js to check platform before running PowerShell
+- Script output is not suppressed - let errors surface for debugging
+- No `exit 0` override - if the script fails, the hook should report it
+
+## Create-McpSymlink.ps1
+
+Creates a symlink from `.cursor/mcp.json` to `.mcp.json` so both Claude Code and Cursor share the same MCP configuration.
+
+### Requirements
+
+- Windows with either:
+  - Developer Mode enabled (no admin required), OR
+  - Administrator privileges (UAC prompt)
+
+### Manual Execution
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .claude/tools/Create-McpSymlink.ps1
+```
+
+## File Structure
+
+```
+.claude/tools/
+├── README.md                 # This file
+├── CLAUDE.md                 # MCP server development guide
+├── .env.local.example        # Token template (copy to .env.local)
+├── .env.local                # Your tokens (gitignored)
+├── github-unified-mcp.mjs    # Unified GitHub MCP (28 tools: 27 official + PR update)
+├── linear-mcp.mjs            # Custom Linear MCP using @linear/sdk (9 tools)
+├── vercel-mcp.mjs            # Vercel MCP wrapper script (official)
+├── vercel-lite-mcp.mjs       # Lightweight Vercel MCP (custom, 10 tools)
+├── logrocket-mcp.mjs         # LogRocket session replay MCP (custom, 3 tools)
+├── Create-McpSymlink.ps1     # Windows symlink creation script
+├── claude-launcher.sh        # Claude launcher with MSYS path fix
+├── claude-env-setup.sh       # Source-able script for shell alias
+├── restart-with-skill.sh     # Spawn fresh Claude session with skill
+└── detect-claude-flags.sh    # Detect Claude startup flags
+```
+
+## Git Bash Path Conversion Fix
+
+### The Problem
+
+When using Git Bash (MINGW) on Windows, paths starting with `/` get automatically converted to Windows paths. For example:
+
+- `/test-ascii` becomes `C:/Program Files/Git/test-ascii`
+- `/submit-pr` becomes `C:/Program Files/Git/submit-pr`
+
+This breaks slash commands typed directly in Claude Code's prompt.
+
+### Solution 1: Source the Setup Script (Recommended)
+
+Source the provided setup script to configure your shell:
+
+```bash
+# One-time setup - add to your ~/.bashrc
+echo 'source /path/to/project/.claude/tools/claude-env-setup.sh' >> ~/.bashrc
+
+# Or source it manually in current session
+source .claude/tools/claude-env-setup.sh
+```
+
+This creates an alias that automatically disables path conversion for the `claude` command.
+
+### Solution 2: Add Alias to ~/.bashrc
+
+Add this to your `~/.bashrc` to launch Claude with path conversion disabled:
+
+```bash
+# Claude Code wrapper - disable MSYS path conversion
+alias claude='MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL="*" command claude'
+```
+
+Then restart Git Bash or run `source ~/.bashrc`.
+
+### Solution 3: Use the Launcher Script
+
+Use the provided launcher script instead of the `claude` command directly:
+
+```bash
+# Run from project root
+.claude/tools/claude-launcher.sh
+
+# Or add an alias to your ~/.bashrc
+alias claude='/path/to/project/.claude/tools/claude-launcher.sh'
+```
+
+The launcher script:
+
+- Sets `MSYS_NO_PATHCONV=1` automatically
+- Finds Claude executable reliably (handles nvm, npm global, etc.)
+- Uses winpty if available for proper terminal handling
+
+### Solution 4: Global Environment Variable
+
+Add to your `~/.bashrc` (has side effects for other programs):
+
+```bash
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL='*'
+```
+
+**Warning:** This affects ALL programs, which may break tools that expect path conversion (like gVim).
+
+### Solution 5: Use the Restart Script
+
+The `restart-with-skill.sh` script automatically detects and fixes converted paths:
+
+```bash
+.claude/tools/restart-with-skill.sh "/test-ascii --no-restart"
+# If Git Bash converts the path, the script will detect and fix it
+```
+
+### Solution 6: Use PowerShell or cmd.exe
+
+These shells don't have MSYS path conversion:
+
+```powershell
+# PowerShell
+claude "/test-ascii"
+```
+
+### Setup Files
+
+| File                  | Purpose                                               |
+| --------------------- | ----------------------------------------------------- |
+| `claude-launcher.sh`  | Standalone launcher script with full Claude detection |
+| `claude-env-setup.sh` | Source-able script that creates an alias              |
+
+### Technical Details
+
+The path conversion is done by MSYS2's `msys-2.0.dll` when passing arguments to native Windows executables (like Node.js). Setting `MSYS_NO_PATHCONV=1` disables this conversion.
+
+References:
+
+- [MSYS2 Filesystem Paths](https://www.msys2.org/docs/filesystem-paths/)
+- [Docker Path Workaround](https://gist.github.com/borekb/cb1536a3685ca6fc0ad9a028e6a959e3)
+- [winpty Path Conversion Issue](https://github.com/rprichard/winpty/issues/146)
 
 ## Troubleshooting
 
-1. Verify the referenced wrapper files exist.
-2. Verify `.env.local` contains the expected token names.
-3. Restart the MCP client after changing tokens or `.mcp.json`.
+### MCP Server Not Connecting
+
+1. Check if the token is set correctly in `.claude/tools/.env.local`
+2. Verify the token has the required permissions/scopes
+3. Restart Claude Code after adding/changing tokens
+4. Check Claude Code logs for specific error messages
+
+### Linear MCP Issues
+
+- API key must be a Personal API Key from https://linear.app/settings/api
+- Key format: `lin_api_xxxxxxxxxxxx`
+- Token must not be expired
+- If you see "LINEAR_API_KEY not found" error, ensure the token is set in either:
+  - Project root `.env.local`, or
+  - `.claude/tools/.env.local`
+- Token can be quoted or unquoted in `.env.local` files (both formats are supported)
+- Image download requires proper authentication - Linear uses API key WITHOUT "Bearer" prefix in headers
+- If `linear_get_comments_images` returns no images but you see them in Linear:
+  - Verify images are embedded as markdown: `![alt](url)`
+  - Check image URLs are accessible (not private attachments)
+  - Linear image URLs should be from `uploads.linear.app` domain
+
+### GitHub MCP Issues
+
+- Ensure token has `repo` scope for full repository access
+- Token must not be expired
+- For fine-grained tokens, ensure repository access is configured
+- Token can be quoted or unquoted in `.env.local` files (both formats are supported)
+- Script automatically handles Windows `.cmd` file execution
+
+### Vercel MCP Issues
+
+- Token must be valid and not expired
+- Check team/account permissions if accessing team resources
+- Requires Node.js v20 or greater
+- If you see "VERCEL_TOKEN not found" error, ensure the token is set in either:
+  - Project root `.env.local`, or
+  - `.claude/tools/.env.local`
+- Token can be quoted or unquoted in `.env.local` files
+
+### LogRocket MCP Issues
+
+- API key must be in format: `org_id:app_id:secret_key`
+  - Example: `abc123:my-app:secretkey456`
+- Get API key from LogRocket Settings > API Keys
+- If using `logrocket_export_sessions` and getting empty results:
+  - This API is deprecated for SaaS customers
+  - Use Streaming Data Export service instead
+  - See: https://docs.logrocket.com/docs/streaming-data-export
+- Token can be quoted or unquoted in `.env.local` files
+
+### Slash Commands Converted to Windows Paths
+
+**Symptom:** When typing `/skill-name` in Claude Code, it appears as `C:/Program Files/Git/skill-name`.
+
+**Cause:** Git Bash's MSYS path conversion automatically converts paths starting with `/` to Windows paths.
+
+**Solutions:**
+
+1. **Add wrapper to ~/.bashrc** (recommended):
+
+   ```bash
+   claude() { MSYS_NO_PATHCONV=1 command claude "$@"; }
+   ```
+
+2. **Use restart script** - it auto-detects and fixes converted paths:
+
+   ```bash
+   .claude/tools/restart-with-skill.sh "/skill-name"
+   ```
+
+3. **Use PowerShell or cmd.exe** instead of Git Bash
+
+See "Git Bash Path Conversion Fix" section above for more details.

--- a/.claude/tools/claude-env-setup.sh
+++ b/.claude/tools/claude-env-setup.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# claude-env-setup.sh - Setup environment for Claude Code on Git Bash/MSYS
+#
+# This script sets up the environment to prevent MSYS path conversion
+# which breaks Claude Code skill invocations (e.g., /skill-name).
+#
+# USAGE:
+#   Option 1: Source in current session
+#     source .claude/tools/claude-env-setup.sh
+#
+#   Option 2: Add to ~/.bashrc for permanent setup
+#     echo 'source /path/to/project/.claude/tools/claude-env-setup.sh' >> ~/.bashrc
+#
+#   Option 3: Copy the alias directly to ~/.bashrc
+#     alias claude='MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL="*" command claude'
+#
+
+# =============================================================================
+# DETECT ENVIRONMENT
+# =============================================================================
+# Only apply fixes on MSYS/Git Bash (Windows)
+if [[ "$OSTYPE" != "msys" ]] && [[ "$OSTYPE" != "mingw"* ]] && [[ "$OSTYPE" != "cygwin" ]]; then
+    # Not on Windows/MSYS - no fixes needed
+    return 0 2>/dev/null || exit 0
+fi
+
+# =============================================================================
+# CREATE CLAUDE ALIAS
+# =============================================================================
+# This alias wraps the claude command with MSYS path conversion disabled.
+#
+# MSYS_NO_PATHCONV=1     - Disables "/" to "C:/Program Files/Git/" conversion
+# MSYS2_ARG_CONV_EXCL=*  - Excludes all arguments from path conversion
+# command claude         - Uses 'command' to bypass any existing aliases
+#
+alias claude='MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL="*" command claude'
+
+# =============================================================================
+# OPTIONAL: GLOBAL SETTINGS
+# =============================================================================
+# Uncomment these lines to disable path conversion for ALL commands in this shell.
+# Warning: This may affect other programs that rely on path conversion.
+#
+# export MSYS_NO_PATHCONV=1
+# export MSYS2_ARG_CONV_EXCL='*'
+
+# =============================================================================
+# FEEDBACK
+# =============================================================================
+echo -e "\033[32m✓ Claude Code MSYS fix loaded\033[0m"
+echo -e "\033[90m  Path conversion disabled for 'claude' command\033[0m"
+echo -e "\033[90m  Skills like /test-ascii will now work correctly\033[0m"

--- a/.claude/tools/claude-launcher.sh
+++ b/.claude/tools/claude-launcher.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# claude-launcher.sh - Launch Claude Code with MSYS path conversion disabled
+#
+# PROBLEM: Git Bash/MSYS converts paths starting with "/" to Windows paths.
+#          "/skill-name" becomes "C:/Program Files/Git/skill-name"
+#          This breaks Claude Code skill invocations.
+#
+# SOLUTION: Set MSYS_NO_PATHCONV=1 before launching Claude.
+#           This disables the automatic path conversion.
+#
+# USAGE:
+#   Option 1: Run this script directly
+#     .claude/tools/claude-launcher.sh [claude-args]
+#
+#   Option 2: Add alias to ~/.bashrc (recommended)
+#     alias claude='MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL="*" command claude'
+#
+#   Option 3: Source the setup script
+#     source .claude/tools/claude-env-setup.sh
+#
+
+# =============================================================================
+# DISABLE MSYS PATH CONVERSION
+# =============================================================================
+# MSYS_NO_PATHCONV=1  - Disables "/" to "C:/Program Files/Git/" conversion
+# MSYS2_ARG_CONV_EXCL - Excludes specific patterns from conversion (* = all)
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL='*'
+
+# =============================================================================
+# FIND CLAUDE EXECUTABLE
+# =============================================================================
+CLAUDE_PATH=""
+CLAUDE_CLI_JS=""
+
+# Method 1: Check if claude is in PATH
+if command -v claude &> /dev/null; then
+    CLAUDE_PATH=$(command -v claude)
+fi
+
+# Method 2: Try to find CLI.js directly (most reliable on Windows)
+if [ -f "/c/nvm4w/nodejs/node_modules/@anthropic-ai/claude-code/cli.js" ]; then
+    CLAUDE_CLI_JS="/c/nvm4w/nodejs/node_modules/@anthropic-ai/claude-code/cli.js"
+elif [ -n "$APPDATA" ] && [ -f "$APPDATA/npm/node_modules/@anthropic-ai/claude-code/cli.js" ]; then
+    CLAUDE_CLI_JS="$APPDATA/npm/node_modules/@anthropic-ai/claude-code/cli.js"
+elif [ -f "$HOME/.npm-global/lib/node_modules/@anthropic-ai/claude-code/cli.js" ]; then
+    CLAUDE_CLI_JS="$HOME/.npm-global/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+fi
+
+# Method 3: Try common Windows locations for claude script
+if [ -z "$CLAUDE_PATH" ]; then
+    if [ -f "/c/nvm4w/nodejs/claude" ]; then
+        CLAUDE_PATH="/c/nvm4w/nodejs/claude"
+    elif [ -n "$APPDATA" ] && [ -f "$APPDATA/npm/claude.cmd" ]; then
+        CLAUDE_PATH="$APPDATA/npm/claude.cmd"
+    elif [ -f "$HOME/.npm-global/bin/claude" ]; then
+        CLAUDE_PATH="$HOME/.npm-global/bin/claude"
+    elif where claude &> /dev/null 2>&1; then
+        CLAUDE_PATH=$(where claude 2>/dev/null | head -1 | tr -d '\r')
+    fi
+fi
+
+# =============================================================================
+# LAUNCH CLAUDE
+# =============================================================================
+# Prefer running via node + CLI.js for reliability
+# Use winpty if available for proper terminal handling
+
+if [ -n "$CLAUDE_CLI_JS" ] && command -v node &> /dev/null; then
+    if command -v winpty &> /dev/null; then
+        exec winpty node "$CLAUDE_CLI_JS" "$@"
+    else
+        exec node "$CLAUDE_CLI_JS" "$@"
+    fi
+elif [ -n "$CLAUDE_PATH" ]; then
+    if command -v winpty &> /dev/null; then
+        exec winpty "$CLAUDE_PATH" "$@"
+    else
+        exec "$CLAUDE_PATH" "$@"
+    fi
+else
+    echo -e "\033[31m❌ ERROR: Claude Code not found\033[0m"
+    echo ""
+    echo "Searched locations:"
+    echo "  - PATH (command -v claude)"
+    echo "  - /c/nvm4w/nodejs/claude"
+    [ -n "$APPDATA" ] && echo "  - \$APPDATA/npm/claude.cmd"
+    echo "  - ~/.npm-global/bin/claude"
+    echo ""
+    echo "Please install Claude Code:"
+    echo "  npm install -g @anthropic-ai/claude-code"
+    exit 1
+fi

--- a/.claude/tools/detect-claude-flags.ps1
+++ b/.claude/tools/detect-claude-flags.ps1
@@ -1,0 +1,59 @@
+# detect-claude-flags.ps1
+# Detects how Claude Code was started and outputs the flags
+
+# Strategy: Try multiple detection methods in order of preference
+# 1. Native claude.exe (new method - installed via installer)
+# 2. node cli.js (old method - npm global install)
+
+$flags = ""
+
+# Method 1: Look for claude.exe (native executable)
+# Note: Allow optional trailing quote for quoted paths (e.g., "C:\Program Files\claude.exe")
+$claudeExe = Get-CimInstance Win32_Process | Where-Object {
+    $_.CommandLine -match '\\claude\.exe(?:"|\s)' -or $_.CommandLine -match '/claude\.exe(?:"|\s)'
+}
+
+if ($claudeExe) {
+    $process = $claudeExe | Select-Object -First 1
+    $cmdLine = $process.CommandLine
+
+    # Extract flags after claude.exe (handle both quoted and unquoted paths)
+    # Pattern: claude.exe" [flags] or claude.exe [flags]
+    if ($cmdLine -match 'claude\.exe"?\s+(.+)$') {
+        $flags = $Matches[1]
+
+        # Remove the prompt/command part (anything in quotes at the end)
+        $flags = $flags -replace "'[^']*'$", ""
+        $flags = $flags -replace '"[^"]*"$', ""
+        $flags = $flags.Trim()
+    }
+}
+
+# Method 2: Look for node cli.js (npm global install method)
+if (-not $flags) {
+    $cliJs = Get-CimInstance Win32_Process | Where-Object {
+        $_.CommandLine -match 'claude-code.cli\.js' -or $_.CommandLine -match 'claude-code\\cli\.js'
+    }
+
+    if ($cliJs) {
+        $process = $cliJs | Select-Object -First 1
+        $cmdLine = $process.CommandLine
+
+        # Extract flags after cli.js
+        if ($cmdLine -match 'cli\.js\s+(.+)$') {
+            $flags = $Matches[1]
+
+            # Remove the prompt/command part (anything in quotes at the end)
+            $flags = $flags -replace "'[^']*'$", ""
+            $flags = $flags -replace '"[^"]*"$', ""
+            $flags = $flags.Trim()
+        }
+    }
+}
+
+# Output result
+if ($flags) {
+    Write-Output $flags
+} else {
+    Write-Output "NONE"
+}

--- a/.claude/tools/detect-claude-flags.sh
+++ b/.claude/tools/detect-claude-flags.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# detect-claude-flags.sh
+# Detects how Claude Code was started and outputs the flags
+# Usage: .claude/tools/detect-claude-flags.sh
+
+# Use the existing PowerShell script which handles escaping correctly
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Convert Unix-style path to Windows-style for PowerShell
+# /z/Github/... -> Z:/Github/...
+# /c/Users/... -> C:/Users/...
+WIN_SCRIPT_DIR="$SCRIPT_DIR"
+if [[ "$SCRIPT_DIR" =~ ^/([a-z])/ ]]; then
+    drive_letter="${BASH_REMATCH[1]}"
+    WIN_SCRIPT_DIR="${drive_letter^^}:${SCRIPT_DIR:2}"
+fi
+
+# Run PowerShell with Windows-style path
+# Filter out any copyright banner that might appear
+raw_output=$(powershell -NoProfile -NoLogo -ExecutionPolicy Bypass -File "$WIN_SCRIPT_DIR/detect-claude-flags.ps1" 2>/dev/null)
+
+# Process the output: remove carriage returns, filter to only valid flag lines
+flags=""
+while IFS= read -r line; do
+    line=$(echo "$line" | tr -d '\r' | xargs)
+    # Skip empty lines and known banner lines
+    if [ -z "$line" ]; then
+        continue
+    fi
+    if [[ "$line" == Windows* ]] || [[ "$line" == PowerShell* ]] || [[ "$line" == Copyright* ]] || [[ "$line" == Install* ]] || [[ "$line" == https* ]]; then
+        continue
+    fi
+    # Valid output - either a flag or NONE
+    flags="$line"
+    break
+done <<< "$raw_output"
+
+if [ -n "$flags" ] && [ "$flags" != "NONE" ]; then
+    echo "$flags"
+else
+    echo "NONE"
+fi

--- a/.claude/tools/encode-prompt.sh
+++ b/.claude/tools/encode-prompt.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# encode-prompt.sh - Safely encode a prompt to avoid MSYS path conversion
+# Usage:
+#   source .claude/tools/encode-prompt.sh "/test-ascii --no-restart"
+#   # Then call restart-with-skill.sh - it reads CLAUDE_PROMPT_ENCODED
+#
+# Or in a single line:
+#   eval "$(.claude/tools/encode-prompt.sh "/test-ascii --no-restart")" && bash .claude/tools/restart-with-skill.sh
+#
+# This script outputs an export command that sets CLAUDE_PROMPT_ENCODED
+# The restart-with-skill.sh script checks for this env var first.
+
+# CRITICAL: Disable MSYS path conversion for this script
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL='*'
+
+# =============================================================================
+# FIX MSYS PATH CONVERSION (recovery if it already happened)
+# =============================================================================
+fix_msys_path() {
+    local input="$1"
+
+    # Pattern 1: Windows-style Git path (C:/Program Files/Git/skill-name)
+    if [[ "$input" =~ ^[A-Za-z]:/Program\ Files(/\ \(x86\))?/Git/(.+)$ ]]; then
+        echo "/${BASH_REMATCH[2]}"
+        return
+    fi
+
+    # Pattern 2: Windows-style Git path without spaces (C:/Git/skill-name)
+    if [[ "$input" =~ ^[A-Za-z]:/Git/(.+)$ ]]; then
+        echo "/${BASH_REMATCH[1]}"
+        return
+    fi
+
+    # Pattern 3: MSYS-style path (/c/Program Files/Git/skill-name)
+    if [[ "$input" =~ ^/[a-z]/Program\ Files(/\ \(x86\))?/Git/(.+)$ ]]; then
+        echo "/${BASH_REMATCH[2]}"
+        return
+    fi
+
+    # Pattern 4: MSYS mingw64 path (/mingw64/skill-name becomes /skill-name)
+    if [[ "$input" =~ ^/mingw64/(.+)$ ]]; then
+        echo "/${BASH_REMATCH[1]}"
+        return
+    fi
+
+    # Pattern 5: MSYS usr path (/usr/skill-name becomes /skill-name)
+    if [[ "$input" =~ ^/usr/(.+)$ ]]; then
+        echo "/${BASH_REMATCH[1]}"
+        return
+    fi
+
+    # No conversion needed
+    echo "$input"
+}
+
+# Get prompt from arguments
+PROMPT="$*"
+
+if [ -z "$PROMPT" ]; then
+    echo "export CLAUDE_PROMPT_ENCODED=''"
+    exit 0
+fi
+
+# Fix any path conversion that already happened
+FIXED_PROMPT=$(fix_msys_path "$PROMPT")
+
+if [ "$PROMPT" != "$FIXED_PROMPT" ]; then
+    echo "# MSYS path conversion detected and fixed:" >&2
+    echo "#   Original: $PROMPT" >&2
+    echo "#   Fixed:    $FIXED_PROMPT" >&2
+fi
+
+# Base64 encode to completely prevent any further conversion
+# Use -w0 to output on single line (GNU coreutils)
+# Fall back to no -w flag for BSD/macOS
+ENCODED=$(printf '%s' "$FIXED_PROMPT" | base64 -w0 2>/dev/null || printf '%s' "$FIXED_PROMPT" | base64 | tr -d '\n')
+
+# Output export command - can be eval'd or sourced
+echo "export CLAUDE_PROMPT_ENCODED='$ENCODED'"

--- a/.claude/tools/find-claude-process.ps1
+++ b/.claude/tools/find-claude-process.ps1
@@ -1,0 +1,9 @@
+# Find Claude process and show command line
+Get-Process node -ErrorAction SilentlyContinue | ForEach-Object {
+    $cmdLine = (Get-CimInstance Win32_Process -Filter "ProcessId=$($_.Id)").CommandLine
+    if ($cmdLine -match 'anthropic|claude-code') {
+        Write-Output "PID: $($_.Id)"
+        Write-Output "CMD: $cmdLine"
+        Write-Output "---"
+    }
+}

--- a/.claude/tools/git-mcp.mjs
+++ b/.claude/tools/git-mcp.mjs
@@ -87,7 +87,7 @@ const helperScriptPath = path.join(
   os.tmpdir(),
   isWindows
     ? `git-askpass-helper-${process.pid}.bat`
-    : `git-askpass-helper-${process.pid}.sh`,
+    : `git-askpass-helper-${process.pid}.sh`
 );
 
 // Create helper script content based on platform
@@ -121,31 +121,35 @@ process.on("SIGTERM", () => {
 });
 
 // Spawn git-mcp-server with environment configured for authentication
-const gitMcpServer = spawn("npx", ["@cyanheads/git-mcp-server@latest"], {
-  env: {
-    ...process.env,
-    // Authentication via GIT_ASKPASS (secure - no command-line exposure)
-    GIT_ASKPASS: helperScriptPath,
-    GIT_TERMINAL_PROMPT: "0", // Disable interactive prompts
+const gitMcpServer = spawn(
+  "npx",
+  ["@cyanheads/git-mcp-server@latest"],
+  {
+    env: {
+      ...process.env,
+      // Authentication via GIT_ASKPASS (secure - no command-line exposure)
+      GIT_ASKPASS: helperScriptPath,
+      GIT_TERMINAL_PROMPT: "0", // Disable interactive prompts
 
-    // MCP transport configuration
-    MCP_TRANSPORT_TYPE: "stdio",
-    MCP_LOG_LEVEL: process.env.MCP_LOG_LEVEL || "error",
+      // MCP transport configuration
+      MCP_TRANSPORT_TYPE: "stdio",
+      MCP_LOG_LEVEL: process.env.MCP_LOG_LEVEL || "error",
 
-    // Git identity (falls back to global git config if not set)
-    GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME || undefined,
-    GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL || undefined,
+      // Git identity (falls back to global git config if not set)
+      GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME || undefined,
+      GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL || undefined,
 
-    // Optional: Restrict operations to project directory for security
-    GIT_BASE_DIR: projectRoot,
+      // Optional: Restrict operations to project directory for security
+      GIT_BASE_DIR: projectRoot,
 
-    // Optional: Commit signing
-    GIT_SIGN_COMMITS: process.env.GIT_SIGN_COMMITS || "false",
-  },
-  stdio: "inherit",
-  cwd: projectRoot,
-  shell: isWindows, // Required on Windows to find npx in PATH
-});
+      // Optional: Commit signing
+      GIT_SIGN_COMMITS: process.env.GIT_SIGN_COMMITS || "false",
+    },
+    stdio: "inherit",
+    cwd: projectRoot,
+    shell: isWindows, // Required on Windows to find npx in PATH
+  }
+);
 
 // Handle server process events
 gitMcpServer.on("error", (error) => {

--- a/.claude/tools/github-unified-mcp.mjs
+++ b/.claude/tools/github-unified-mcp.mjs
@@ -40,10 +40,8 @@ function loadEnvFile(filePath) {
     const match = trimmed.match(/^GITHUB_PERSONAL_ACCESS_TOKEN=(.+)$/);
     if (match) {
       let token = match[1].trim();
-      if (
-        (token.startsWith('"') && token.endsWith('"')) ||
-        (token.startsWith("'") && token.endsWith("'"))
-      ) {
+      if ((token.startsWith('"') && token.endsWith('"')) ||
+          (token.startsWith("'") && token.endsWith("'"))) {
         token = token.slice(1, -1);
       }
       process.env.GITHUB_PERSONAL_ACCESS_TOKEN = token;
@@ -66,9 +64,7 @@ const GITHUB_API = "https://api.github.com";
 
 // GitHub API helper
 async function githubFetch(endpoint, options = {}) {
-  const url = endpoint.startsWith("http")
-    ? endpoint
-    : `${GITHUB_API}${endpoint}`;
+  const url = endpoint.startsWith("http") ? endpoint : `${GITHUB_API}${endpoint}`;
   const response = await fetch(url, {
     ...options,
     headers: {
@@ -81,12 +77,8 @@ async function githubFetch(endpoint, options = {}) {
   });
 
   if (!response.ok) {
-    const error = await response
-      .json()
-      .catch(() => ({ message: response.statusText }));
-    throw new Error(
-      `GitHub API error (${response.status}): ${error.message || JSON.stringify(error)}`,
-    );
+    const error = await response.json().catch(() => ({ message: response.statusText }));
+    throw new Error(`GitHub API error (${response.status}): ${error.message || JSON.stringify(error)}`);
   }
 
   const text = await response.text();
@@ -102,18 +94,9 @@ const TOOLS = [
     inputSchema: {
       type: "object",
       properties: {
-        query: {
-          type: "string",
-          description: "Search query (see GitHub search syntax)",
-        },
-        page: {
-          type: "number",
-          description: "Page number for pagination (default: 1)",
-        },
-        perPage: {
-          type: "number",
-          description: "Number of results per page (default: 30, max: 100)",
-        },
+        query: { type: "string", description: "Search query (see GitHub search syntax)" },
+        page: { type: "number", description: "Page number for pagination (default: 1)" },
+        perPage: { type: "number", description: "Number of results per page (default: 30, max: 100)" },
       },
       required: ["query"],
     },
@@ -126,10 +109,7 @@ const TOOLS = [
       properties: {
         name: { type: "string", description: "Repository name" },
         description: { type: "string", description: "Repository description" },
-        private: {
-          type: "boolean",
-          description: "Whether the repository should be private",
-        },
+        private: { type: "boolean", description: "Whether the repository should be private" },
         autoInit: { type: "boolean", description: "Initialize with README.md" },
       },
       required: ["name"],
@@ -137,20 +117,13 @@ const TOOLS = [
   },
   {
     name: "fork_repository",
-    description:
-      "Fork a GitHub repository to your account or specified organization",
+    description: "Fork a GitHub repository to your account or specified organization",
     inputSchema: {
       type: "object",
       properties: {
-        owner: {
-          type: "string",
-          description: "Repository owner (username or organization)",
-        },
+        owner: { type: "string", description: "Repository owner (username or organization)" },
         repo: { type: "string", description: "Repository name" },
-        organization: {
-          type: "string",
-          description: "Optional: organization to fork to",
-        },
+        organization: { type: "string", description: "Optional: organization to fork to" },
       },
       required: ["owner", "repo"],
     },
@@ -164,11 +137,7 @@ const TOOLS = [
         owner: { type: "string", description: "Repository owner" },
         repo: { type: "string", description: "Repository name" },
         branch: { type: "string", description: "Name for the new branch" },
-        from_branch: {
-          type: "string",
-          description:
-            "Source branch to create from (defaults to default branch)",
-        },
+        from_branch: { type: "string", description: "Source branch to create from (defaults to default branch)" },
       },
       required: ["owner", "repo", "branch"],
     },
@@ -260,30 +229,16 @@ const TOOLS = [
   },
   {
     name: "get_issue_comments",
-    description:
-      "Get comments on an issue or pull request. Note: GitHub treats PR conversation comments as issue comments. Use this to fetch bot comments (e.g. from Claude, Vercel, Linear) and general discussion comments on PRs.",
+    description: "Get comments on an issue or pull request. Note: GitHub treats PR conversation comments as issue comments. Use this to fetch bot comments (e.g. from Claude, Vercel, Linear) and general discussion comments on PRs.",
     inputSchema: {
       type: "object",
       properties: {
         owner: { type: "string" },
         repo: { type: "string" },
-        issue_number: {
-          type: "number",
-          description: "Issue or pull request number",
-        },
-        since: {
-          type: "string",
-          description:
-            "Only show comments updated after this time (ISO 8601 format)",
-        },
-        page: {
-          type: "number",
-          description: "Page number for pagination (default: 1)",
-        },
-        per_page: {
-          type: "number",
-          description: "Results per page (default: 30, max: 100)",
-        },
+        issue_number: { type: "number", description: "Issue or pull request number" },
+        since: { type: "string", description: "Only show comments updated after this time (ISO 8601 format)" },
+        page: { type: "number", description: "Page number for pagination (default: 1)" },
+        per_page: { type: "number", description: "Results per page (default: 30, max: 100)" },
       },
       required: ["owner", "repo", "issue_number"],
     },
@@ -303,16 +258,12 @@ const TOOLS = [
   },
   {
     name: "search_issues",
-    description:
-      "Search for issues and pull requests across GitHub repositories",
+    description: "Search for issues and pull requests across GitHub repositories",
     inputSchema: {
       type: "object",
       properties: {
         q: { type: "string", description: "Search query" },
-        sort: {
-          type: "string",
-          enum: ["comments", "reactions", "created", "updated"],
-        },
+        sort: { type: "string", enum: ["comments", "reactions", "created", "updated"] },
         order: { type: "string", enum: ["asc", "desc"] },
         page: { type: "number" },
         per_page: { type: "number" },
@@ -330,14 +281,8 @@ const TOOLS = [
         owner: { type: "string", description: "Repository owner" },
         repo: { type: "string", description: "Repository name" },
         title: { type: "string", description: "Pull request title" },
-        head: {
-          type: "string",
-          description: "Branch where your changes are implemented",
-        },
-        base: {
-          type: "string",
-          description: "Branch you want changes pulled into",
-        },
+        head: { type: "string", description: "Branch where your changes are implemented" },
+        base: { type: "string", description: "Branch you want changes pulled into" },
         body: { type: "string", description: "Pull request body/description" },
         draft: { type: "boolean", description: "Create as draft pull request" },
         maintainer_can_modify: { type: "boolean" },
@@ -356,10 +301,7 @@ const TOOLS = [
         state: { type: "string", enum: ["open", "closed", "all"] },
         head: { type: "string" },
         base: { type: "string" },
-        sort: {
-          type: "string",
-          enum: ["created", "updated", "popularity", "long-running"],
-        },
+        sort: { type: "string", enum: ["created", "updated", "popularity", "long-running"] },
         direction: { type: "string", enum: ["asc", "desc"] },
         page: { type: "number" },
         per_page: { type: "number" },
@@ -439,8 +381,7 @@ const TOOLS = [
   },
   {
     name: "get_pull_request_status",
-    description:
-      "Get the combined status of all status checks for a pull request",
+    description: "Get the combined status of all status checks for a pull request",
     inputSchema: {
       type: "object",
       properties: {
@@ -461,10 +402,7 @@ const TOOLS = [
         repo: { type: "string" },
         pull_number: { type: "number" },
         body: { type: "string", description: "Review body text" },
-        event: {
-          type: "string",
-          enum: ["APPROVE", "REQUEST_CHANGES", "COMMENT"],
-        },
+        event: { type: "string", enum: ["APPROVE", "REQUEST_CHANGES", "COMMENT"] },
         commit_id: { type: "string", description: "SHA of commit to review" },
         comments: {
           type: "array",
@@ -501,8 +439,7 @@ const TOOLS = [
   },
   {
     name: "update_pull_request_branch",
-    description:
-      "Update a pull request branch with the latest changes from the base branch",
+    description: "Update a pull request branch with the latest changes from the base branch",
     inputSchema: {
       type: "object",
       properties: {
@@ -580,9 +517,7 @@ async function handleTool(name, args) {
     case "create_branch": {
       // First get the SHA of the source branch
       const sourceBranch = args.from_branch || "main";
-      const ref = await githubFetch(
-        `/repos/${args.owner}/${args.repo}/git/ref/heads/${sourceBranch}`,
-      );
+      const ref = await githubFetch(`/repos/${args.owner}/${args.repo}/git/ref/heads/${sourceBranch}`);
 
       // Create new branch
       return await githubFetch(`/repos/${args.owner}/${args.repo}/git/refs`, {
@@ -599,9 +534,7 @@ async function handleTool(name, args) {
       if (args.sha) params.set("sha", args.sha);
       if (args.page) params.set("page", String(args.page));
       if (args.perPage) params.set("per_page", String(args.perPage));
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/commits?${params}`,
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/commits?${params}`);
     }
 
     // Issue tools
@@ -626,9 +559,7 @@ async function handleTool(name, args) {
       if (args.since) params.set("since", args.since);
       if (args.page) params.set("page", String(args.page));
       if (args.per_page) params.set("per_page", String(args.per_page));
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/issues?${params}`,
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/issues?${params}`);
     }
 
     case "update_issue": {
@@ -639,23 +570,17 @@ async function handleTool(name, args) {
       if (args.labels) body.labels = args.labels;
       if (args.assignees) body.assignees = args.assignees;
       if (args.milestone !== undefined) body.milestone = args.milestone;
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/issues/${args.issue_number}`,
-        {
-          method: "PATCH",
-          body: JSON.stringify(body),
-        },
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/issues/${args.issue_number}`, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      });
     }
 
     case "add_issue_comment": {
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/issues/${args.issue_number}/comments`,
-        {
-          method: "POST",
-          body: JSON.stringify({ body: args.body }),
-        },
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/issues/${args.issue_number}/comments`, {
+        method: "POST",
+        body: JSON.stringify({ body: args.body }),
+      });
     }
 
     case "get_issue_comments": {
@@ -663,15 +588,11 @@ async function handleTool(name, args) {
       if (args.since) params.set("since", args.since);
       if (args.page) params.set("page", String(args.page));
       if (args.per_page) params.set("per_page", String(args.per_page));
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/issues/${args.issue_number}/comments?${params}`,
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/issues/${args.issue_number}/comments?${params}`);
     }
 
     case "get_issue": {
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/issues/${args.issue_number}`,
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/issues/${args.issue_number}`);
     }
 
     case "search_issues": {
@@ -692,8 +613,7 @@ async function handleTool(name, args) {
       };
       if (args.body) body.body = args.body;
       if (args.draft !== undefined) body.draft = args.draft;
-      if (args.maintainer_can_modify !== undefined)
-        body.maintainer_can_modify = args.maintainer_can_modify;
+      if (args.maintainer_can_modify !== undefined) body.maintainer_can_modify = args.maintainer_can_modify;
       return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls`, {
         method: "POST",
         body: JSON.stringify(body),
@@ -709,15 +629,11 @@ async function handleTool(name, args) {
       if (args.direction) params.set("direction", args.direction);
       if (args.page) params.set("page", String(args.page));
       if (args.per_page) params.set("per_page", String(args.per_page));
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/pulls?${params}`,
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls?${params}`);
     }
 
     case "get_pull_request": {
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}`,
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}`);
     }
 
     case "github_update_pull_request": {
@@ -726,44 +642,30 @@ async function handleTool(name, args) {
       if (args.body) body.body = args.body;
       if (args.base) body.base = args.base;
       if (args.state) body.state = args.state;
-      if (args.maintainer_can_modify !== undefined)
-        body.maintainer_can_modify = args.maintainer_can_modify;
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}`,
-        {
-          method: "PATCH",
-          body: JSON.stringify(body),
-        },
-      );
+      if (args.maintainer_can_modify !== undefined) body.maintainer_can_modify = args.maintainer_can_modify;
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}`, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      });
     }
 
     case "get_pull_request_files": {
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/files`,
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/files`);
     }
 
     case "get_pull_request_comments": {
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/comments`,
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/comments`);
     }
 
     case "get_pull_request_reviews": {
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/reviews`,
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/reviews`);
     }
 
     case "get_pull_request_status": {
       // Get the PR first to get the head SHA
-      const pr = await githubFetch(
-        `/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}`,
-      );
+      const pr = await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}`);
       // Get combined status for the head commit
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/commits/${pr.head.sha}/status`,
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/commits/${pr.head.sha}/status`);
     }
 
     case "create_pull_request_review": {
@@ -773,13 +675,10 @@ async function handleTool(name, args) {
       };
       if (args.commit_id) body.commit_id = args.commit_id;
       if (args.comments) body.comments = args.comments;
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/reviews`,
-        {
-          method: "POST",
-          body: JSON.stringify(body),
-        },
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/reviews`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
     }
 
     case "merge_pull_request": {
@@ -787,26 +686,19 @@ async function handleTool(name, args) {
       if (args.commit_title) body.commit_title = args.commit_title;
       if (args.commit_message) body.commit_message = args.commit_message;
       if (args.merge_method) body.merge_method = args.merge_method;
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/merge`,
-        {
-          method: "PUT",
-          body: JSON.stringify(body),
-        },
-      );
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/merge`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      });
     }
 
     case "update_pull_request_branch": {
       const body = {};
-      if (args.expected_head_sha)
-        body.expected_head_sha = args.expected_head_sha;
-      return await githubFetch(
-        `/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/update-branch`,
-        {
-          method: "PUT",
-          body: JSON.stringify(body),
-        },
-      );
+      if (args.expected_head_sha) body.expected_head_sha = args.expected_head_sha;
+      return await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.pull_number}/update-branch`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      });
     }
 
     // Search tools

--- a/.claude/tools/linear-mcp.mjs
+++ b/.claude/tools/linear-mcp.mjs
@@ -1,0 +1,1731 @@
+#!/usr/bin/env node
+/**
+ * Linear MCP Server
+ *
+ * A zero-dependency MCP server using only Node.js built-ins.
+ * Implements MCP protocol (JSON-RPC 2.0 over stdio) directly.
+ * Uses Linear's GraphQL API via raw fetch calls.
+ *
+ * Based on official Linear GraphQL API and community MCP implementations:
+ * - https://linear.app/developers/graphql
+ * - https://github.com/tacticlaunch/mcp-linear
+ * - https://github.com/jerhadf/linear-mcp-server
+ *
+ * Tools Provided:
+ *
+ * User & Organization:
+ * - linear_get_viewer: Get authenticated user info
+ * - linear_get_organization: Get organization info
+ * - linear_get_users: List users in organization
+ *
+ * Teams:
+ * - linear_list_teams: List all teams
+ * - linear_get_team: Get team details with issues
+ *
+ * Issues:
+ * - linear_list_issues: List issues with filtering
+ * - linear_get_issue: Get issue by ID or identifier
+ * - linear_search_issues: Search issues with text query
+ * - linear_create_issue: Create a new issue
+ * - linear_update_issue: Update an existing issue
+ * - linear_get_user_issues: Get issues assigned to a user
+ *
+ * Issue Management:
+ * - linear_assign_issue: Assign issue to a user
+ * - linear_set_issue_priority: Set issue priority
+ * - linear_set_issue_state: Set issue workflow state
+ * - linear_archive_issue: Archive an issue
+ * - linear_add_issue_label: Add label to issue
+ * - linear_remove_issue_label: Remove label from issue
+ *
+ * Comments:
+ * - linear_create_comment: Add comment to issue
+ * - linear_get_comments: Get comments for an issue
+ *
+ * Projects:
+ * - linear_list_projects: List projects
+ * - linear_create_project: Create a new project
+ * - linear_add_issue_to_project: Add issue to project
+ *
+ * Workflow:
+ * - linear_list_workflow_states: List workflow states for a team
+ * - linear_get_labels: Get available labels
+ *
+ * Cycles:
+ * - linear_get_cycles: Get cycles for a team
+ * - linear_get_active_cycle: Get active cycle for a team
+ * - linear_add_issue_to_cycle: Add issue to a cycle
+ *
+ * Images:
+ * - linear_get_issue_images: Download images from issue description
+ * - linear_get_comments_images: Download images from issue comments
+ *
+ * Uploads:
+ * - linear_upload_image: Upload a local image to Linear's storage, returns asset URL
+ * - linear_create_comment_with_images: Upload images and create a comment with them embedded
+ *
+ * Favorites:
+ * - linear_favorite_issue: Add an issue to the authenticated user's favorites
+ *
+ * Requires LINEAR_API_KEY in .env.local or .claude/tools/.env.local
+ * Get your API key from: https://linear.app/settings/api
+ */
+/* global process */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import { createInterface } from "readline";
+
+const __toolsDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__toolsDir, "..", "..");
+
+// Load environment variables
+function loadEnvFile(filePath) {
+  if (!existsSync(filePath)) return;
+  const content = readFileSync(filePath, "utf-8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const match = trimmed.match(/^LINEAR_API_KEY=(.+)$/);
+    if (match) {
+      let token = match[1].trim();
+      if ((token.startsWith('"') && token.endsWith('"')) ||
+          (token.startsWith("'") && token.endsWith("'"))) {
+        token = token.slice(1, -1);
+      }
+      process.env.LINEAR_API_KEY = token;
+      break;
+    }
+  }
+}
+
+loadEnvFile(join(projectRoot, ".env.local"));
+loadEnvFile(join(__toolsDir, ".env.local"));
+
+const LINEAR_API_KEY = process.env.LINEAR_API_KEY;
+if (!LINEAR_API_KEY) {
+  console.error("Error: LINEAR_API_KEY not found");
+  console.error("Please set LINEAR_API_KEY in .env.local or .claude/tools/.env.local");
+  process.exit(1);
+}
+
+const LINEAR_API = "https://api.linear.app/graphql";
+
+// GraphQL helper
+async function linearQuery(query, variables = {}) {
+  const response = await fetch(LINEAR_API, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: LINEAR_API_KEY,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Linear API error (${response.status}): ${error}`);
+  }
+
+  const result = await response.json();
+  if (result.errors) {
+    throw new Error(`Linear GraphQL error: ${result.errors.map(e => e.message).join(", ")}`);
+  }
+
+  return result.data;
+}
+
+// Tool definitions
+const TOOLS = [
+  // ===== User & Organization =====
+  {
+    name: "linear_get_viewer",
+    description: "Get the currently authenticated user's information (useful for getting your user ID for assignments).",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "linear_get_organization",
+    description: "Get information about the current Linear organization.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "linear_get_users",
+    description: "Get a list of users in the Linear organization.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        includeDisabled: { type: "boolean", description: "Include disabled users (default: false)" },
+        first: { type: "number", description: "Number of users to return (default: 50)" },
+      },
+    },
+  },
+
+  // ===== Teams =====
+  {
+    name: "linear_list_teams",
+    description: "List all teams in the workspace.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "linear_get_team",
+    description: "Get detailed information about a specific team including its issues.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        teamId: { type: "string", description: "Team ID" },
+        includeIssues: { type: "boolean", description: "Include team's issues (default: false)" },
+        issueLimit: { type: "number", description: "Number of issues to return if includeIssues is true (default: 25)" },
+      },
+      required: ["teamId"],
+    },
+  },
+
+  // ===== Issues =====
+  {
+    name: "linear_list_issues",
+    description: "List issues with optional filtering by team, state, assignee, or project.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        teamId: { type: "string", description: "Filter by team ID" },
+        stateId: { type: "string", description: "Filter by state ID" },
+        assigneeId: { type: "string", description: "Filter by assignee ID" },
+        projectId: { type: "string", description: "Filter by project ID" },
+        first: { type: "number", description: "Number of issues to return (default: 50)" },
+      },
+    },
+  },
+  {
+    name: "linear_get_issue",
+    description: "Get detailed information about a specific issue by its ID or identifier (e.g., 'ENG-123').",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "Issue ID or identifier (e.g., 'ENG-123')" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "linear_search_issues",
+    description: "Search for issues using a text query. Searches in title and description.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query text" },
+        teamId: { type: "string", description: "Filter by team ID" },
+        assigneeId: { type: "string", description: "Filter by assignee ID" },
+        status: { type: "string", description: "Filter by status name" },
+        first: { type: "number", description: "Number of results (default: 25)" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "linear_create_issue",
+    description: "Create a new issue in Linear.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string", description: "Issue title" },
+        description: { type: "string", description: "Issue description (markdown supported)" },
+        teamId: { type: "string", description: "Team ID (required)" },
+        stateId: { type: "string", description: "Workflow state ID" },
+        assigneeId: { type: "string", description: "Assignee user ID" },
+        priority: { type: "number", description: "Priority (0=none, 1=urgent, 2=high, 3=normal, 4=low)" },
+        projectId: { type: "string", description: "Project ID" },
+        parentId: { type: "string", description: "Parent issue ID (for sub-issues)" },
+        labelIds: { type: "array", items: { type: "string" }, description: "Array of label IDs" },
+        cycleId: { type: "string", description: "Cycle ID to add issue to" },
+      },
+      required: ["title", "teamId"],
+    },
+  },
+  {
+    name: "linear_update_issue",
+    description: "Update an existing issue.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "Issue ID or identifier (e.g., 'ENG-123') to update" },
+        title: { type: "string", description: "New title" },
+        description: { type: "string", description: "New description" },
+        stateId: { type: "string", description: "New workflow state ID" },
+        assigneeId: { type: "string", description: "New assignee ID (use null to unassign)" },
+        priority: { type: "number", description: "New priority (0=none, 1=urgent, 2=high, 3=normal, 4=low)" },
+        projectId: { type: "string", description: "New project ID" },
+        cycleId: { type: "string", description: "New cycle ID" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "linear_get_user_issues",
+    description: "Get issues assigned to a specific user or the authenticated user.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        userId: { type: "string", description: "User ID (omit to get authenticated user's issues)" },
+        includeArchived: { type: "boolean", description: "Include archived issues (default: false)" },
+        first: { type: "number", description: "Number of issues to return (default: 50)" },
+      },
+    },
+  },
+
+  // ===== Issue Management =====
+  {
+    name: "linear_assign_issue",
+    description: "Assign an issue to a user.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier to assign" },
+        assigneeId: { type: "string", description: "User ID to assign (use null to unassign)" },
+      },
+      required: ["issueId"],
+    },
+  },
+  {
+    name: "linear_set_issue_priority",
+    description: "Set the priority of an issue.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier" },
+        priority: { type: "number", description: "Priority (0=none, 1=urgent, 2=high, 3=normal, 4=low)" },
+      },
+      required: ["issueId", "priority"],
+    },
+  },
+  {
+    name: "linear_set_issue_state",
+    description: "Set the workflow state of an issue.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier" },
+        stateId: { type: "string", description: "Workflow state ID" },
+      },
+      required: ["issueId", "stateId"],
+    },
+  },
+  {
+    name: "linear_archive_issue",
+    description: "Archive an issue.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier to archive" },
+      },
+      required: ["issueId"],
+    },
+  },
+  {
+    name: "linear_add_issue_label",
+    description: "Add a label to an issue.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier" },
+        labelId: { type: "string", description: "Label ID to add" },
+      },
+      required: ["issueId", "labelId"],
+    },
+  },
+  {
+    name: "linear_remove_issue_label",
+    description: "Remove a label from an issue.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier" },
+        labelId: { type: "string", description: "Label ID to remove" },
+      },
+      required: ["issueId", "labelId"],
+    },
+  },
+
+  // ===== Comments =====
+  {
+    name: "linear_create_comment",
+    description: "Add a comment to an issue.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier to comment on" },
+        body: { type: "string", description: "Comment body (markdown supported)" },
+      },
+      required: ["issueId", "body"],
+    },
+  },
+  {
+    name: "linear_get_comments",
+    description: "Get all comments for an issue.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier" },
+        first: { type: "number", description: "Number of comments to return (default: 50)" },
+      },
+      required: ["issueId"],
+    },
+  },
+
+  // ===== Projects =====
+  {
+    name: "linear_list_projects",
+    description: "List projects, optionally filtered by team.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        teamId: { type: "string", description: "Filter by team ID" },
+        first: { type: "number", description: "Number of projects to return (default: 50)" },
+      },
+    },
+  },
+  {
+    name: "linear_create_project",
+    description: "Create a new project in Linear.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Project name" },
+        description: { type: "string", description: "Project description" },
+        teamIds: { type: "array", items: { type: "string" }, description: "Array of team IDs this project belongs to" },
+        leadId: { type: "string", description: "Project lead user ID" },
+        state: { type: "string", description: "Project state (planned, started, paused, completed, canceled)" },
+      },
+      required: ["name", "teamIds"],
+    },
+  },
+  {
+    name: "linear_add_issue_to_project",
+    description: "Add an existing issue to a project.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier" },
+        projectId: { type: "string", description: "Project ID to add issue to" },
+      },
+      required: ["issueId", "projectId"],
+    },
+  },
+
+  // ===== Workflow & Labels =====
+  {
+    name: "linear_list_workflow_states",
+    description: "List workflow states for a team (e.g., Backlog, In Progress, Done).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        teamId: { type: "string", description: "Team ID to get states for" },
+      },
+      required: ["teamId"],
+    },
+  },
+  {
+    name: "linear_get_labels",
+    description: "Get available labels, optionally filtered by team.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        teamId: { type: "string", description: "Filter by team ID" },
+        first: { type: "number", description: "Number of labels to return (default: 100)" },
+      },
+    },
+  },
+
+  // ===== Cycles =====
+  {
+    name: "linear_get_cycles",
+    description: "Get cycles for a team.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        teamId: { type: "string", description: "Team ID to get cycles for" },
+        first: { type: "number", description: "Number of cycles to return (default: 10)" },
+      },
+      required: ["teamId"],
+    },
+  },
+  {
+    name: "linear_get_active_cycle",
+    description: "Get the currently active cycle for a team.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        teamId: { type: "string", description: "Team ID to get active cycle for" },
+      },
+      required: ["teamId"],
+    },
+  },
+  {
+    name: "linear_add_issue_to_cycle",
+    description: "Add an issue to a cycle.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier" },
+        cycleId: { type: "string", description: "Cycle ID to add issue to" },
+      },
+      required: ["issueId", "cycleId"],
+    },
+  },
+
+  // ===== Images =====
+  {
+    name: "linear_get_issue_images",
+    description: "Download images embedded in an issue's description. Parses markdown image syntax and downloads files to the specified directory.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "Issue ID or identifier (e.g., 'CLA-1234')" },
+        outputDir: { type: "string", description: "Directory to save downloaded images (will be created if it doesn't exist)" },
+      },
+      required: ["id", "outputDir"],
+    },
+  },
+  {
+    name: "linear_get_comments_images",
+    description: "Download images embedded in an issue's comments. Parses markdown image syntax and downloads files to the specified directory.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier (e.g., 'CLA-1234')" },
+        outputDir: { type: "string", description: "Directory to save downloaded images (will be created if it doesn't exist)" },
+      },
+      required: ["issueId", "outputDir"],
+    },
+  },
+
+  // ===== Uploads =====
+  {
+    name: "linear_upload_image",
+    description: "Upload a local image file to Linear's storage and return the asset URL. The returned URL can be used in markdown comments/descriptions with ![alt](url) syntax.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        filePath: { type: "string", description: "Absolute path to the local image file to upload" },
+        filename: { type: "string", description: "Optional filename override (defaults to original filename)" },
+      },
+      required: ["filePath"],
+    },
+  },
+  {
+    name: "linear_create_comment_with_images",
+    description: "Upload local images to Linear and create a comment on an issue with the images embedded. Images are uploaded first, then referenced in the comment body using markdown image syntax.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier (e.g., 'CLA-1234')" },
+        body: { type: "string", description: "Comment body in markdown. Use {image:N} placeholders (1-indexed) where images should appear, e.g., 'Here is the screenshot:\\n\\n{image:1}\\n\\nAnd another:\\n\\n{image:2}'" },
+        imagePaths: {
+          type: "array",
+          items: { type: "string" },
+          description: "Array of absolute paths to local image files to upload and embed",
+        },
+      },
+      required: ["issueId", "body", "imagePaths"],
+    },
+  },
+
+  // ===== Favorites =====
+  {
+    name: "linear_favorite_issue",
+    description: "Add an issue to the authenticated user's favorites (starred items). The issue appears in the user's favorites sidebar in Linear.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issueId: { type: "string", description: "Issue ID or identifier (e.g., 'CLA-1234') to favorite" },
+      },
+      required: ["issueId"],
+    },
+  },
+];
+
+// Helper to get issue ID from identifier (e.g., "ENG-123")
+async function resolveIssueId(idOrIdentifier) {
+  if (!idOrIdentifier.includes("-")) {
+    return idOrIdentifier; // Already an ID
+  }
+
+  const data = await linearQuery(`
+    query($identifier: String!) {
+      issue(id: $identifier) {
+        id
+      }
+    }
+  `, { identifier: idOrIdentifier });
+
+  if (!data.issue) {
+    throw new Error(`Issue not found: ${idOrIdentifier}`);
+  }
+
+  return data.issue.id;
+}
+
+// Helper to extract image URLs from markdown text
+function extractMarkdownImages(text) {
+  if (!text) return [];
+  // Match ![alt text](url) pattern
+  const regex = /!\[([^\]]*)\]\(([^)]+)\)/g;
+  const images = [];
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    images.push({
+      alt: match[1],
+      url: match[2],
+    });
+  }
+  return images;
+}
+
+// Helper to determine if a URL points to a trusted Linear asset host
+function isLinearAssetUrl(url) {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    return (
+      hostname === "linear.app" ||
+      hostname === "api.linear.app" ||
+      hostname.endsWith(".linear.app") ||
+      hostname === "linearusercontent.com" ||
+      hostname.endsWith(".linearusercontent.com")
+    );
+  } catch {
+    // If URL parsing fails, treat as untrusted and do not send auth
+    return false;
+  }
+}
+
+// Helper to validate outputDir stays within project root (prevent path traversal)
+function validateOutputDir(outputDir) {
+  const resolved = resolve(projectRoot, outputDir);
+  const normalizedRoot = resolve(projectRoot);
+
+  // Ensure the resolved path is within projectRoot
+  if (!resolved.startsWith(normalizedRoot + "/") && !resolved.startsWith(normalizedRoot + "\\") && resolved !== normalizedRoot) {
+    throw new Error(`Security error: outputDir must be within project root. Got: ${outputDir}`);
+  }
+
+  return resolved;
+}
+
+// Helper to download an image and save to disk
+async function downloadImage(url, outputPath) {
+  const fetchOptions = {};
+
+  // Only send Authorization header for known Linear asset hosts
+  // This prevents leaking the API key to external image hosts
+  if (LINEAR_API_KEY && isLinearAssetUrl(url)) {
+    fetchOptions.headers = {
+      Authorization: LINEAR_API_KEY,
+    };
+  }
+
+  const response = await fetch(url, fetchOptions);
+
+  if (!response.ok) {
+    throw new Error(`Failed to download image: ${response.status} ${response.statusText}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  writeFileSync(outputPath, buffer);
+
+  return {
+    path: outputPath,
+    size: buffer.length,
+    contentType: response.headers.get("content-type"),
+  };
+}
+
+// Helper to sanitize filename
+function sanitizeFilename(filename) {
+  // Remove or replace problematic characters
+  return filename
+    .replace(/[<>:"/\\|?*]/g, "_")
+    .replace(/\s+/g, "_")
+    .substring(0, 200); // Limit length
+}
+
+// Helper to upload a file to Linear's storage
+async function uploadFileToLinear(filePath, filenameOverride) {
+  // Validate path is within project root
+  const resolvedPath = resolve(filePath);
+
+  if (!existsSync(resolvedPath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+
+  const fileBuffer = readFileSync(resolvedPath);
+  const fileSize = fileBuffer.length;
+  const filename = filenameOverride || resolvedPath.split(/[/\\]/).pop();
+
+  // Determine content type from extension
+  const ext = filename.split(".").pop().toLowerCase();
+  const mimeTypes = {
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    gif: "image/gif",
+    webp: "image/webp",
+    svg: "image/svg+xml",
+    bmp: "image/bmp",
+    pdf: "application/pdf",
+  };
+  const contentType = mimeTypes[ext] || "application/octet-stream";
+
+  // Step 1: Request upload URL from Linear
+  const data = await linearQuery(`
+    mutation($size: Int!, $contentType: String!, $filename: String!) {
+      fileUpload(size: $size, contentType: $contentType, filename: $filename) {
+        uploadFile {
+          filename
+          uploadUrl
+          assetUrl
+          size
+          contentType
+          headers {
+            key
+            value
+          }
+        }
+      }
+    }
+  `, { size: fileSize, contentType, filename });
+
+  const uploadFile = data.fileUpload?.uploadFile;
+  if (!uploadFile) {
+    throw new Error("Failed to get upload URL from Linear");
+  }
+
+  // Step 2: Upload the file to the presigned URL
+  // Build headers from Linear's response (includes required signed headers)
+  const uploadHeaders = {
+    "Content-Type": contentType,
+    "Content-Length": String(fileSize),
+    "Cache-Control": "public, max-age=31536000",
+  };
+
+  // Add headers from Linear's fileUpload response (e.g., x-goog-content-length-range)
+  if (uploadFile.headers && Array.isArray(uploadFile.headers)) {
+    for (const h of uploadFile.headers) {
+      if (h.key && h.value) {
+        uploadHeaders[h.key] = h.value;
+      }
+    }
+  }
+
+  const uploadResponse = await fetch(uploadFile.uploadUrl, {
+    method: "PUT",
+    headers: uploadHeaders,
+    body: fileBuffer,
+  });
+
+  if (!uploadResponse.ok) {
+    const errorText = await uploadResponse.text();
+    throw new Error(`Upload failed (${uploadResponse.status}): ${errorText}`);
+  }
+
+  return {
+    filename: uploadFile.filename,
+    assetUrl: uploadFile.assetUrl,
+    size: fileSize,
+    contentType,
+  };
+}
+
+// Tool handlers
+async function handleTool(name, args) {
+  switch (name) {
+    // ===== User & Organization =====
+    case "linear_get_viewer": {
+      const data = await linearQuery(`
+        query {
+          viewer {
+            id
+            name
+            email
+            displayName
+            active
+            admin
+            avatarUrl
+            createdAt
+          }
+        }
+      `);
+      return data.viewer;
+    }
+
+    case "linear_get_organization": {
+      const data = await linearQuery(`
+        query {
+          organization {
+            id
+            name
+            urlKey
+            logoUrl
+            createdAt
+            userCount
+          }
+        }
+      `);
+      return data.organization;
+    }
+
+    case "linear_get_users": {
+      const data = await linearQuery(`
+        query($first: Int, $includeDisabled: Boolean) {
+          users(first: $first, includeDisabled: $includeDisabled) {
+            nodes {
+              id
+              name
+              email
+              displayName
+              active
+              admin
+              avatarUrl
+            }
+          }
+        }
+      `, { first: args.first || 50, includeDisabled: args.includeDisabled || false });
+      return data.users.nodes;
+    }
+
+    // ===== Teams =====
+    case "linear_list_teams": {
+      const data = await linearQuery(`
+        query {
+          teams {
+            nodes {
+              id
+              name
+              key
+              description
+            }
+          }
+        }
+      `);
+      return data.teams.nodes;
+    }
+
+    case "linear_get_team": {
+      const includeIssues = args.includeIssues || false;
+      const issueLimit = args.issueLimit || 25;
+
+      const query = includeIssues ? `
+        query($teamId: String!, $issueLimit: Int) {
+          team(id: $teamId) {
+            id
+            name
+            key
+            description
+            issues(first: $issueLimit) {
+              nodes {
+                id
+                identifier
+                title
+                state { id name }
+                assignee { id name }
+                priority
+                createdAt
+              }
+            }
+          }
+        }
+      ` : `
+        query($teamId: String!) {
+          team(id: $teamId) {
+            id
+            name
+            key
+            description
+            private
+            timezone
+          }
+        }
+      `;
+
+      const data = await linearQuery(query, { teamId: args.teamId, issueLimit });
+      return data.team;
+    }
+
+    // ===== Issues =====
+    case "linear_list_issues": {
+      const filter = {};
+      if (args.teamId) filter.team = { id: { eq: args.teamId } };
+      if (args.stateId) filter.state = { id: { eq: args.stateId } };
+      if (args.assigneeId) filter.assignee = { id: { eq: args.assigneeId } };
+      if (args.projectId) filter.project = { id: { eq: args.projectId } };
+
+      const data = await linearQuery(`
+        query($filter: IssueFilter, $first: Int) {
+          issues(filter: $filter, first: $first) {
+            nodes {
+              id
+              identifier
+              title
+              state { id name }
+              assignee { id name }
+              priority
+              project { id name }
+              team { id name }
+              createdAt
+              updatedAt
+            }
+          }
+        }
+      `, { filter: Object.keys(filter).length ? filter : undefined, first: args.first || 50 });
+
+      return data.issues.nodes;
+    }
+
+    case "linear_get_issue": {
+      const data = await linearQuery(`
+        query($id: String!) {
+          issue(id: $id) {
+            id
+            identifier
+            title
+            description
+            state { id name }
+            assignee { id name email }
+            priority
+            project { id name }
+            team { id name }
+            parent { id identifier title }
+            children { nodes { id identifier title } }
+            labels { nodes { id name color } }
+            cycle { id name startsAt endsAt }
+            comments { nodes { id body user { name } createdAt } }
+            createdAt
+            updatedAt
+            url
+          }
+        }
+      `, { id: args.id });
+      return data.issue;
+    }
+
+    case "linear_search_issues": {
+      const data = await linearQuery(`
+        query($term: String!, $first: Int) {
+          searchIssues(term: $term, first: $first) {
+            nodes {
+              id
+              identifier
+              title
+              description
+              state { id name }
+              assignee { id name }
+              team { id name }
+              priority
+              url
+            }
+          }
+        }
+      `, { term: args.query, first: args.first || 25 });
+
+      return data.searchIssues.nodes;
+    }
+
+    case "linear_create_issue": {
+      const input = {
+        title: args.title,
+        teamId: args.teamId,
+      };
+      if (args.description) input.description = args.description;
+      if (args.stateId) input.stateId = args.stateId;
+      if (args.assigneeId) input.assigneeId = args.assigneeId;
+      if (args.priority !== undefined) input.priority = args.priority;
+      if (args.projectId) input.projectId = args.projectId;
+      if (args.parentId) input.parentId = args.parentId;
+      if (args.labelIds) input.labelIds = args.labelIds;
+      if (args.cycleId) input.cycleId = args.cycleId;
+
+      const data = await linearQuery(`
+        mutation($input: IssueCreateInput!) {
+          issueCreate(input: $input) {
+            success
+            issue {
+              id
+              identifier
+              title
+              url
+            }
+          }
+        }
+      `, { input });
+
+      return data.issueCreate;
+    }
+
+    case "linear_update_issue": {
+      const issueId = await resolveIssueId(args.id);
+
+      const input = {};
+      if (args.title) input.title = args.title;
+      if (args.description !== undefined) input.description = args.description;
+      if (args.stateId) input.stateId = args.stateId;
+      if (args.assigneeId !== undefined) input.assigneeId = args.assigneeId;
+      if (args.priority !== undefined) input.priority = args.priority;
+      if (args.projectId !== undefined) input.projectId = args.projectId;
+      if (args.cycleId !== undefined) input.cycleId = args.cycleId;
+
+      const data = await linearQuery(`
+        mutation($id: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $id, input: $input) {
+            success
+            issue {
+              id
+              identifier
+              title
+              state { id name }
+              assignee { id name }
+              url
+            }
+          }
+        }
+      `, { id: issueId, input });
+
+      return data.issueUpdate;
+    }
+
+    case "linear_get_user_issues": {
+      let userId = args.userId;
+
+      // If no userId provided, get the viewer's ID
+      if (!userId) {
+        const viewerData = await linearQuery(`query { viewer { id } }`);
+        userId = viewerData.viewer.id;
+      }
+
+      const filter = {
+        assignee: { id: { eq: userId } },
+      };
+
+      if (!args.includeArchived) {
+        filter.archivedAt = { null: true };
+      }
+
+      const data = await linearQuery(`
+        query($filter: IssueFilter, $first: Int) {
+          issues(filter: $filter, first: $first) {
+            nodes {
+              id
+              identifier
+              title
+              state { id name }
+              priority
+              project { id name }
+              team { id name }
+              createdAt
+              updatedAt
+              url
+            }
+          }
+        }
+      `, { filter, first: args.first || 50 });
+
+      return data.issues.nodes;
+    }
+
+    // ===== Issue Management =====
+    case "linear_assign_issue": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      const data = await linearQuery(`
+        mutation($id: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $id, input: $input) {
+            success
+            issue {
+              id
+              identifier
+              assignee { id name }
+            }
+          }
+        }
+      `, { id: issueId, input: { assigneeId: args.assigneeId || null } });
+
+      return data.issueUpdate;
+    }
+
+    case "linear_set_issue_priority": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      const data = await linearQuery(`
+        mutation($id: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $id, input: $input) {
+            success
+            issue {
+              id
+              identifier
+              priority
+            }
+          }
+        }
+      `, { id: issueId, input: { priority: args.priority } });
+
+      return data.issueUpdate;
+    }
+
+    case "linear_set_issue_state": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      const data = await linearQuery(`
+        mutation($id: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $id, input: $input) {
+            success
+            issue {
+              id
+              identifier
+              state { id name }
+            }
+          }
+        }
+      `, { id: issueId, input: { stateId: args.stateId } });
+
+      return data.issueUpdate;
+    }
+
+    case "linear_archive_issue": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      const data = await linearQuery(`
+        mutation($id: String!) {
+          issueArchive(id: $id) {
+            success
+          }
+        }
+      `, { id: issueId });
+
+      return data.issueArchive;
+    }
+
+    case "linear_add_issue_label": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      // First get current labels
+      const issue = await linearQuery(`
+        query($id: String!) {
+          issue(id: $id) {
+            labels { nodes { id } }
+          }
+        }
+      `, { id: issueId });
+
+      const currentLabelIds = issue.issue.labels.nodes.map(l => l.id);
+      const newLabelIds = [...new Set([...currentLabelIds, args.labelId])];
+
+      const data = await linearQuery(`
+        mutation($id: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $id, input: $input) {
+            success
+            issue {
+              id
+              identifier
+              labels { nodes { id name } }
+            }
+          }
+        }
+      `, { id: issueId, input: { labelIds: newLabelIds } });
+
+      return data.issueUpdate;
+    }
+
+    case "linear_remove_issue_label": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      // First get current labels
+      const issue = await linearQuery(`
+        query($id: String!) {
+          issue(id: $id) {
+            labels { nodes { id } }
+          }
+        }
+      `, { id: issueId });
+
+      const newLabelIds = issue.issue.labels.nodes
+        .map(l => l.id)
+        .filter(id => id !== args.labelId);
+
+      const data = await linearQuery(`
+        mutation($id: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $id, input: $input) {
+            success
+            issue {
+              id
+              identifier
+              labels { nodes { id name } }
+            }
+          }
+        }
+      `, { id: issueId, input: { labelIds: newLabelIds } });
+
+      return data.issueUpdate;
+    }
+
+    // ===== Comments =====
+    case "linear_create_comment": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      const data = await linearQuery(`
+        mutation($input: CommentCreateInput!) {
+          commentCreate(input: $input) {
+            success
+            comment {
+              id
+              body
+              createdAt
+              user { name }
+            }
+          }
+        }
+      `, { input: { issueId, body: args.body } });
+
+      return data.commentCreate;
+    }
+
+    case "linear_get_comments": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      const data = await linearQuery(`
+        query($id: String!, $first: Int) {
+          issue(id: $id) {
+            comments(first: $first) {
+              nodes {
+                id
+                body
+                createdAt
+                updatedAt
+                user { id name email }
+              }
+            }
+          }
+        }
+      `, { id: issueId, first: args.first || 50 });
+
+      return data.issue.comments.nodes;
+    }
+
+    // ===== Projects =====
+    case "linear_list_projects": {
+      const filter = {};
+      if (args.teamId) filter.accessibleTeams = { id: { eq: args.teamId } };
+
+      const data = await linearQuery(`
+        query($filter: ProjectFilter, $first: Int) {
+          projects(filter: $filter, first: $first) {
+            nodes {
+              id
+              name
+              description
+              state
+              progress
+              lead { id name }
+              teams { nodes { id name } }
+              createdAt
+              updatedAt
+            }
+          }
+        }
+      `, { filter: Object.keys(filter).length ? filter : undefined, first: args.first || 50 });
+
+      return data.projects.nodes;
+    }
+
+    case "linear_create_project": {
+      const input = {
+        name: args.name,
+        teamIds: args.teamIds,
+      };
+      if (args.description) input.description = args.description;
+      if (args.leadId) input.leadId = args.leadId;
+      if (args.state) input.state = args.state;
+
+      const data = await linearQuery(`
+        mutation($input: ProjectCreateInput!) {
+          projectCreate(input: $input) {
+            success
+            project {
+              id
+              name
+              state
+              url
+            }
+          }
+        }
+      `, { input });
+
+      return data.projectCreate;
+    }
+
+    case "linear_add_issue_to_project": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      const data = await linearQuery(`
+        mutation($id: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $id, input: $input) {
+            success
+            issue {
+              id
+              identifier
+              project { id name }
+            }
+          }
+        }
+      `, { id: issueId, input: { projectId: args.projectId } });
+
+      return data.issueUpdate;
+    }
+
+    // ===== Workflow & Labels =====
+    case "linear_list_workflow_states": {
+      const data = await linearQuery(`
+        query($teamId: ID!) {
+          workflowStates(filter: { team: { id: { eq: $teamId } } }) {
+            nodes {
+              id
+              name
+              type
+              position
+              color
+            }
+          }
+        }
+      `, { teamId: args.teamId });
+
+      return data.workflowStates.nodes;
+    }
+
+    case "linear_get_labels": {
+      const filter = {};
+      if (args.teamId) filter.team = { id: { eq: args.teamId } };
+
+      const data = await linearQuery(`
+        query($filter: IssueLabelFilter, $first: Int) {
+          issueLabels(filter: $filter, first: $first) {
+            nodes {
+              id
+              name
+              color
+              description
+              team { id name }
+            }
+          }
+        }
+      `, { filter: Object.keys(filter).length ? filter : undefined, first: args.first || 100 });
+
+      return data.issueLabels.nodes;
+    }
+
+    // ===== Cycles =====
+    case "linear_get_cycles": {
+      const data = await linearQuery(`
+        query($teamId: ID!, $first: Int) {
+          cycles(filter: { team: { id: { eq: $teamId } } }, first: $first) {
+            nodes {
+              id
+              name
+              number
+              startsAt
+              endsAt
+              progress
+              completedAt
+            }
+          }
+        }
+      `, { teamId: args.teamId, first: args.first || 10 });
+
+      return data.cycles.nodes;
+    }
+
+    case "linear_get_active_cycle": {
+      const data = await linearQuery(`
+        query($teamId: String!) {
+          team(id: $teamId) {
+            activeCycle {
+              id
+              name
+              number
+              startsAt
+              endsAt
+              progress
+            }
+          }
+        }
+      `, { teamId: args.teamId });
+
+      return data.team?.activeCycle || null;
+    }
+
+    case "linear_add_issue_to_cycle": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      const data = await linearQuery(`
+        mutation($id: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $id, input: $input) {
+            success
+            issue {
+              id
+              identifier
+              cycle { id name }
+            }
+          }
+        }
+      `, { id: issueId, input: { cycleId: args.cycleId } });
+
+      return data.issueUpdate;
+    }
+
+    // ===== Images =====
+    case "linear_get_issue_images": {
+      // Fetch the issue to get its description
+      const data = await linearQuery(`
+        query($id: String!) {
+          issue(id: $id) {
+            id
+            identifier
+            title
+            description
+          }
+        }
+      `, { id: args.id });
+
+      if (!data.issue) {
+        throw new Error(`Issue not found: ${args.id}`);
+      }
+
+      const images = extractMarkdownImages(data.issue.description);
+
+      if (images.length === 0) {
+        return {
+          issueId: data.issue.identifier,
+          issueTitle: data.issue.title,
+          imagesFound: 0,
+          downloaded: [],
+          message: "No images found in issue description",
+        };
+      }
+
+      // Create output directory (with path traversal protection)
+      const outputDir = validateOutputDir(args.outputDir);
+      mkdirSync(outputDir, { recursive: true });
+
+      const downloaded = [];
+      const errors = [];
+
+      for (let i = 0; i < images.length; i++) {
+        const img = images[i];
+        try {
+          // Extract filename from URL or use index
+          // Prefix with issue identifier to prevent filename collisions across issues
+          const urlParts = img.url.split("/");
+          const rawFilename = img.alt || urlParts[urlParts.length - 1] || `image_${i + 1}.png`;
+          const filename = sanitizeFilename(`${data.issue.identifier}_${rawFilename}`);
+          const outputPath = join(outputDir, filename);
+
+          const result = await downloadImage(img.url, outputPath);
+          downloaded.push({
+            index: i + 1,
+            alt: img.alt,
+            url: img.url,
+            savedTo: outputPath,
+            size: result.size,
+            contentType: result.contentType,
+          });
+        } catch (error) {
+          errors.push({
+            index: i + 1,
+            alt: img.alt,
+            url: img.url,
+            error: error.message,
+          });
+        }
+      }
+
+      return {
+        issueId: data.issue.identifier,
+        issueTitle: data.issue.title,
+        imagesFound: images.length,
+        downloaded,
+        errors: errors.length > 0 ? errors : undefined,
+        outputDir,
+      };
+    }
+
+    case "linear_get_comments_images": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      // Fetch all comments for the issue
+      const data = await linearQuery(`
+        query($id: String!, $first: Int) {
+          issue(id: $id) {
+            id
+            identifier
+            title
+            comments(first: $first) {
+              nodes {
+                id
+                body
+                createdAt
+                user { name }
+              }
+            }
+          }
+        }
+      `, { id: issueId, first: 100 });
+
+      if (!data.issue) {
+        throw new Error(`Issue not found: ${args.issueId}`);
+      }
+
+      // Extract images from all comments
+      const allImages = [];
+      for (const comment of data.issue.comments.nodes) {
+        const images = extractMarkdownImages(comment.body);
+        for (const img of images) {
+          allImages.push({
+            ...img,
+            commentId: comment.id,
+            commentAuthor: comment.user?.name || "Unknown",
+            commentDate: comment.createdAt,
+          });
+        }
+      }
+
+      if (allImages.length === 0) {
+        return {
+          issueId: data.issue.identifier,
+          issueTitle: data.issue.title,
+          commentsChecked: data.issue.comments.nodes.length,
+          imagesFound: 0,
+          downloaded: [],
+          message: "No images found in comments",
+        };
+      }
+
+      // Create output directory (with path traversal protection)
+      const outputDir = validateOutputDir(args.outputDir);
+      mkdirSync(outputDir, { recursive: true });
+
+      const downloaded = [];
+      const errors = [];
+
+      for (let i = 0; i < allImages.length; i++) {
+        const img = allImages[i];
+        try {
+          // Extract filename from URL or use index
+          // Prefix with issue identifier to prevent filename collisions across issues
+          const urlParts = img.url.split("/");
+          const rawFilename = img.alt || urlParts[urlParts.length - 1] || `comment_image_${i + 1}.png`;
+          const filename = sanitizeFilename(`${data.issue.identifier}_${i + 1}_${rawFilename}`);
+          const outputPath = join(outputDir, filename);
+
+          const result = await downloadImage(img.url, outputPath);
+          downloaded.push({
+            index: i + 1,
+            alt: img.alt,
+            url: img.url,
+            commentAuthor: img.commentAuthor,
+            commentDate: img.commentDate,
+            savedTo: outputPath,
+            size: result.size,
+            contentType: result.contentType,
+          });
+        } catch (error) {
+          errors.push({
+            index: i + 1,
+            alt: img.alt,
+            url: img.url,
+            commentAuthor: img.commentAuthor,
+            error: error.message,
+          });
+        }
+      }
+
+      return {
+        issueId: data.issue.identifier,
+        issueTitle: data.issue.title,
+        commentsChecked: data.issue.comments.nodes.length,
+        imagesFound: allImages.length,
+        downloaded,
+        errors: errors.length > 0 ? errors : undefined,
+        outputDir,
+      };
+    }
+
+    // ===== Uploads =====
+    case "linear_upload_image": {
+      const result = await uploadFileToLinear(args.filePath, args.filename);
+      return {
+        ...result,
+        markdown: `![${result.filename}](${result.assetUrl})`,
+        message: `Image uploaded successfully. Use this markdown to embed it: ![${result.filename}](${result.assetUrl})`,
+      };
+    }
+
+    case "linear_create_comment_with_images": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      // Upload all images first
+      const uploaded = [];
+      const uploadErrors = [];
+
+      for (let i = 0; i < args.imagePaths.length; i++) {
+        try {
+          const result = await uploadFileToLinear(args.imagePaths[i]);
+          uploaded.push({
+            index: i + 1,
+            filePath: args.imagePaths[i],
+            ...result,
+          });
+        } catch (error) {
+          uploadErrors.push({
+            index: i + 1,
+            filePath: args.imagePaths[i],
+            error: error.message,
+          });
+        }
+      }
+
+      if (uploaded.length === 0) {
+        throw new Error(`All image uploads failed: ${uploadErrors.map(e => e.error).join(", ")}`);
+      }
+
+      // Replace {image:N} placeholders with markdown image syntax
+      let commentBody = args.body;
+      for (const img of uploaded) {
+        const placeholder = `{image:${img.index}}`;
+        const markdown = `![${img.filename}](${img.assetUrl})`;
+        commentBody = commentBody.split(placeholder).join(markdown);
+      }
+
+      // Create the comment
+      const commentData = await linearQuery(`
+        mutation($input: CommentCreateInput!) {
+          commentCreate(input: $input) {
+            success
+            comment {
+              id
+              body
+              createdAt
+              user { name }
+            }
+          }
+        }
+      `, { input: { issueId, body: commentBody } });
+
+      return {
+        comment: commentData.commentCreate,
+        imagesUploaded: uploaded.length,
+        uploadErrors: uploadErrors.length > 0 ? uploadErrors : undefined,
+        imageUrls: uploaded.map(img => ({ filename: img.filename, assetUrl: img.assetUrl })),
+      };
+    }
+
+    // ===== Favorites =====
+    case "linear_favorite_issue": {
+      const issueId = await resolveIssueId(args.issueId);
+
+      const data = await linearQuery(`
+        mutation($input: FavoriteCreateInput!) {
+          favoriteCreate(input: $input) {
+            success
+            favorite {
+              id
+            }
+          }
+        }
+      `, { input: { issueId } });
+
+      return data.favoriteCreate;
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+// JSON-RPC response helpers
+function jsonRpcResponse(id, result) {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function jsonRpcError(id, code, message) {
+  return JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+// Handle MCP protocol messages
+async function handleMessage(message) {
+  const { id, method, params } = message;
+
+  try {
+    switch (method) {
+      case "initialize":
+        return jsonRpcResponse(id, {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {} },
+          serverInfo: { name: "linear-mcp-server", version: "2.0.0" },
+        });
+
+      case "notifications/initialized":
+        return null;
+
+      case "tools/list":
+        return jsonRpcResponse(id, { tools: TOOLS });
+
+      case "tools/call": {
+        const { name, arguments: args } = params;
+        try {
+          const result = await handleTool(name, args || {});
+          return jsonRpcResponse(id, {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          });
+        } catch (error) {
+          return jsonRpcResponse(id, {
+            content: [{ type: "text", text: `Error: ${error.message}` }],
+            isError: true,
+          });
+        }
+      }
+
+      default:
+        return jsonRpcError(id, -32601, `Method not found: ${method}`);
+    }
+  } catch (error) {
+    return jsonRpcError(id, -32603, error.message);
+  }
+}
+
+// Main: Read JSON-RPC messages from stdin, write responses to stdout
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", async (line) => {
+  if (!line.trim()) return;
+
+  try {
+    const message = JSON.parse(line);
+    const response = await handleMessage(message);
+    if (response) {
+      process.stdout.write(response + "\n");
+    }
+  } catch (error) {
+    const errorResponse = jsonRpcError(null, -32700, "Parse error");
+    process.stdout.write(errorResponse + "\n");
+  }
+});
+
+rl.on("close", () => process.exit(0));

--- a/.claude/tools/logrocket-mcp.mjs
+++ b/.claude/tools/logrocket-mcp.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+/**
+ * LogRocket MCP Server
+ *
+ * A zero-dependency MCP server using only Node.js built-ins.
+ * Implements MCP protocol (JSON-RPC 2.0 over stdio) directly.
+ *
+ * Tools Provided:
+ * - logrocket_get_session_highlights: Get AI-generated summaries of user sessions with errors
+ * - logrocket_export_sessions: Export raw session data with events, errors, network requests
+ * - logrocket_update_user: Update user information and custom traits
+ *
+ * Requires LOGROCKET_API_KEY in .env.local or .claude/tools/.env.local
+ * Format: LOGROCKET_API_KEY=org_id:app_id:secret_key
+ */
+/* global process */
+
+import { existsSync, readFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import { createInterface } from "readline";
+
+const __toolsDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__toolsDir, "..", "..");
+
+// Load environment variables
+function loadEnvFile(filePath) {
+  if (!existsSync(filePath)) return;
+  const content = readFileSync(filePath, "utf-8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const match = trimmed.match(/^(LOGROCKET_[A-Z_]+)=(.+)$/);
+    if (match) {
+      let value = match[2].trim();
+      if ((value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      process.env[match[1]] = value;
+    }
+  }
+}
+
+loadEnvFile(join(projectRoot, ".env.local"));
+loadEnvFile(join(__toolsDir, ".env.local"));
+
+// Configuration
+const API_KEY = process.env.LOGROCKET_API_KEY;
+const API_BASE_URL = process.env.LOGROCKET_API_BASE_URL || "https://api.logrocket.com";
+
+if (!API_KEY) {
+  console.error("Error: Missing LOGROCKET_API_KEY");
+  console.error("Please set LOGROCKET_API_KEY in .env.local or .claude/tools/.env.local");
+  console.error("Format: LOGROCKET_API_KEY=org_id:app_id:secret_key");
+  process.exit(1);
+}
+
+// Parse ORG_ID and APP_ID from API key (format: org_id:app_id:secret_key)
+let ORG_ID, APP_ID;
+const keyParts = API_KEY.split(':');
+if (keyParts.length === 3) {
+  [ORG_ID, APP_ID] = keyParts;
+} else {
+  ORG_ID = process.env.LOGROCKET_ORG_ID;
+  APP_ID = process.env.LOGROCKET_APP_ID;
+
+  if (!ORG_ID || !APP_ID) {
+    console.error("Error: Invalid LOGROCKET_API_KEY format");
+    console.error("Expected format: org_id:app_id:secret_key");
+    process.exit(1);
+  }
+}
+
+// API Helper
+async function logRocketFetch(method, endpoint, body = null) {
+  const url = `${API_BASE_URL}${endpoint}`;
+  const options = {
+    method,
+    headers: {
+      Authorization: `token ${API_KEY}`,
+      "Content-Type": "application/json",
+    },
+  };
+
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url, options);
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`LogRocket API error (${response.status}): ${errorText}`);
+  }
+
+  const text = await response.text();
+
+  if (!text || text.length === 0) {
+    if (endpoint.includes('/data-export/')) {
+      throw new Error(
+        `Data Export API returned empty response. This API is deprecated for SaaS customers.`
+      );
+    }
+    return {};
+  }
+
+  return JSON.parse(text);
+}
+
+// Tool definitions
+const TOOLS = [
+  {
+    name: "logrocket_get_session_highlights",
+    description: "Get AI-generated summaries of user sessions including errors and key interactions. Returns a request ID - the actual highlights will be delivered to the webhook URL you provide.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        userID: {
+          type: "string",
+          description: "User identifier from LogRocket.identify() calls (provide either userID or userEmail)",
+        },
+        userEmail: {
+          type: "string",
+          description: "User email from LogRocket.identify() calls (provide either userID or userEmail)",
+        },
+        startMs: {
+          type: "number",
+          description: "Start time in milliseconds (Unix epoch) for session time range (optional)",
+        },
+        endMs: {
+          type: "number",
+          description: "End time in milliseconds (Unix epoch) for session time range (optional)",
+        },
+        webhookURL: {
+          type: "string",
+          description: "URL where LogRocket will POST the highlights results",
+        },
+      },
+      required: ["webhookURL"],
+    },
+  },
+  {
+    name: "logrocket_export_sessions",
+    description: "Export raw session data including events, errors, network requests, and metadata. WARNING: This API is deprecated for SaaS customers and may return empty results. Requires Data Export to be manually configured in LogRocket dashboard. Consider using the Streaming Data Export service instead. If available, returns URLs to JSON Lines files containing session data.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        cursor: {
+          type: "string",
+          description: "Pagination cursor for retrieving newer sessions (from previous response)",
+        },
+        limit: {
+          type: "number",
+          description: "Number of sessions to return (default: 10, max: 100)",
+        },
+        date: {
+          type: "number",
+          description: "Unix timestamp in milliseconds to filter sessions from this date onwards",
+        },
+      },
+    },
+  },
+  {
+    name: "logrocket_update_user",
+    description: "Update user information and custom traits in LogRocket. Useful for adding context about users that can help with debugging and support.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        userId: {
+          type: "string",
+          description: "User ID to update",
+        },
+        name: {
+          type: "string",
+          description: "User's name (max 1,024 characters)",
+        },
+        email: {
+          type: "string",
+          description: "User's email address (max 1,024 characters)",
+        },
+        timestamp: {
+          type: "number",
+          description: "Unix timestamp in milliseconds for when data was recorded",
+        },
+        traits: {
+          type: "object",
+          description: "Custom key-value pairs describing the user (e.g., subscription tier, account type)",
+        },
+      },
+      required: ["userId"],
+    },
+  },
+];
+
+// Tool handlers
+async function handleTool(name, args) {
+  switch (name) {
+    case "logrocket_get_session_highlights": {
+      const { userID, userEmail, startMs, endMs, webhookURL } = args;
+
+      if (!userID && !userEmail) {
+        throw new Error("Either userID or userEmail is required");
+      }
+
+      const requestBody = { webhookURL };
+      if (userID) requestBody.userID = userID;
+      if (userEmail) requestBody.userEmail = userEmail;
+      if (startMs && endMs) {
+        requestBody.timeRange = { startMs, endMs };
+      }
+
+      return await logRocketFetch(
+        "POST",
+        `/v1/orgs/${ORG_ID}/apps/${APP_ID}/highlights/`,
+        requestBody
+      );
+    }
+
+    case "logrocket_export_sessions": {
+      const { cursor, limit, date } = args;
+
+      const params = new URLSearchParams();
+      if (cursor) params.append("cursor", cursor);
+      if (limit) params.append("limit", limit.toString());
+      if (date) params.append("date", date.toString());
+
+      const queryString = params.toString();
+      const endpoint = `/v1/orgs/${ORG_ID}/apps/${APP_ID}/data-export/${
+        queryString ? `?${queryString}` : ""
+      }`;
+
+      return await logRocketFetch("GET", endpoint);
+    }
+
+    case "logrocket_update_user": {
+      const { userId, name, email, timestamp, traits } = args;
+
+      const requestBody = {};
+      if (name) requestBody.name = name;
+      if (email) requestBody.email = email;
+      if (timestamp) requestBody.timestamp = timestamp;
+      if (traits) requestBody.traits = traits;
+
+      return await logRocketFetch(
+        "PUT",
+        `/v1/orgs/${ORG_ID}/apps/${APP_ID}/users/${userId}`,
+        requestBody
+      );
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+// JSON-RPC response helpers
+function jsonRpcResponse(id, result) {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function jsonRpcError(id, code, message) {
+  return JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+// Handle MCP protocol messages
+async function handleMessage(message) {
+  const { id, method, params } = message;
+
+  try {
+    switch (method) {
+      case "initialize":
+        return jsonRpcResponse(id, {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {} },
+          serverInfo: { name: "logrocket-mcp-server", version: "1.0.0" },
+        });
+
+      case "notifications/initialized":
+        return null;
+
+      case "tools/list":
+        return jsonRpcResponse(id, { tools: TOOLS });
+
+      case "tools/call": {
+        const { name, arguments: args } = params;
+        try {
+          const result = await handleTool(name, args || {});
+          return jsonRpcResponse(id, {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          });
+        } catch (error) {
+          return jsonRpcResponse(id, {
+            content: [{ type: "text", text: `Error: ${error.message}` }],
+            isError: true,
+          });
+        }
+      }
+
+      default:
+        return jsonRpcError(id, -32601, `Method not found: ${method}`);
+    }
+  } catch (error) {
+    return jsonRpcError(id, -32603, error.message);
+  }
+}
+
+// Main: Read JSON-RPC messages from stdin, write responses to stdout
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", async (line) => {
+  if (!line.trim()) return;
+
+  try {
+    const message = JSON.parse(line);
+    const response = await handleMessage(message);
+    if (response) {
+      process.stdout.write(response + "\n");
+    }
+  } catch (error) {
+    const errorResponse = jsonRpcError(null, -32700, "Parse error");
+    process.stdout.write(errorResponse + "\n");
+  }
+});
+
+rl.on("close", () => process.exit(0));

--- a/.claude/tools/restart-with-skill.sh
+++ b/.claude/tools/restart-with-skill.sh
@@ -1,0 +1,682 @@
+#!/bin/bash
+# restart-with-skill.sh - Spawn fresh Claude session in new Git Bash window
+# Usage: .claude/tools/restart-with-skill.sh [claude-flags] "/skill-command args --no-restart"
+#
+# Example:
+#   .claude/tools/restart-with-skill.sh --dangerously-skip-permissions "/submit-pr everything --no-restart"
+#
+# This script:
+# 1. Parses Claude CLI flags and skill command (with all arguments)
+# 2. Detects current elevation level (admin/non-admin)
+# 3. Spawns a NEW mintty window with fresh Claude session (preserving elevation)
+# 4. Exits the current terminal (which closes the old Claude session)
+
+# CRITICAL: Disable Git Bash POSIX path conversion
+# Without this, "/submit-pr" gets converted to "C:/Program Files/Git/submit-pr"
+export MSYS_NO_PATHCONV=1
+
+# Dynamically determine project path from script location
+# This makes the script portable across different development environments
+PROJECT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# =============================================================================
+# ELEVATION DETECTION
+# =============================================================================
+# Detect if running as Administrator - new session should match
+IS_ADMIN=$(powershell -NoProfile -Command '
+([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+' 2>/dev/null | tr -d '\r')
+
+if [ "$IS_ADMIN" = "True" ]; then
+    echo -e "\033[33m🔒 Running as Administrator - new session will also be elevated\033[0m"
+else
+    echo -e "\033[33m🔓 Running as standard user\033[0m"
+fi
+
+# =============================================================================
+# MINTTY PATH DETECTION
+# =============================================================================
+# Find mintty reliably - check multiple locations
+MINTTY_PATH=""
+if command -v mintty &> /dev/null; then
+    MINTTY_PATH=$(command -v mintty)
+elif [ -f "/usr/bin/mintty" ]; then
+    MINTTY_PATH="/usr/bin/mintty"
+elif [ -f "/mingw64/bin/mintty" ]; then
+    MINTTY_PATH="/mingw64/bin/mintty"
+fi
+
+if [ -z "$MINTTY_PATH" ]; then
+    echo -e "\033[31m❌ ERROR: mintty not found. Cannot spawn new Git Bash window.\033[0m"
+    echo -e "\033[31m   Please ensure Git Bash is properly installed.\033[0m"
+    exit 1
+fi
+
+echo -e "\033[90mUsing mintty: $MINTTY_PATH\033[0m"
+
+# =============================================================================
+# FIX MSYS PATH CONVERSION
+# =============================================================================
+# Git Bash converts "/skill-name" to "C:/Program Files/Git/skill-name" BEFORE
+# this script even runs. We detect and recover from this conversion.
+#
+# This function is defined EARLY because it's needed by both:
+# 1. Pre-encoded prompt path (in case encoding happened after conversion)
+# 2. Command-line argument path (fallback)
+#
+# Known MSYS/Git installation paths to strip:
+# - C:/Program Files/Git/
+# - C:/Program Files (x86)/Git/
+# - D:/Git/, E:/Git/, etc.
+# - /c/Program Files/Git/ (MSYS style)
+# - /mingw64/, /usr/, etc.
+#
+fix_msys_path() {
+    local input="$1"
+
+    # Pattern 1: Windows-style Git path (C:/Program Files/Git/skill-name)
+    if [[ "$input" =~ ^[A-Za-z]:/Program\ Files(/\ \(x86\))?/Git/(.+)$ ]]; then
+        echo "/${BASH_REMATCH[2]}"
+        return
+    fi
+
+    # Pattern 2: Windows-style Git path without spaces (C:/Git/skill-name)
+    if [[ "$input" =~ ^[A-Za-z]:/Git/(.+)$ ]]; then
+        echo "/${BASH_REMATCH[1]}"
+        return
+    fi
+
+    # Pattern 3: MSYS-style path (/c/Program Files/Git/skill-name)
+    if [[ "$input" =~ ^/[a-z]/Program\ Files(/\ \(x86\))?/Git/(.+)$ ]]; then
+        echo "/${BASH_REMATCH[2]}"
+        return
+    fi
+
+    # Pattern 4: MSYS mingw64 path (/mingw64/skill-name becomes /skill-name)
+    if [[ "$input" =~ ^/mingw64/(.+)$ ]]; then
+        echo "/${BASH_REMATCH[1]}"
+        return
+    fi
+
+    # Pattern 5: MSYS usr path (/usr/skill-name becomes /skill-name)
+    if [[ "$input" =~ ^/usr/(.+)$ ]]; then
+        echo "/${BASH_REMATCH[1]}"
+        return
+    fi
+
+    # No conversion needed
+    echo "$input"
+}
+
+# =============================================================================
+# CHECK FOR PRE-ENCODED PROMPT (PREFERRED METHOD)
+# =============================================================================
+# If CLAUDE_PROMPT_ENCODED is set, use it instead of command-line args.
+# This completely avoids MSYS path conversion issues.
+# Set via: eval "$(.claude/tools/encode-prompt.sh "/skill-name --no-restart")"
+#
+if [ -n "${CLAUDE_PROMPT_ENCODED:-}" ]; then
+    # Decode the prompt - try GNU base64 (-d) first
+    SKILL_COMMAND=$(printf '%s' "$CLAUDE_PROMPT_ENCODED" | base64 -d 2>/dev/null | tr -d '\r')
+
+    # Fallback for BSD/macOS base64 (--decode) - only runs if first decode produced empty output
+    # This is efficient: second decode only executes when needed for cross-platform compatibility
+    if [ -z "$SKILL_COMMAND" ] && [ -n "$CLAUDE_PROMPT_ENCODED" ]; then
+        SKILL_COMMAND=$(printf '%s' "$CLAUDE_PROMPT_ENCODED" | base64 --decode 2>/dev/null | tr -d '\r')
+    fi
+
+    # IMPORTANT: Apply MSYS path fix even to pre-encoded values!
+    # If Claude's bash command that set the env var already had the mangled path
+    # (e.g., PROMPT="/test-ascii" instead of using heredoc), the base64 contains
+    # the mangled path. We fix it here as a safety net.
+    ORIGINAL_DECODED="$SKILL_COMMAND"
+    SKILL_COMMAND=$(fix_msys_path "$SKILL_COMMAND")
+
+    if [ "$ORIGINAL_DECODED" != "$SKILL_COMMAND" ]; then
+        echo -e "\033[33m⚠️  Pre-encoded value had MSYS path conversion - fixed:\033[0m"
+        echo -e "\033[31m   Before: $ORIGINAL_DECODED\033[0m"
+        echo -e "\033[32m   After:  $SKILL_COMMAND\033[0m"
+        echo -e "\033[32m✅ Using pre-encoded prompt (with path fix applied)\033[0m"
+    else
+        echo -e "\033[32m✅ Using pre-encoded prompt (path conversion avoided)\033[0m"
+    fi
+    echo -e "\033[90m   Decoded: $SKILL_COMMAND\033[0m"
+
+    # Parse flags from CLAUDE_FLAGS_ENCODED if present
+    # Uses same GNU/BSD fallback pattern: try -d first, --decode only if empty result
+    CLAUDE_FLAGS=""
+    if [ -n "${CLAUDE_FLAGS_ENCODED:-}" ]; then
+        CLAUDE_FLAGS=$(printf '%s' "$CLAUDE_FLAGS_ENCODED" | base64 -d 2>/dev/null | tr -d '\r')
+        if [ -z "$CLAUDE_FLAGS" ]; then
+            CLAUDE_FLAGS=$(printf '%s' "$CLAUDE_FLAGS_ENCODED" | base64 --decode 2>/dev/null | tr -d '\r')
+        fi
+    fi
+
+    # Skip argument parsing - jump to the execution section
+    SKIP_ARG_PARSING=true
+else
+    SKIP_ARG_PARSING=false
+fi
+
+# =============================================================================
+# PARSE COMMAND-LINE ARGS (FALLBACK)
+# =============================================================================
+
+# Parse arguments - separate Claude flags from skill command
+# CRITICAL: Once we see a skill command (starts with / or is a Windows path),
+# ALL subsequent arguments belong to the skill command, even if they start with --
+#
+# NOTE: This section is SKIPPED if CLAUDE_PROMPT_ENCODED was provided
+if [ "$SKIP_ARG_PARSING" = false ]; then
+
+CLAUDE_FLAGS=""
+SKILL_COMMAND=""
+SKILL_COMMAND_STARTED=false
+
+for arg in "$@"; do
+    if [ "$SKILL_COMMAND_STARTED" = true ]; then
+        # Already in skill command - append everything (including --flags like --no-restart)
+        SKILL_COMMAND="$SKILL_COMMAND $arg"
+    elif [[ "$arg" == /* ]] || [[ "$arg" =~ ^[A-Za-z]:/ ]]; then
+        # Skill command starts - either starts with / OR is a Windows path (mangled by MSYS)
+        SKILL_COMMAND="$arg"
+        SKILL_COMMAND_STARTED=true
+    elif [[ "$arg" == --* ]]; then
+        # Claude CLI flag (e.g., --dangerously-skip-permissions) - only before skill command
+        CLAUDE_FLAGS="$CLAUDE_FLAGS $arg"
+    else
+        # Non-flag, non-skill argument before skill command - could be a skill name without /
+        # Treat as start of skill command
+        SKILL_COMMAND="$arg"
+        SKILL_COMMAND_STARTED=true
+    fi
+done
+
+# Trim leading space from flags
+CLAUDE_FLAGS="${CLAUDE_FLAGS# }"
+
+# Fix MSYS path conversion if detected
+if [ -n "$SKILL_COMMAND" ]; then
+    ORIGINAL_COMMAND="$SKILL_COMMAND"
+    SKILL_COMMAND=$(fix_msys_path "$SKILL_COMMAND")
+
+    if [ "$ORIGINAL_COMMAND" != "$SKILL_COMMAND" ]; then
+        echo -e "\033[33m⚠️  MSYS path conversion detected and fixed:\033[0m"
+        echo -e "\033[31m   Mangled:  $ORIGINAL_COMMAND\033[0m"
+        echo -e "\033[32m   Fixed:    $SKILL_COMMAND\033[0m"
+    fi
+fi
+
+fi  # End of SKIP_ARG_PARSING check
+
+# =============================================================================
+# AUTO-DETECT FLAGS FALLBACK
+# =============================================================================
+# If no flags were provided via CLAUDE_FLAGS_ENCODED or command-line args,
+# auto-detect them from the running Claude process. This prevents the new
+# session from losing flags like --dangerously-skip-permissions when the
+# caller (Claude AI) forgets to pass them.
+if [ -z "$CLAUDE_FLAGS" ]; then
+    echo -e "\033[33m⚠️  No flags provided - auto-detecting from running process...\033[0m"
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    AUTO_FLAGS=$(bash "$SCRIPT_DIR/detect-claude-flags.sh" 2>/dev/null | tr -d '\r')
+
+    if [ -n "$AUTO_FLAGS" ] && [ "$AUTO_FLAGS" != "NONE" ]; then
+        CLAUDE_FLAGS="$AUTO_FLAGS"
+        echo -e "\033[32m✅ Auto-detected flags: $CLAUDE_FLAGS\033[0m"
+    else
+        echo -e "\033[90m   No flags detected (running without special flags)\033[0m"
+    fi
+fi
+
+echo -e "\033[36mSpawning new terminal with: claude $CLAUDE_FLAGS \"$SKILL_COMMAND\"\033[0m"
+
+# =============================================================================
+# CLAUDE PATH DETECTION
+# =============================================================================
+# Find claude now and pass the path to the new terminal
+# This ensures the new terminal can find claude even if PATH differs
+DETECTED_CLAUDE_PATH=""
+DETECTED_CLI_JS=""
+
+# First, try to find the CLI.js directly (most reliable method)
+if [ -f "/c/nvm4w/nodejs/node_modules/@anthropic-ai/claude-code/cli.js" ]; then
+    DETECTED_CLI_JS="/c/nvm4w/nodejs/node_modules/@anthropic-ai/claude-code/cli.js"
+elif [ -n "$APPDATA" ] && [ -f "$APPDATA/npm/node_modules/@anthropic-ai/claude-code/cli.js" ]; then
+    DETECTED_CLI_JS="$APPDATA/npm/node_modules/@anthropic-ai/claude-code/cli.js"
+elif [ -f "$HOME/.npm-global/lib/node_modules/@anthropic-ai/claude-code/cli.js" ]; then
+    DETECTED_CLI_JS="$HOME/.npm-global/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+fi
+
+# Also detect the claude script as backup
+if command -v claude &> /dev/null; then
+    DETECTED_CLAUDE_PATH=$(command -v claude)
+elif [ -f "$HOME/.local/bin/claude.exe" ]; then
+    # Native installer location (e.g., C:\Users\<user>\.local\bin\claude.exe)
+    DETECTED_CLAUDE_PATH="$HOME/.local/bin/claude.exe"
+elif [ -f "$HOME/.local/bin/claude" ]; then
+    DETECTED_CLAUDE_PATH="$HOME/.local/bin/claude"
+elif [ -f "/c/nvm4w/nodejs/claude" ]; then
+    DETECTED_CLAUDE_PATH="/c/nvm4w/nodejs/claude"
+elif [ -n "$APPDATA" ] && [ -f "$APPDATA/npm/claude.cmd" ]; then
+    DETECTED_CLAUDE_PATH="$APPDATA/npm/claude.cmd"
+elif [ -f "$HOME/.npm-global/bin/claude" ]; then
+    DETECTED_CLAUDE_PATH="$HOME/.npm-global/bin/claude"
+elif where claude &> /dev/null 2>&1; then
+    DETECTED_CLAUDE_PATH=$(where claude 2>/dev/null | head -1 | tr -d '\r')
+fi
+
+if [ -n "$DETECTED_CLI_JS" ]; then
+    echo -e "\033[90mClaude CLI.js found at: $DETECTED_CLI_JS\033[0m"
+elif [ -n "$DETECTED_CLAUDE_PATH" ]; then
+    echo -e "\033[90mClaude found at: $DETECTED_CLAUDE_PATH\033[0m"
+else
+    echo -e "\033[33m⚠️  Could not detect claude path - new terminal will search for it\033[0m"
+fi
+
+# Get list of current mintty PIDs BEFORE spawning
+OLD_MINTTY_PIDS=$(powershell -NoProfile -Command '
+(Get-Process mintty -ErrorAction SilentlyContinue).Id -join ","
+' 2>/dev/null | tr -d '\r')
+
+# Count how many minttys exist
+MINTTY_COUNT=$(echo "$OLD_MINTTY_PIDS" | tr ',' '\n' | grep -c .)
+
+echo -e "\033[33mFound $MINTTY_COUNT mintty window(s): $OLD_MINTTY_PIDS\033[0m"
+
+# Only auto-kill if exactly 1 mintty (must be ours)
+# If multiple, user might have other windows - don't kill those
+KILL_CMD=""
+if [ "$MINTTY_COUNT" -eq 1 ] && [ -n "$OLD_MINTTY_PIDS" ]; then
+    # Use PowerShell Stop-Process instead of taskkill to avoid Git Bash path conversion issues
+    # taskkill //PID doesn't work reliably because // -> / conversion is inconsistent
+    KILL_CMD="(sleep 3 && powershell -NoProfile -Command 'Stop-Process -Id $OLD_MINTTY_PIDS -Force -ErrorAction SilentlyContinue') &"
+    echo -e "\033[32m✅ New terminal will auto-close this window in ~3 seconds.\033[0m"
+else
+    echo -e "\033[33m⚠️  Multiple terminals detected - please close this one manually.\033[0m"
+fi
+
+# Write the startup script to a temp file to avoid nested quoting issues
+# This ensures the full skill command with all arguments is preserved
+TEMP_SCRIPT=$(mktemp /tmp/claude-restart-XXXXXX.sh)
+
+# Ensure temp file cleanup on any exit (success, failure, or interrupt)
+trap 'rm -f "$TEMP_SCRIPT"' EXIT INT TERM
+
+# CRITICAL: Compute base64 encoding NOW, before writing to temp script
+# The heredoc below uses single quotes around the value, so we can't use $() there
+SKILL_COMMAND_B64=""
+if [ -n "$SKILL_COMMAND" ]; then
+    SKILL_COMMAND_B64=$(printf '%s' "$SKILL_COMMAND" | base64 -w0 2>/dev/null || printf '%s' "$SKILL_COMMAND" | base64 | tr -d '\n')
+fi
+echo -e "\033[90mDEBUG: SKILL_COMMAND='$SKILL_COMMAND'\033[0m"
+echo -e "\033[90mDEBUG: SKILL_COMMAND_B64='$SKILL_COMMAND_B64'\033[0m"
+cat > "$TEMP_SCRIPT" << 'SCRIPT_HEADER'
+#!/bin/bash
+# CRITICAL: Export MSYS path conversion blockers at the VERY START
+# These must be set BEFORE any argument expansion happens in bash
+# Without this, ${cmd_args[@]} expansion converts /skill to C:/Program Files/Git/skill
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL='*'
+
+# CRITICAL: Unset CLAUDECODE to allow launching Claude from a spawned terminal
+# Claude Code sets this env var to detect nested sessions, but our restart
+# spawns a genuinely NEW terminal (not a nested session), so this is safe.
+unset CLAUDECODE
+
+# Function to run Claude in a loop until user explicitly exits
+run_claude() {
+    while true; do
+        # Configure terminal for proper key handling before running Claude
+        # -ixon: Disable XON/XOFF flow control (frees up Ctrl+S/Q)
+        # -ixoff: Disable sending start/stop characters
+        stty -ixon -ixoff 2>/dev/null
+
+        # Set terminal type for proper escape sequence handling
+        export TERM=xterm-256color
+
+        # Set ESCDELAY=0 to eliminate delay after Escape key press
+        # This prevents the terminal from waiting to see if Escape is part of a sequence
+        export ESCDELAY=0
+
+        # Debug: Show what was passed from parent
+        echo -e "\033[90mDEBUG: CLAUDE_PATH_OVERRIDE='$CLAUDE_PATH_OVERRIDE'\033[0m"
+        echo -e "\033[90mDEBUG: CLAUDE_CLI_JS_OVERRIDE='$CLAUDE_CLI_JS_OVERRIDE'\033[0m"
+
+        # Find claude executable - winpty needs full path on Windows
+        # Check multiple locations where npm might install global packages
+        # CLAUDE_PATH_OVERRIDE and CLAUDE_CLI_JS_OVERRIDE are set by the parent script
+        CLAUDE_PATH="${CLAUDE_PATH_OVERRIDE:-}"
+        CLAUDE_CLI_JS="${CLAUDE_CLI_JS_OVERRIDE:-}"
+
+        # If no CLI.js passed from parent, try to find it directly
+        # This is the most reliable method on Windows
+        if [ -z "$CLAUDE_CLI_JS" ]; then
+            if [ -f "/c/nvm4w/nodejs/node_modules/@anthropic-ai/claude-code/cli.js" ]; then
+                CLAUDE_CLI_JS="/c/nvm4w/nodejs/node_modules/@anthropic-ai/claude-code/cli.js"
+            elif [ -n "$APPDATA" ] && [ -f "$APPDATA/npm/node_modules/@anthropic-ai/claude-code/cli.js" ]; then
+                CLAUDE_CLI_JS="$APPDATA/npm/node_modules/@anthropic-ai/claude-code/cli.js"
+            elif [ -f "$HOME/.npm-global/lib/node_modules/@anthropic-ai/claude-code/cli.js" ]; then
+                CLAUDE_CLI_JS="$HOME/.npm-global/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+            fi
+        fi
+
+        if [ -z "$CLAUDE_PATH" ]; then
+            # First check if claude is in PATH
+            if command -v claude &> /dev/null; then
+                CLAUDE_PATH=$(command -v claude)
+            # Native installer location (~/.local/bin/)
+            elif [ -f "$HOME/.local/bin/claude.exe" ]; then
+                CLAUDE_PATH="$HOME/.local/bin/claude.exe"
+            elif [ -f "$HOME/.local/bin/claude" ]; then
+                CLAUDE_PATH="$HOME/.local/bin/claude"
+            # nvm for Windows (nvm4w) - common location
+            elif [ -f "/c/nvm4w/nodejs/claude" ]; then
+                CLAUDE_PATH="/c/nvm4w/nodejs/claude"
+            elif [ -f "/c/nvm4w/nodejs/claude.cmd" ]; then
+                CLAUDE_PATH="/c/nvm4w/nodejs/claude.cmd"
+            # npm global installs on Windows (typically %APPDATA%\npm)
+            elif [ -n "$APPDATA" ] && [ -f "$APPDATA/npm/claude.cmd" ]; then
+                CLAUDE_PATH="$APPDATA/npm/claude.cmd"
+            elif [ -n "$APPDATA" ] && [ -f "$APPDATA/npm/claude" ]; then
+                CLAUDE_PATH="$APPDATA/npm/claude"
+            # Custom npm prefix location
+            elif [ -f "$HOME/.npm-global/bin/claude" ]; then
+                CLAUDE_PATH="$HOME/.npm-global/bin/claude"
+            # nvm for Windows - alternative locations
+            elif [ -n "$NVM_SYMLINK" ] && [ -f "$NVM_SYMLINK/claude.cmd" ]; then
+                CLAUDE_PATH="$NVM_SYMLINK/claude.cmd"
+            elif [ -n "$NVM_HOME" ] && [ -f "$NVM_HOME/nodejs/claude" ]; then
+                CLAUDE_PATH="$NVM_HOME/nodejs/claude"
+            # Local node_modules (if installed locally)
+            elif [ -f "./node_modules/.bin/claude" ]; then
+                CLAUDE_PATH="./node_modules/.bin/claude"
+            # Fallback: try to find using 'where' command (Windows)
+            elif where claude &> /dev/null 2>&1; then
+                CLAUDE_PATH=$(where claude 2>/dev/null | head -1 | tr -d '\r')
+            fi
+        fi
+
+        echo -e "\033[90mDEBUG: CLAUDE_PATH='$CLAUDE_PATH'\033[0m"
+        echo -e "\033[90mDEBUG: CLAUDE_CLI_JS='$CLAUDE_CLI_JS'\033[0m"
+
+        if [ -z "$CLAUDE_PATH" ] && [ -z "$CLAUDE_CLI_JS" ]; then
+            echo -e "\033[31m❌ ERROR: claude not found\033[0m"
+            echo -e "\033[33mSearched locations:\033[0m"
+            echo -e "  - PATH (command -v): not found"
+            echo -e "  - /c/nvm4w/nodejs/claude: not found"
+            [ -n "$APPDATA" ] && echo -e "  - \$APPDATA/npm/claude.cmd: not found"
+            echo -e "  - ~/.npm-global/bin/claude: not found"
+            echo -e "  - ./node_modules/.bin/claude: not found"
+            echo -e "\033[33mPlease ensure Claude Code CLI is installed:\033[0m"
+            echo -e "  npm install -g @anthropic-ai/claude-code"
+            return 1
+        fi
+
+        # Run Claude - it will handle Escape and Ctrl+C internally
+        # MSYS_NO_PATHCONV=1 prevents Git Bash from converting /skill to C:/Program Files/Git/skill
+        #
+        # Use winpty if available - it creates a proper pseudo-terminal on Windows
+        # that handles escape sequences and special keys correctly
+        #
+        # Strategy: Try methods in order of reliability
+        # 1. Direct node execution of CLI.js (most reliable on Windows)
+        # 2. winpty with full path to claude script
+        # 3. Direct execution as fallback
+        #
+        # IMPORTANT: Claude CLI expects: claude [flags] [prompt]
+        # The prompt is passed as a positional argument, NOT with --prompt flag
+        #
+        # CRITICAL: We read from environment variables instead of $@ to avoid
+        # MSYS path conversion. Git Bash converts "/skill" to "C:/Program Files/Git/skill"
+        # even with MSYS_NO_PATHCONV=1 when passed as command-line args.
+        # We use BASE64 encoding to completely prevent any path conversion.
+        local flags_str="${CLAUDE_FLAGS_OVERRIDE:-}"
+        local prompt=""
+        if [ -n "${CLAUDE_PROMPT_OVERRIDE_B64:-}" ]; then
+            # Decode from base64 - this is the safe path that won't be converted
+            # Use printf (not echo) to avoid adding newline before piping
+            # Use tr -d '\r' to strip any Windows carriage returns
+            # Try GNU base64 (-d) first, only fall back to BSD (--decode) if result is empty
+            prompt=$(printf '%s' "$CLAUDE_PROMPT_OVERRIDE_B64" | base64 -d 2>/dev/null | tr -d '\r')
+
+            # Fallback: if base64 -d fails (empty result), try base64 --decode (macOS/BSD)
+            if [ -z "$prompt" ] && [ -n "$CLAUDE_PROMPT_OVERRIDE_B64" ]; then
+                prompt=$(printf '%s' "$CLAUDE_PROMPT_OVERRIDE_B64" | base64 --decode 2>/dev/null | tr -d '\r')
+            fi
+
+            echo -e "\033[90mDEBUG: Decoded prompt='$prompt'\033[0m"
+        fi
+
+        # Convert flags string to array
+        local flags=()
+        if [ -n "$flags_str" ]; then
+            read -ra flags <<< "$flags_str"
+        fi
+
+        echo -e "\033[90mDEBUG: flags_str='$flags_str'\033[0m"
+        echo -e "\033[90mDEBUG: flags array=(${flags[*]})\033[0m"
+        echo -e "\033[90mDEBUG: prompt='$prompt'\033[0m"
+        echo -e "\033[90mDEBUG: B64 env var='$CLAUDE_PROMPT_OVERRIDE_B64'\033[0m"
+
+        # Build the command - prompt is a positional argument, not a flag
+        # Claude CLI syntax: claude [options] [prompt]
+        #
+        # CRITICAL: Even with MSYS_NO_PATHCONV=1, array expansion can still trigger
+        # path conversion in some Git Bash versions. To be absolutely safe, we:
+        # 1. Export MSYS_NO_PATHCONV=1 (affects child processes)
+        # 2. Also set it inline (affects current command)
+        # 3. Use eval with properly quoted arguments as last resort
+        export MSYS_NO_PATHCONV=1
+        export MSYS2_ARG_CONV_EXCL='*'
+
+        local cmd_args=("${flags[@]}")
+        if [ -n "$prompt" ]; then
+            cmd_args+=("$prompt")
+        fi
+
+        echo -e "\033[90mDEBUG: Final cmd_args=(${cmd_args[*]})\033[0m"
+
+        # =================================================================
+        # MSYS PATH CONVERSION FIX:
+        # Array expansion ${cmd_args[@]} triggers path conversion in Git Bash
+        # even with MSYS_NO_PATHCONV=1. The solution is to pass the prompt
+        # through a temp file that's sourced, avoiding bash argument expansion.
+        # =================================================================
+
+        # =================================================================
+        # CRITICAL FIX: Decode base64 at execution time, not before!
+        #
+        # The problem: Even with MSYS_NO_PATHCONV=1, when we write
+        # '/test-ascii --no-restart' literally to a script and then source it,
+        # Git Bash STILL converts it to 'C:/Program Files/Git/test-ascii'.
+        #
+        # The solution: Keep the prompt base64 encoded until the EXACT moment
+        # of execution. The string '/test-ascii' should NEVER appear literally
+        # in any bash script that gets sourced.
+        # =================================================================
+
+        # Get the base64-encoded prompt from environment (set by parent script)
+        local prompt_b64="${CLAUDE_PROMPT_OVERRIDE_B64:-}"
+
+        # Create a mini-script that decodes and executes in one command
+        local EXEC_SCRIPT=$(mktemp /tmp/claude-exec-XXXXXX.sh)
+
+        cat > "$EXEC_SCRIPT" << 'EXEC_EOF'
+#!/bin/bash
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL='*'
+EXEC_EOF
+
+        if [ -n "$CLAUDE_CLI_JS" ] && command -v node &> /dev/null; then
+            echo -e "\033[90mUsing node to run: $CLAUDE_CLI_JS\033[0m"
+
+            # Build command - but decode prompt INLINE at execution time
+            # This prevents MSYS from ever seeing the /skill-name string
+            if command -v winpty &> /dev/null; then
+                echo -n 'winpty ' >> "$EXEC_SCRIPT"
+            fi
+            echo -n "node '$CLAUDE_CLI_JS'" >> "$EXEC_SCRIPT"
+
+            # Add flags (these don't start with / so they're safe)
+            for flag in "${flags[@]}"; do
+                printf " '%s'" "$flag" >> "$EXEC_SCRIPT"
+            done
+
+            # Add prompt - decode base64 INLINE so /skill never appears literally
+            if [ -n "$prompt_b64" ]; then
+                # The magic: Decode base64 at runtime AND prefix with extra / to prevent MSYS conversion
+                # MSYS treats // as UNC path prefix and doesn't convert it
+                # We decode, check if starts with /, and if so add another /
+                # The sed 's#^/#//#' converts /skill to //skill which MSYS leaves alone
+                # Using # as delimiter instead of | to avoid conflicts with pipe characters in prompts
+                printf ' "$(printf '"'"'%%s'"'"' '"'"'%s'"'"' | base64 -d 2>/dev/null | sed '"'"'s#^/#//#'"'"' || printf '"'"'%%s'"'"' '"'"'%s'"'"' | base64 --decode 2>/dev/null | sed '"'"'s#^/#//#'"'"')"' "$prompt_b64" "$prompt_b64" >> "$EXEC_SCRIPT"
+            fi
+            echo "" >> "$EXEC_SCRIPT"
+
+        elif [ -n "$CLAUDE_PATH" ]; then
+            echo -e "\033[90mUsing claude at: $CLAUDE_PATH\033[0m"
+
+            if command -v winpty &> /dev/null; then
+                echo -n 'winpty ' >> "$EXEC_SCRIPT"
+            fi
+            printf "'%s'" "$CLAUDE_PATH" >> "$EXEC_SCRIPT"
+
+            for flag in "${flags[@]}"; do
+                printf " '%s'" "$flag" >> "$EXEC_SCRIPT"
+            done
+
+            # Same inline decode for CLAUDE_PATH method - with // prefix to prevent MSYS conversion
+            # Using # as delimiter instead of | to avoid conflicts with pipe characters in prompts
+            if [ -n "$prompt_b64" ]; then
+                printf ' "$(printf '"'"'%%s'"'"' '"'"'%s'"'"' | base64 -d 2>/dev/null | sed '"'"'s#^/#//#'"'"' || printf '"'"'%%s'"'"' '"'"'%s'"'"' | base64 --decode 2>/dev/null | sed '"'"'s#^/#//#'"'"')"' "$prompt_b64" "$prompt_b64" >> "$EXEC_SCRIPT"
+            fi
+            echo "" >> "$EXEC_SCRIPT"
+        fi
+
+        echo -e "\033[90mDEBUG: Exec script contents:\033[0m"
+        cat "$EXEC_SCRIPT" | head -10
+
+        # Execute the script - the /skill string only exists AFTER base64 decode
+        # at the exact moment node/claude receives it
+        chmod +x "$EXEC_SCRIPT"
+        source "$EXEC_SCRIPT"
+        EXIT_CODE=$?
+        rm -f "$EXEC_SCRIPT"
+
+        # Check exit code:
+        # 0 = normal exit (user typed /exit or similar)
+        # 130 = SIGINT (Ctrl+C) - Claude handles this, just show prompt
+        # Other = error
+
+        echo ""
+        if [ $EXIT_CODE -eq 0 ]; then
+            echo -e "\033[32mClaude session ended normally.\033[0m"
+        elif [ $EXIT_CODE -eq 130 ]; then
+            echo -e "\033[33mClaude interrupted (Ctrl+C).\033[0m"
+        else
+            echo -e "\033[31mClaude exited with code $EXIT_CODE\033[0m"
+        fi
+
+        echo ""
+        echo -e "\033[36mOptions:\033[0m"
+        echo -e "  \033[33mr\033[0m - Restart Claude with same command"
+        echo -e "  \033[33mc\033[0m - Start new Claude session (no command)"
+        echo -e "  \033[33mq\033[0m - Quit and close terminal"
+        echo -e "  \033[33mENTER\033[0m - Stay in bash shell"
+        echo ""
+        read -p "Choice [r/c/q/ENTER]: " -n 1 choice
+        echo ""
+
+        case "$choice" in
+            r|R)
+                echo -e "\033[32mRestarting Claude...\033[0m"
+                continue
+                ;;
+            c|C)
+                echo -e "\033[32mStarting fresh Claude session...\033[0m"
+                # Use same logic as main execution - prefer CLI.js
+                if [ -n "$CLAUDE_CLI_JS" ] && command -v node &> /dev/null; then
+                    if command -v winpty &> /dev/null; then
+                        MSYS_NO_PATHCONV=1 winpty node "$CLAUDE_CLI_JS"
+                    else
+                        MSYS_NO_PATHCONV=1 node "$CLAUDE_CLI_JS"
+                    fi
+                elif [ -n "$CLAUDE_PATH" ]; then
+                    if command -v winpty &> /dev/null; then
+                        MSYS_NO_PATHCONV=1 winpty "$CLAUDE_PATH"
+                    else
+                        MSYS_NO_PATHCONV=1 "$CLAUDE_PATH"
+                    fi
+                fi
+                ;;
+            q|Q)
+                echo -e "\033[33mExiting...\033[0m"
+                exit 0
+                ;;
+            *)
+                echo -e "\033[32mDropping to bash shell. Type '$CLAUDE_PATH' to start a new session.\033[0m"
+                return 0
+                ;;
+        esac
+    done
+}
+SCRIPT_HEADER
+
+cat >> "$TEMP_SCRIPT" << SCRIPT_BODY
+cd '$PROJECT_PATH'
+
+# Pass the detected paths to the run_claude function
+# This ensures it can find claude even if the new terminal's PATH differs
+export CLAUDE_PATH_OVERRIDE='$DETECTED_CLAUDE_PATH'
+export CLAUDE_CLI_JS_OVERRIDE='$DETECTED_CLI_JS'
+
+# CRITICAL: Pass prompt via BASE64 to completely avoid MSYS path conversion
+# Environment variables can still get converted in some contexts.
+# Base64 encoding ensures no path-like strings exist to be converted.
+export CLAUDE_PROMPT_OVERRIDE_B64='$SKILL_COMMAND_B64'
+export CLAUDE_FLAGS_OVERRIDE='$CLAUDE_FLAGS'
+
+$KILL_CMD
+echo -e "\033[32m🚀 Fresh Claude session starting...\033[0m"
+echo -e "\033[36mCommand: claude $CLAUDE_FLAGS \"$SKILL_COMMAND\"\033[0m"
+echo ""
+run_claude
+SCRIPT_BODY
+
+chmod +x "$TEMP_SCRIPT"
+
+# =============================================================================
+# SPAWN NEW MINTTY WITH MATCHING ELEVATION
+# =============================================================================
+# When already elevated, child processes inherit admin rights automatically
+# No special handling needed - just spawn mintty directly in both cases
+#
+# Mintty options used:
+#   -o AllowSetSelection=yes    - Allow programs to access clipboard
+#   -o ScrollbackLines=10000    - Increase scrollback buffer
+#   -o ConfirmExit=no           - Don't prompt on close (we handle exit ourselves)
+#   -o BellType=0               - Disable terminal bell (less annoying)
+#   -o Term=xterm-256color      - Set terminal type for proper escape sequences
+#   -o CtrlShiftShortcuts=false - Don't use Ctrl+Shift shortcuts (pass to app)
+#   -o AltSendsEsc=true         - Alt key sends Escape prefix (standard behavior)
+
+MINTTY_OPTS="-o AllowSetSelection=yes -o ScrollbackLines=10000 -o ConfirmExit=no -o BellType=0 -o Term=xterm-256color -o CtrlShiftShortcuts=false -o AltSendsEsc=true"
+
+# CRITICAL: Disable the EXIT trap before spawning mintty
+# The mintty command handles its own cleanup (rm -f inside -c string)
+# If we keep the trap, it fires on exit 0 BEFORE mintty can read the temp file
+trap - EXIT INT TERM
+
+if [ "$IS_ADMIN" = "True" ]; then
+    # When already elevated, child processes inherit elevation automatically
+    # Using -Verb RunAs when already admin can cause issues - just spawn directly
+    echo -e "\033[90mSpawning mintty (elevation inherited from parent)...\033[0m"
+    "$MINTTY_PATH" $MINTTY_OPTS -e bash -il -c "source '$TEMP_SCRIPT'; rm -f '$TEMP_SCRIPT'; exec bash -il" &
+else
+    # Spawn regular (non-elevated) mintty directly
+    echo -e "\033[90mSpawning mintty directly...\033[0m"
+    "$MINTTY_PATH" $MINTTY_OPTS -e bash -il -c "source '$TEMP_SCRIPT'; rm -f '$TEMP_SCRIPT'; exec bash -il" &
+fi
+
+exit 0

--- a/.claude/tools/slack-mcp.mjs
+++ b/.claude/tools/slack-mcp.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Slack MCP Server
+ *
+ * Provides Slack integration for Claude Code with explicit .env.local loading.
+ * This is a wrapper around @modelcontextprotocol/server-slack that loads
+ * credentials from .env.local files (project root or .claude/tools/).
+ *
+ * Requires SLACK_BOT_TOKEN and SLACK_TEAM_ID in .env.local
+ */
+/* global process */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..', '..');
+
+// Load environment variables from .env.local
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) return;
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    // Match SLACK_BOT_TOKEN or SLACK_TEAM_ID
+    const match = trimmed.match(/^(SLACK_[A-Z_]+)=(.+)$/);
+    if (match) {
+      const key = match[1];
+      // Only allow the specific variables we expect
+      if (key !== 'SLACK_BOT_TOKEN' && key !== 'SLACK_TEAM_ID') {
+        continue;
+      }
+      let value = match[2].trim();
+      // Handle quoted values
+      if ((value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      process.env[key] = value;
+    }
+  }
+}
+
+// Load from both project root and tools directory
+loadEnvFile(path.join(projectRoot, '.env.local'));
+loadEnvFile(path.join(__dirname, '.env.local'));
+
+// Validate required variables
+const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
+const SLACK_TEAM_ID = process.env.SLACK_TEAM_ID;
+
+if (!SLACK_BOT_TOKEN || !SLACK_TEAM_ID) {
+  console.error('Error: Missing required Slack credentials');
+  if (!SLACK_BOT_TOKEN) console.error('  - SLACK_BOT_TOKEN not found');
+  if (!SLACK_TEAM_ID) console.error('  - SLACK_TEAM_ID not found');
+  console.error('');
+  console.error('Please set them in .env.local or .claude/tools/.env.local');
+  console.error('See .claude/docs/SLACK_MCP_SETUP.md for setup instructions');
+  process.exit(1);
+}
+
+// Spawn the official Slack MCP server with loaded environment variables
+const slackMcp = spawn('npx', ['-y', '@modelcontextprotocol/server-slack'], {
+  env: {
+    ...process.env,
+    SLACK_BOT_TOKEN,
+    SLACK_TEAM_ID,
+  },
+  stdio: 'inherit',
+  shell: true, // Required for Windows to find npx
+});
+
+slackMcp.on('error', (error) => {
+  console.error('Failed to start Slack MCP server:', error);
+  process.exit(1);
+});
+
+slackMcp.on('close', (code) => {
+  process.exit(code || 0);
+});

--- a/.claude/tools/test-prompt-delivery.sh
+++ b/.claude/tools/test-prompt-delivery.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# test-prompt-delivery.sh
+# Tests how Claude CLI handles prompt arguments
+
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL='*'
+
+echo "=== Claude Prompt Delivery Test ==="
+echo ""
+
+# Test 1: Check if Claude auto-submits prompts
+echo "Test 1: Does Claude auto-submit prompt arguments?"
+echo "Running: claude 'hello test'"
+echo "Expected: Claude should respond to 'hello test' automatically"
+echo ""
+echo "Press Enter to run test (Ctrl+C to skip)..."
+read
+
+timeout 30 claude "hello test" || echo "Test completed or timed out"
+
+echo ""
+echo "=== Results ==="
+echo "Did Claude:"
+echo "  a) Immediately respond to 'hello test'? (auto-submit works)"
+echo "  b) Show 'hello test' in input but wait for Enter? (no auto-submit)"
+echo "  c) Show an error? (prompt not recognized)"
+echo ""
+
+# Test 2: Test with slash command
+echo "Test 2: Testing with slash command format"
+echo "Running: claude '/test-ascii --no-restart'"
+echo ""
+echo "Press Enter to run test (Ctrl+C to skip)..."
+read
+
+timeout 30 claude "/test-ascii --no-restart" || echo "Test completed or timed out"
+
+echo ""
+echo "=== Analysis ==="
+echo "If Claude showed 'Unknown command: /test-ascii' - the CLI is parsing it as a command"
+echo "If Claude executed the skill - the current approach should work"
+echo "If Claude just showed the prompt but didn't process - we need stdin piping"

--- a/.claude/tools/vercel-lite-mcp.mjs
+++ b/.claude/tools/vercel-lite-mcp.mjs
@@ -1,0 +1,428 @@
+#!/usr/bin/env node
+/**
+ * Lightweight Vercel MCP Server
+ *
+ * A zero-dependency MCP server using only Node.js built-ins.
+ * Implements MCP protocol (JSON-RPC 2.0 over stdio) directly.
+ *
+ * Essential Tools Provided:
+ * - vercel_list_deployments: List recent deployments
+ * - vercel_get_deployment: Get deployment details and status
+ * - vercel_get_deployment_events: Get build logs/events
+ * - vercel_list_projects: List projects
+ * - vercel_get_project: Get project details
+ * - vercel_get_project_domains: Get domains for a project
+ * - vercel_get_project_env: Get environment variable names
+ * - vercel_cancel_deployment: Cancel a building deployment
+ * - vercel_redeploy: Trigger a redeployment
+ * - vercel_get_latest_deployment: Get latest deployment for a project
+ *
+ * Requires VERCEL_TOKEN in .env.local or .claude/tools/.env.local
+ */
+/* global process */
+
+import { existsSync, readFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import { createInterface } from "readline";
+
+const __toolsDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__toolsDir, "..", "..");
+
+// Load environment variables
+function loadEnvFile(filePath) {
+  if (!existsSync(filePath)) return;
+  const content = readFileSync(filePath, "utf-8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const match = trimmed.match(/^VERCEL_TOKEN=(.+)$/);
+    if (match) {
+      let token = match[1].trim();
+      if ((token.startsWith('"') && token.endsWith('"')) ||
+          (token.startsWith("'") && token.endsWith("'"))) {
+        token = token.slice(1, -1);
+      }
+      process.env.VERCEL_TOKEN = token;
+      break;
+    }
+  }
+}
+
+loadEnvFile(join(projectRoot, ".env.local"));
+loadEnvFile(join(__toolsDir, ".env.local"));
+
+const VERCEL_TOKEN = process.env.VERCEL_TOKEN;
+if (!VERCEL_TOKEN) {
+  console.error("Error: VERCEL_TOKEN not found");
+  process.exit(1);
+}
+
+const VERCEL_API = "https://api.vercel.com";
+
+// API helper
+async function vercelFetch(endpoint, options = {}) {
+  const url = `${VERCEL_API}${endpoint}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${VERCEL_TOKEN}`,
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Vercel API error (${response.status}): ${error}`);
+  }
+
+  return response.json();
+}
+
+// Tool definitions
+const TOOLS = [
+  {
+    name: "vercel_list_deployments",
+    description: "List recent deployments. Returns deployment ID, URL, state, and creation time.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string", description: "Filter by project ID or name" },
+        limit: { type: "number", description: "Number of deployments to return (default: 10, max: 100)" },
+        state: { type: "string", enum: ["BUILDING", "ERROR", "INITIALIZING", "QUEUED", "READY", "CANCELED"], description: "Filter by deployment state" },
+      },
+    },
+  },
+  {
+    name: "vercel_get_deployment",
+    description: "Get details of a specific deployment by ID or URL. Includes status, build info, and errors.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        idOrUrl: { type: "string", description: "Deployment ID or URL" },
+      },
+      required: ["idOrUrl"],
+    },
+  },
+  {
+    name: "vercel_get_deployment_events",
+    description: "Get build logs and events for a deployment. Essential for debugging build failures.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        idOrUrl: { type: "string", description: "Deployment ID or URL" },
+        limit: { type: "number", description: "Number of events to return (default: 100)" },
+        direction: { type: "string", enum: ["backward", "forward"], description: "Direction to fetch events" },
+      },
+      required: ["idOrUrl"],
+    },
+  },
+  {
+    name: "vercel_list_projects",
+    description: "List all projects in the account.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        search: { type: "string", description: "Search projects by name" },
+        limit: { type: "number", description: "Number of projects to return (default: 20)" },
+      },
+    },
+  },
+  {
+    name: "vercel_get_project",
+    description: "Get details of a specific project including settings, domains, and environment info.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        idOrName: { type: "string", description: "Project ID or name" },
+      },
+      required: ["idOrName"],
+    },
+  },
+  {
+    name: "vercel_get_project_domains",
+    description: "Get all domains configured for a project.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        idOrName: { type: "string", description: "Project ID or name" },
+      },
+      required: ["idOrName"],
+    },
+  },
+  {
+    name: "vercel_get_project_env",
+    description: "Get environment variables for a project (names only, not values for security).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        idOrName: { type: "string", description: "Project ID or name" },
+        target: { type: "string", enum: ["production", "preview", "development"], description: "Environment target" },
+      },
+      required: ["idOrName"],
+    },
+  },
+  {
+    name: "vercel_cancel_deployment",
+    description: "Cancel a deployment that is currently building.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "Deployment ID to cancel" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "vercel_redeploy",
+    description: "Trigger a redeployment of an existing deployment.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        deploymentId: { type: "string", description: "Deployment ID to redeploy" },
+        target: { type: "string", enum: ["production", "preview"], description: "Deployment target" },
+      },
+      required: ["deploymentId"],
+    },
+  },
+  {
+    name: "vercel_get_latest_deployment",
+    description: "Get the latest deployment for a project (convenience wrapper).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string", description: "Project ID or name" },
+        target: { type: "string", enum: ["production", "preview"], description: "Filter by target (optional)" },
+      },
+      required: ["projectId"],
+    },
+  },
+];
+
+// Tool handlers
+async function handleTool(name, args) {
+  switch (name) {
+    case "vercel_list_deployments": {
+      const params = new URLSearchParams();
+      if (args.projectId) params.set("projectId", args.projectId);
+      if (args.limit) params.set("limit", String(args.limit));
+      if (args.state) params.set("state", args.state);
+      const data = await vercelFetch(`/v6/deployments?${params}`);
+      return data.deployments.map(d => ({
+        id: d.uid,
+        url: d.url,
+        state: d.state || d.readyState,
+        target: d.target,
+        createdAt: d.createdAt,
+        name: d.name,
+        meta: d.meta?.githubCommitMessage || d.meta?.gitlabCommitMessage,
+      }));
+    }
+
+    case "vercel_get_deployment": {
+      const data = await vercelFetch(`/v13/deployments/${args.idOrUrl}`);
+      return {
+        id: data.id,
+        url: data.url,
+        state: data.readyState,
+        target: data.target,
+        createdAt: data.createdAt,
+        buildingAt: data.buildingAt,
+        ready: data.ready,
+        errorCode: data.errorCode,
+        errorMessage: data.errorMessage,
+        meta: {
+          githubCommitRef: data.meta?.githubCommitRef,
+          githubCommitMessage: data.meta?.githubCommitMessage,
+          githubCommitAuthorName: data.meta?.githubCommitAuthorName,
+        },
+      };
+    }
+
+    case "vercel_get_deployment_events": {
+      const params = new URLSearchParams();
+      if (args.limit) params.set("limit", String(args.limit));
+      if (args.direction) params.set("direction", args.direction);
+      const data = await vercelFetch(`/v3/deployments/${args.idOrUrl}/events?${params}`);
+      return data.filter(e =>
+        e.type === "stdout" ||
+        e.type === "stderr" ||
+        e.type === "error" ||
+        e.type === "command" ||
+        e.type === "exit"
+      ).map(e => ({
+        type: e.type,
+        created: e.created,
+        text: e.text || e.payload?.text,
+      }));
+    }
+
+    case "vercel_list_projects": {
+      const params = new URLSearchParams();
+      if (args.search) params.set("search", args.search);
+      if (args.limit) params.set("limit", String(args.limit));
+      const data = await vercelFetch(`/v9/projects?${params}`);
+      return data.projects.map(p => ({
+        id: p.id,
+        name: p.name,
+        framework: p.framework,
+        updatedAt: p.updatedAt,
+        latestDeployments: p.latestDeployments?.map(d => ({
+          id: d.id,
+          state: d.readyState,
+          target: d.target,
+        })),
+      }));
+    }
+
+    case "vercel_get_project": {
+      const data = await vercelFetch(`/v9/projects/${args.idOrName}`);
+      return {
+        id: data.id,
+        name: data.name,
+        framework: data.framework,
+        nodeVersion: data.nodeVersion,
+        buildCommand: data.buildCommand,
+        devCommand: data.devCommand,
+        installCommand: data.installCommand,
+        outputDirectory: data.outputDirectory,
+        rootDirectory: data.rootDirectory,
+        updatedAt: data.updatedAt,
+      };
+    }
+
+    case "vercel_get_project_domains": {
+      const data = await vercelFetch(`/v9/projects/${args.idOrName}/domains`);
+      return data.domains.map(d => ({
+        name: d.name,
+        verified: d.verified,
+        gitBranch: d.gitBranch,
+        redirect: d.redirect,
+      }));
+    }
+
+    case "vercel_get_project_env": {
+      const params = new URLSearchParams();
+      if (args.target) params.set("target", args.target);
+      const data = await vercelFetch(`/v10/projects/${args.idOrName}/env?${params}`);
+      return data.envs.map(e => ({
+        key: e.key,
+        target: e.target,
+        type: e.type,
+        gitBranch: e.gitBranch,
+      }));
+    }
+
+    case "vercel_cancel_deployment": {
+      const data = await vercelFetch(`/v12/deployments/${args.id}/cancel`, {
+        method: "PATCH",
+      });
+      return { id: data.id, state: data.readyState };
+    }
+
+    case "vercel_redeploy": {
+      const body = { deploymentId: args.deploymentId };
+      if (args.target) body.target = args.target;
+      const data = await vercelFetch(`/v13/deployments`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      return { id: data.id, url: data.url, state: data.readyState };
+    }
+
+    case "vercel_get_latest_deployment": {
+      const params = new URLSearchParams();
+      params.set("projectId", args.projectId);
+      params.set("limit", "1");
+      if (args.target) params.set("target", args.target);
+      const data = await vercelFetch(`/v6/deployments?${params}`);
+      if (!data.deployments?.length) {
+        return { error: "No deployments found" };
+      }
+      const d = data.deployments[0];
+      return {
+        id: d.uid,
+        url: d.url,
+        state: d.state || d.readyState,
+        target: d.target,
+        createdAt: d.createdAt,
+        meta: d.meta?.githubCommitMessage,
+      };
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+// JSON-RPC response helpers
+function jsonRpcResponse(id, result) {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function jsonRpcError(id, code, message) {
+  return JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+// Handle MCP protocol messages
+async function handleMessage(message) {
+  const { id, method, params } = message;
+
+  try {
+    switch (method) {
+      case "initialize":
+        return jsonRpcResponse(id, {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {} },
+          serverInfo: { name: "vercel-lite", version: "1.0.0" },
+        });
+
+      case "notifications/initialized":
+        return null; // No response needed for notifications
+
+      case "tools/list":
+        return jsonRpcResponse(id, { tools: TOOLS });
+
+      case "tools/call": {
+        const { name, arguments: args } = params;
+        try {
+          const result = await handleTool(name, args || {});
+          return jsonRpcResponse(id, {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          });
+        } catch (error) {
+          return jsonRpcResponse(id, {
+            content: [{ type: "text", text: `Error: ${error.message}` }],
+            isError: true,
+          });
+        }
+      }
+
+      default:
+        return jsonRpcError(id, -32601, `Method not found: ${method}`);
+    }
+  } catch (error) {
+    return jsonRpcError(id, -32603, error.message);
+  }
+}
+
+// Main: Read JSON-RPC messages from stdin, write responses to stdout
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", async (line) => {
+  if (!line.trim()) return;
+
+  try {
+    const message = JSON.parse(line);
+    const response = await handleMessage(message);
+    if (response) {
+      process.stdout.write(response + "\n");
+    }
+  } catch (error) {
+    const errorResponse = jsonRpcError(null, -32700, "Parse error");
+    process.stdout.write(errorResponse + "\n");
+  }
+});
+
+rl.on("close", () => process.exit(0));

--- a/.claude/tools/vercel-mcp.mjs
+++ b/.claude/tools/vercel-mcp.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform wrapper script for Vercel MCP server
+ *
+ * Loads VERCEL_TOKEN from environment files and runs the MCP server.
+ * Checks the following locations (in order):
+ * 1. Project root: .env.local
+ * 2. Script directory: .claude/tools/.env.local
+ *
+ * Uses @vercel/sdk - the OFFICIAL Vercel SDK with MCP server support.
+ * GitHub: https://github.com/vercel/sdk
+ * Provides ~95+ tools covering the full Vercel REST API.
+ *
+ * Requires VERCEL_TOKEN environment variable to be set.
+ *
+ * To get a Vercel token:
+ * 1. Go to https://vercel.com/account/tokens
+ * 2. Click "Create" to generate a new token
+ * 3. Add to .env.local: VERCEL_TOKEN=your_token_here
+ *
+ * Requires Node.js v20 or greater.
+ * Compatible with Windows, macOS, and Linux.
+ */
+/* global process */
+
+import { spawn } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// Get the directory where this script is located
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const scriptDir = __dirname;
+// Go up two levels: .claude/tools/ -> .claude/ -> project root
+const projectRoot = path.resolve(scriptDir, "..", "..");
+
+// Change to project root
+process.chdir(projectRoot);
+
+// Function to load environment variables from .env.local
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  const content = fs.readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+
+  for (const line of lines) {
+    // Skip comments and empty lines
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    // Match VERCEL_TOKEN=value
+    const match = trimmed.match(/^VERCEL_TOKEN=(.+)$/);
+    if (match) {
+      // Remove quotes if present
+      let token = match[1].trim();
+      if (
+        (token.startsWith('"') && token.endsWith('"')) ||
+        (token.startsWith("'") && token.endsWith("'"))
+      ) {
+        token = token.slice(1, -1);
+      }
+      process.env.VERCEL_TOKEN = token;
+      break;
+    }
+  }
+}
+
+// Load from project root .env.local
+const projectEnvPath = path.join(projectRoot, ".env.local");
+loadEnvFile(projectEnvPath);
+
+// Also check .claude/tools/.env.local
+const toolsEnvPath = path.join(scriptDir, ".env.local");
+loadEnvFile(toolsEnvPath);
+
+// Ensure token is available
+const token = process.env.VERCEL_TOKEN;
+if (!token) {
+  console.error("Error: VERCEL_TOKEN not found.");
+  console.error(
+    "Please set VERCEL_TOKEN in .env.local or .claude/tools/.env.local",
+  );
+  console.error("Get a token at: https://vercel.com/account/tokens");
+  process.exit(1);
+}
+
+// Run the official Vercel SDK MCP server with bearer token auth
+// Using @vercel/sdk - official Vercel package
+const args = [
+  "-y",
+  "--package",
+  "@vercel/sdk",
+  "--",
+  "mcp",
+  "start",
+  "--bearer-token",
+  token,
+  ...process.argv.slice(2),
+];
+
+// On Windows, use shell: true to properly handle .cmd files
+const spawnOptions = {
+  stdio: "inherit",
+  env: process.env,
+  cwd: projectRoot,
+  ...(process.platform === "win32" && { shell: true }),
+};
+
+const child = spawn("npx", args, spawnOptions);
+
+child.on("error", (error) => {
+  console.error("Error spawning Vercel MCP server:", error);
+  process.exit(1);
+});
+
+child.on("exit", (code) => {
+  process.exit(code || 0);
+});


### PR DESCRIPTION
## Summary

- Add self-contained MCP server implementations for git, GitHub, Slack, Linear, Vercel, and LogRocket
- Add Claude launcher scripts (bash/PowerShell) for detecting flags and encoding prompts
- Add `.env.local.example` template for MCP secrets
- Add `CLAUDE.md` and `README.md` documentation for the tools directory

## Test plan

- [ ] MCP tools follow the portability rule (no `npm install`, built-in modules only)
- [ ] `.env.local.example` uses placeholder values only
- [ ] No secrets or project-specific URLs committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)