### PR TITLE
chore(infra): supabase wipe procedure, idempotent audit migration, clean script [GH-126]

### DIFF
--- a/.claude/rules/supabase-wipe.md
+++ b/.claude/rules/supabase-wipe.md
@@ -1,0 +1,161 @@
+# Supabase Full Wipe & Re-Migration Procedure
+
+> **Use this when the user asks for a "full wipe" of Supabase dev or prod.**
+
+---
+
+## Tokens and Projects
+
+| Environment | Project ID             | PAT Variable                 | PAT Location |
+| ----------- | ---------------------- | ---------------------------- | ------------ |
+| Dev         | `dsczudkhoolxjaxjeqdf` | `DEV_SUPABASE_ACCESS_TOKEN`  | `.secrets`   |
+| Prod        | `olafyajipvsltohagiah` | `PROD_SUPABASE_ACCESS_TOKEN` | `.secrets`   |
+
+The PATs are Personal Access Tokens for the Supabase Management API. They are stored in `.secrets` under:
+
+```
+# ─── Supabase Management API (Personal Access Tokens) ───────────
+DEV_SUPABASE_ACCESS_TOKEN=sbp_...
+PROD_SUPABASE_ACCESS_TOKEN=sbp_...
+```
+
+> **Note:** Direct port 5432 (Postgres) connections are blocked on Supabase Cloud from outside AWS. All DB operations must go through the Management API REST endpoint.
+
+---
+
+## Step 1: Drop and Recreate the Public Schema
+
+This wipes all tables, types, functions, policies, and triggers in the `public` schema.
+
+```bash
+TOKEN="<DEV_SUPABASE_ACCESS_TOKEN or PROD_SUPABASE_ACCESS_TOKEN>"
+PROJECT="<dsczudkhoolxjaxjeqdf or olafyajipvsltohagiah>"
+
+DROP_SQL="DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO postgres; GRANT ALL ON SCHEMA public TO public; GRANT ALL ON SCHEMA public TO anon; GRANT ALL ON SCHEMA public TO authenticated; GRANT ALL ON SCHEMA public TO service_role;"
+
+payload=$(python3 -c "import json; print(json.dumps({'query': '$DROP_SQL'}))")
+
+curl -s -X POST \
+  "https://api.supabase.com/v1/projects/${PROJECT}/database/query" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "$payload"
+```
+
+Expected response: `[]` with HTTP 201.
+
+> **Note:** This does NOT delete auth users. The `auth` schema is managed by Supabase and not touched by this command. If you also need to delete auth users, use the Supabase REST API with the service role key to list and delete users via `DELETE /auth/v1/admin/users/{id}`.
+
+---
+
+## Step 2: Apply All Migrations
+
+Run all 27 migration files in order using the Management API:
+
+```bash
+TOKEN="<DEV_SUPABASE_ACCESS_TOKEN or PROD_SUPABASE_ACCESS_TOKEN>"
+PROJECT="<dsczudkhoolxjaxjeqdf or olafyajipvsltohagiah>"
+
+run_migration() {
+  local file="$1"
+  local payload
+  payload=$(python3 -c "import json,sys; print(json.dumps({'query':open(sys.argv[1]).read()}))" "$file")
+
+  local tmpfile
+  tmpfile=$(mktemp)
+  local http_code
+  http_code=$(curl -s -o "$tmpfile" -w "%{http_code}" -X POST \
+    "https://api.supabase.com/v1/projects/${PROJECT}/database/query" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$payload")
+
+  local body
+  body=$(cat "$tmpfile")
+  rm -f "$tmpfile"
+
+  if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+    echo "✅ [$http_code] $(basename $file)"
+  else
+    echo "❌ [$http_code] $(basename $file)"
+    echo "   $body"
+  fi
+}
+
+for f in supabase/migrations/*.sql; do
+  run_migration "$f"
+done
+```
+
+All 27 files in `supabase/migrations/` should return ✅.
+
+---
+
+## Known Issues and Fixes
+
+### `audit.logged_actions` already exists (42P07)
+
+Supabase Cloud provides a built-in `audit` schema with `logged_actions`. The migration `20260325400000_audit_system.sql` was updated to use `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS` so it is idempotent.
+
+### Table filter for data-only wipe
+
+If you only need to wipe data (not schema), use these filters per table type:
+
+- Tables with UUID primary keys: `?created_at=gte.2000-01-01`
+- `payment_settings` table: `?updated_at=gte.2000-01-01` (no `created_at` column)
+
+---
+
+## Auth Users Wipe (if needed)
+
+```bash
+SERVICE_KEY="<DEV_SUPABASE_SERVICE_ROLE_KEY or PROD_SUPABASE_SERVICE_ROLE_KEY>"
+SUPABASE_URL="<DEV_SUPABASE_URL or PROD_SUPABASE_URL>"
+
+# List all users
+users=$(curl -s "${SUPABASE_URL}/auth/v1/admin/users?per_page=1000" \
+  -H "apikey: ${SERVICE_KEY}" \
+  -H "Authorization: Bearer ${SERVICE_KEY}")
+
+# Delete each user
+echo "$users" | python3 -c "
+import json, sys, subprocess
+data = json.load(sys.stdin)
+users = data.get('users', [])
+for u in users:
+    uid = u['id']
+    subprocess.run(['curl', '-s', '-X', 'DELETE',
+        '${SUPABASE_URL}/auth/v1/admin/users/' + uid,
+        '-H', 'apikey: ${SERVICE_KEY}',
+        '-H', 'Authorization: Bearer ${SERVICE_KEY}'])
+    print(f'Deleted: {uid}')
+"
+```
+
+---
+
+## Verify Schema After Migration
+
+```bash
+TOKEN="<token>"
+PROJECT="<project_id>"
+
+CHECK_SQL="SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' ORDER BY table_name"
+payload=$(python3 -c "import json,sys; print(json.dumps({'query': sys.argv[1]}))" "$CHECK_SQL")
+
+curl -s -X POST \
+  "https://api.supabase.com/v1/projects/${PROJECT}/database/query" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "$payload"
+```
+
+Expected tables after migration: `check_in_audit`, `check_ins`, `events`, `order_items`, `orders`, `payment_settings`, `permissions`, `product_entitlements`, `product_reviews`, `product_templates`, `products`, `resource_permissions`, `seller_admins`, `seller_payment_methods`, `ticket_transfers`, `user_permissions`, `user_profiles`.
+
+---
+
+## Related
+
+- `.secrets` — PATs and service role keys
+- `supabase/migrations/` — All 27 migration files
+- [Git Safety](.claude/rules/git-safety.md) — Never commit secrets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,10 @@ If any fail, keep in app's `shared/` folder instead.
 - [Git Workflow](.claude/rules/git-workflow.md)
 - [Git Safety](.claude/rules/git-safety.md)
 
+### Database & Infrastructure
+
+- [Supabase Full Wipe & Re-Migration](.claude/rules/supabase-wipe.md) — PAT tokens, drop schema, apply migrations for dev/prod
+
 ### AI Configuration
 
 - [Generated Code Policy](.claude/rules/generated-code-policy.md)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "supabase:stop": "node scripts/supabase-cmd.mjs stop",
     "supabase:reset": "node scripts/supabase-cmd.mjs db reset",
     "prepare": "husky",
-    "clean:builds": "find . -name '.next' -type d -not -path '*/node_modules/*' -exec rm -rf '{}' + ; find . -name '.turbo' -type d -not -path '*/node_modules/*' -exec rm -rf '{}' + ; find . -name 'tsconfig.tsbuildinfo' -not -path '*/node_modules/*' -delete",
+    "clean:builds": "find . -not -path '*/node_modules/*' -not -path '*/.git/*' \\( -name '.next' -o -name '.turbo' -o -name 'test-results' -o -name 'playwright-report' -o -name 'coverage' \\) -type d -prune -exec rm -rf '{}' + ; find . -not -path '*/node_modules/*' -not -path '*/.git/*' \\( -name 'tsconfig.tsbuildinfo' -o -name 'next-env.d.ts' \\) -delete",
     "clean": "pnpm clean:builds && find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +"
   },
   "devDependencies": {

--- a/supabase/migrations/20260325400000_audit_system.sql
+++ b/supabase/migrations/20260325400000_audit_system.sql
@@ -16,7 +16,7 @@ grant select on all tables in schema audit to authenticated;
 -- -----------------------------------------------------------------------------
 -- Audit log table
 -- -----------------------------------------------------------------------------
-create table audit.logged_actions (
+create table if not exists audit.logged_actions (
   event_id bigserial primary key,
   schema_name text not null,
   table_name text not null,
@@ -35,21 +35,22 @@ create table audit.logged_actions (
 );
 
 -- Indexes for efficient querying
-create index logged_actions_timestamp on audit.logged_actions
+create index if not exists logged_actions_timestamp on audit.logged_actions
   using brin(action_timestamp);
-create index logged_actions_table on audit.logged_actions
+create index if not exists logged_actions_table on audit.logged_actions
   using btree(table_name);
-create index logged_actions_user_id on audit.logged_actions
+create index if not exists logged_actions_user_id on audit.logged_actions
   using btree(user_id) where user_id is not null;
-create index logged_actions_action_type on audit.logged_actions
+create index if not exists logged_actions_action_type on audit.logged_actions
   using btree(action_type);
-create index logged_actions_row_data on audit.logged_actions
+create index if not exists logged_actions_row_data on audit.logged_actions
   using gin(row_data);
 
 -- RLS: restrict audit access to admin users only
 alter table audit.logged_actions enable row level security;
 
 -- Only users with 'audit-view' or 'manage' permission can read audit entries
+drop policy if exists "Audit: admin read only" on audit.logged_actions;
 create policy "Audit: admin read only"
   on audit.logged_actions for select
   using (
@@ -146,6 +147,10 @@ begin
   v_trigger_name := replace(replace(v_trigger_name, '.', '_'), '"', '');
 
   execute format(
+    'drop trigger if exists %I on %s',
+    v_trigger_name, target_table
+  );
+  execute format(
     'create trigger %I after insert or update or delete on %s '
     'for each row execute function audit.log_changes()',
     v_trigger_name, target_table
@@ -191,7 +196,7 @@ select audit.enable_tracking('public.user_permissions'::regclass);
 -- -----------------------------------------------------------------------------
 create schema if not exists audit_archive;
 
-create table audit_archive.logged_actions (like audit.logged_actions including all);
+create table if not exists audit_archive.logged_actions (like audit.logged_actions including all);
 
 -- Archive function: moves records older than retention_days in batches
 create or replace function audit.archive_old_logs(


### PR DESCRIPTION
## Summary

- Add `.claude/rules/supabase-wipe.md` documenting full wipe & re-migration procedure for dev/prod (PAT tokens, drop schema, apply all migrations via Management API)
- Update `CLAUDE.md` to reference the new supabase-wipe rule under Database & Infrastructure
- Make `20260325400000_audit_system.sql` fully idempotent: `IF NOT EXISTS` on all `CREATE TABLE`/`CREATE INDEX`, `DROP POLICY IF EXISTS` and `DROP TRIGGER IF EXISTS` before recreating — handles Supabase Cloud's built-in `audit` schema
- Extend `clean:builds` script to also remove `test-results`, `playwright-report`, `coverage`, and `next-env.d.ts` artifacts (detached `find` commands, no pnpm sub-process)

## Test plan

- [x] All 27 migrations applied successfully to dev and prod via Management API
- [x] Unit tests pass (`pnpm test`)
- [x] No lint/typecheck/format issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)