### PR TITLE
fix(i18n): rename subtotal label to Total in store and payments

### DIFF
--- a/apps/payments/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/payments/src/shared/infrastructure/i18n/messages/en.json
@@ -62,7 +62,7 @@
     "outOfStock": "Some items are no longer available",
     "stockError": "Could not reserve stock for some items",
     "items": "{count} {count, plural, one {item} other {items}}",
-    "subtotal": "Subtotal",
+    "subtotal": "Total",
     "total": "Total",
     "allSubmitted": "All payments submitted!",
     "goToOrders": "View My Orders",

--- a/apps/payments/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/payments/src/shared/infrastructure/i18n/messages/es.json
@@ -62,7 +62,7 @@
     "outOfStock": "Algunos articulos ya no estan disponibles",
     "stockError": "No se pudo reservar el stock de algunos articulos",
     "items": "{count} {count, plural, one {articulo} other {articulos}}",
-    "subtotal": "Subtotal",
+    "subtotal": "Total",
     "total": "Total",
     "allSubmitted": "Todos los pagos enviados!",
     "goToOrders": "Ver Mis Ordenes",

--- a/apps/store/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/store/src/shared/infrastructure/i18n/messages/en.json
@@ -159,7 +159,7 @@
     "removeItem": "Remove {name}",
     "sellerGroup": "{sellerName}",
     "unknownSeller": "Unknown seller",
-    "subtotal": "Subtotal"
+    "subtotal": "Total"
   },
   "categories": {
     "fursuits": "Fursuits",

--- a/apps/store/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/store/src/shared/infrastructure/i18n/messages/es.json
@@ -159,7 +159,7 @@
     "removeItem": "Eliminar {name}",
     "sellerGroup": "{sellerName}",
     "unknownSeller": "Vendedor desconocido",
-    "subtotal": "Subtotal"
+    "subtotal": "Total"
   },
   "categories": {
     "fursuits": "Fursuits",


### PR DESCRIPTION
## Summary

- Cambia el valor de la clave `subtotal` de `"Subtotal"` → `"Total"` en los 4 archivos i18n (store + payments, en + es)

## Motivation

El texto "Subtotal" implica que pueden existir cargos adicionales (IVA, impuestos, etc.). Como no hay cargos adicionales, el término correcto es "Total" para evitar confusión en el comprador.

## Files changed

- `apps/store/src/shared/infrastructure/i18n/messages/en.json`
- `apps/store/src/shared/infrastructure/i18n/messages/es.json`
- `apps/payments/src/shared/infrastructure/i18n/messages/en.json`
- `apps/payments/src/shared/infrastructure/i18n/messages/es.json`

## Test plan

- [ ] Los tests existentes no se rompen (el mock de `useTranslations` devuelve la clave, no el valor)
- [ ] En el carrito del store se muestra "Total" en lugar de "Subtotal"
- [ ] En el resumen de checkout de payments se muestra "Total" en lugar de "Subtotal"

🤖 Generated with [Claude Code](https://claude.com/claude-code)