### PR TITLE
feat(admin): Excel export with embedded images and dynamic buyer_info columns [GH-126]

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -23,6 +23,7 @@
     "axios": "^1.9.0",
     "clsx": "^2.1.1",
     "cookies-next": "^6.1.1",
+    "exceljs": "^4.4.0",
     "lucide-react": "^0.511.0",
     "next": "16.2.0",
     "next-intl": "^4.1.4",

--- a/apps/admin/src/app/api/admin/reports/export/buildSalesWorkbook.ts
+++ b/apps/admin/src/app/api/admin/reports/export/buildSalesWorkbook.ts
@@ -1,0 +1,354 @@
+/* eslint-disable i18next/no-literal-string */
+import ExcelJS from "exceljs";
+
+const SUPABASE_URL =
+  process.env["SUPABASE_URL_INTERNAL"] || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const RECEIPT_CELL_WIDTH = 20;
+const RECEIPT_IMG_WIDTH = 140;
+const RECEIPT_IMG_HEIGHT = 100;
+const COL_WIDTH_DEFAULT = 20;
+const COL_WIDTH_WIDE = 30;
+const ROW_HEIGHT_DEFAULT = 20;
+const ROW_HEIGHT_WITH_IMAGE = 80;
+
+const ORDER_ID_HEADER = "Order ID";
+const DATE_HEADER = "Date";
+const BUYER_EMAIL_HEADER = "Buyer Email";
+const SELLER_EMAIL_HEADER = "Seller Email";
+const RECEIPT_HEADER = "Receipt";
+
+const WIDE_HEADERS = new Set([
+  ORDER_ID_HEADER,
+  DATE_HEADER,
+  BUYER_EMAIL_HEADER,
+  SELLER_EMAIL_HEADER,
+]);
+
+export interface OrderItemRow {
+  id: string;
+  order_id: string;
+  product_id: string;
+  quantity: number;
+  unit_price: number;
+  currency: string;
+  products: { name: string } | null;
+}
+
+export interface OrderRow {
+  id: string;
+  created_at: string;
+  payment_status: string;
+  total: number;
+  currency: string;
+  transfer_number: string | null;
+  receipt_url: string | null;
+  user_id: string;
+  seller_id: string | null;
+  buyer_info: Record<string, string> | null;
+}
+
+export interface UserProfileRow {
+  id: string;
+  email: string;
+  display_name: string | null;
+}
+
+export const CONTENT_TYPE_XLSX =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+const STATIC_HEADERS = [
+  ORDER_ID_HEADER,
+  DATE_HEADER,
+  "Status",
+  BUYER_EMAIL_HEADER,
+  "Buyer Name",
+  SELLER_EMAIL_HEADER,
+  "Seller Name",
+  "Product",
+  "Qty",
+  "Unit Price",
+  "Currency",
+  "Order Total",
+  "Transfer #",
+  RECEIPT_HEADER,
+] as const;
+
+async function fetchReceiptImage(storagePath: string): Promise<Buffer | null> {
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) return null;
+  try {
+    const url = `${SUPABASE_URL}/storage/v1/object/receipts/${storagePath}`;
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${SERVICE_ROLE_KEY}` },
+    });
+    if (!response.ok) return null;
+    return Buffer.from(await response.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+function getImageExtension(storagePath: string): "jpeg" | "png" | "gif" {
+  const lower = storagePath.toLowerCase();
+  if (lower.endsWith(".png")) return "png";
+  if (lower.endsWith(".gif")) return "gif";
+  return "jpeg";
+}
+
+function collectBuyerInfoKeys(orders: OrderRow[]): string[] {
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const order of orders) {
+    if (!order.buyer_info) continue;
+    for (const key of Object.keys(order.buyer_info)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push(key);
+      }
+    }
+  }
+  return keys;
+}
+
+function getColumnWidth(
+  header: string,
+  index: number,
+  buyerInfoStart: number,
+): number {
+  if (header === RECEIPT_HEADER) return RECEIPT_CELL_WIDTH;
+  if (WIDE_HEADERS.has(header) || index >= buyerInfoStart)
+    return COL_WIDTH_WIDE;
+  return COL_WIDTH_DEFAULT;
+}
+
+function buildSheetColumns(buyerInfoKeys: string[]): Partial<ExcelJS.Column>[] {
+  const allHeaders = [...STATIC_HEADERS, ...buyerInfoKeys];
+  const buyerInfoStart = STATIC_HEADERS.length;
+  return allHeaders.map((header, index) => ({
+    header,
+    key: `col_${index}`,
+    width: getColumnWidth(header, index, buyerInfoStart),
+  }));
+}
+
+function buildStaticCellValues(
+  order: OrderRow,
+  buyer: UserProfileRow | undefined,
+  seller: UserProfileRow | undefined,
+): Record<string, string | number> {
+  return {
+    col_0: order.id,
+    col_1: new Date(order.created_at).toLocaleString(),
+    col_2: order.payment_status,
+    col_3: buyer?.email ?? "",
+    col_4: buyer?.display_name ?? "",
+    col_5: seller?.email ?? "",
+    col_6: seller?.display_name ?? "",
+    col_11: order.total,
+    col_12: order.transfer_number ?? "",
+    col_13: "",
+  };
+}
+
+function buildBuyerInfoCellValues(
+  order: OrderRow,
+  buyerInfoKeys: string[],
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [i, key] of buyerInfoKeys.entries()) {
+    result[`col_${STATIC_HEADERS.length + i}`] = order.buyer_info?.[key] ?? "";
+  }
+  return result;
+}
+
+async function addReceiptImage(
+  workbook: ExcelJS.Workbook,
+  sheet: ExcelJS.Worksheet,
+  receiptUrl: string,
+  rowNumber: number,
+  receiptColIndex: number,
+): Promise<void> {
+  const imgBuffer = await fetchReceiptImage(receiptUrl);
+  if (!imgBuffer) return;
+  const imageId = workbook.addImage({
+    buffer: imgBuffer as unknown as ArrayBuffer,
+    extension: getImageExtension(receiptUrl),
+  });
+  sheet.addImage(imageId, {
+    tl: { col: receiptColIndex - 1, row: rowNumber - 1 },
+    ext: { width: RECEIPT_IMG_WIDTH, height: RECEIPT_IMG_HEIGHT },
+  });
+}
+
+async function addOrderRows(
+  workbook: ExcelJS.Workbook,
+  sheet: ExcelJS.Worksheet,
+  order: OrderRow,
+  buyer: UserProfileRow | undefined,
+  seller: UserProfileRow | undefined,
+  itemsByOrder: Map<string, OrderItemRow[]>,
+  buyerInfoKeys: string[],
+  receiptColIndex: number,
+): Promise<void> {
+  const staticValues = buildStaticCellValues(order, buyer, seller);
+  const buyerInfoValues = buildBuyerInfoCellValues(order, buyerInfoKeys);
+  const orderItems = itemsByOrder.get(order.id) ?? [];
+
+  const rowItems =
+    orderItems.length === 0
+      ? [{ name: "", qty: 0, price: 0, currency: order.currency }]
+      : orderItems.map((item) => ({
+          name: item.products?.name ?? "",
+          qty: item.quantity,
+          price: item.unit_price,
+          currency: item.currency,
+        }));
+
+  for (const item of rowItems) {
+    const row = sheet.addRow({
+      ...staticValues,
+      col_7: item.name,
+      col_8: item.qty,
+      col_9: item.price,
+      col_10: item.currency,
+      ...buyerInfoValues,
+    });
+    row.height = order.receipt_url ? ROW_HEIGHT_WITH_IMAGE : ROW_HEIGHT_DEFAULT;
+    row.alignment = { vertical: "middle" };
+    row.commit();
+
+    if (order.receipt_url) {
+      await addReceiptImage(
+        workbook,
+        sheet,
+        order.receipt_url,
+        row.number,
+        receiptColIndex,
+      );
+    }
+  }
+}
+
+export async function buildSalesWorkbook(
+  orders: OrderRow[],
+  profileMap: Map<string, UserProfileRow>,
+  itemsByOrder: Map<string, OrderItemRow[]>,
+): Promise<ExcelJS.Workbook> {
+  const buyerInfoKeys = collectBuyerInfoKeys(orders);
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = "Admin Reports";
+  workbook.created = new Date();
+
+  const sheet = workbook.addWorksheet("Sales Report");
+  sheet.columns = buildSheetColumns(buyerInfoKeys);
+
+  const headerRow = sheet.getRow(1);
+  headerRow.font = { bold: true };
+  headerRow.alignment = { vertical: "middle", horizontal: "center" };
+  headerRow.height = ROW_HEIGHT_DEFAULT;
+  headerRow.commit();
+
+  const receiptColIndex = STATIC_HEADERS.indexOf(RECEIPT_HEADER) + 1;
+
+  for (const order of orders) {
+    const buyer = profileMap.get(order.user_id);
+    const seller = order.seller_id
+      ? profileMap.get(order.seller_id)
+      : undefined;
+    await addOrderRows(
+      workbook,
+      sheet,
+      order,
+      buyer,
+      seller,
+      itemsByOrder,
+      buyerInfoKeys,
+      receiptColIndex,
+    );
+  }
+
+  addRawDataSheet(workbook, orders, itemsByOrder);
+
+  return workbook;
+}
+
+const RAW_ORDERS_HEADERS = [
+  "id",
+  "created_at",
+  "payment_status",
+  "total",
+  "currency",
+  "transfer_number",
+  "receipt_url",
+  "user_id",
+  "seller_id",
+  "buyer_info",
+] as const;
+
+const RAW_ITEMS_HEADERS = [
+  "id",
+  "order_id",
+  "product_id",
+  "quantity",
+  "unit_price",
+  "currency",
+] as const;
+
+function addRawDataSheet(
+  workbook: ExcelJS.Workbook,
+  orders: OrderRow[],
+  itemsByOrder: Map<string, OrderItemRow[]>,
+): void {
+  const ordersSheet = workbook.addWorksheet("Raw Orders");
+  ordersSheet.columns = RAW_ORDERS_HEADERS.map((h) => ({
+    header: h,
+    key: h,
+    width: COL_WIDTH_WIDE,
+  }));
+  const ordersHeader = ordersSheet.getRow(1);
+  ordersHeader.font = { bold: true };
+  ordersHeader.commit();
+
+  for (const order of orders) {
+    ordersSheet
+      .addRow({
+        id: order.id,
+        created_at: order.created_at,
+        payment_status: order.payment_status,
+        total: order.total,
+        currency: order.currency,
+        transfer_number: order.transfer_number ?? "",
+        receipt_url: order.receipt_url ?? "",
+        user_id: order.user_id,
+        seller_id: order.seller_id ?? "",
+        buyer_info: order.buyer_info ? JSON.stringify(order.buyer_info) : "",
+      })
+      .commit();
+  }
+
+  const itemsSheet = workbook.addWorksheet("Raw Order Items");
+  itemsSheet.columns = RAW_ITEMS_HEADERS.map((h) => ({
+    header: h,
+    key: h,
+    width: COL_WIDTH_WIDE,
+  }));
+  const itemsHeader = itemsSheet.getRow(1);
+  itemsHeader.font = { bold: true };
+  itemsHeader.commit();
+
+  for (const items of itemsByOrder.values()) {
+    for (const item of items) {
+      itemsSheet
+        .addRow({
+          id: item.id,
+          order_id: item.order_id,
+          product_id: item.product_id,
+          quantity: item.quantity,
+          unit_price: item.unit_price,
+          currency: item.currency,
+        })
+        .commit();
+    }
+  }
+}

--- a/apps/admin/src/app/api/admin/reports/export/route.ts
+++ b/apps/admin/src/app/api/admin/reports/export/route.ts
@@ -1,0 +1,209 @@
+/* eslint-disable i18next/no-literal-string */
+import ExcelJS from "exceljs";
+import { NextResponse } from "next/server";
+
+import {
+  buildSalesWorkbook,
+  CONTENT_TYPE_XLSX,
+  type OrderItemRow,
+  type OrderRow,
+  type UserProfileRow,
+} from "./buildSalesWorkbook";
+
+import {
+  adminFetch,
+  createRestPath,
+  FORBIDDEN_ERROR,
+  getAuthorizedAdmin,
+  INTERNAL_SERVER_ERROR_STATUS,
+} from "@/app/api/admin/_shared/adminRest";
+
+const ADMIN_REPORTS = "admin.reports";
+const MAX_LIMIT = 10_000;
+const ISO_DATE_LENGTH = 10;
+const ORDERS_SELECT =
+  "id,created_at,payment_status,total,currency,transfer_number,receipt_url,user_id,seller_id,buyer_info";
+const ITEMS_SELECT =
+  "id,order_id,product_id,quantity,unit_price,currency,products(name)";
+
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidIsoDate(value: string): boolean {
+  return ISO_DATE_REGEX.test(value) && !Number.isNaN(Date.parse(value));
+}
+
+function isValidAmount(value: string): boolean {
+  const num = Number.parseFloat(value);
+  return !Number.isNaN(num) && num >= 0;
+}
+
+function addDateFilters(
+  filters: Record<string, string>,
+  dateFrom: string | null,
+  dateTo: string | null,
+): void {
+  const validFrom = dateFrom && isValidIsoDate(dateFrom) ? dateFrom : null;
+  const validTo = dateTo && isValidIsoDate(dateTo) ? dateTo : null;
+  if (validFrom && validTo) {
+    const end = new Date(validTo);
+    end.setDate(end.getDate() + 1);
+    filters["created_at"] = `gte.${validFrom}`;
+    filters["and"] =
+      `(created_at.lt.${end.toISOString().slice(0, ISO_DATE_LENGTH)})`;
+  } else if (validFrom) {
+    filters["created_at"] = `gte.${validFrom}`;
+  } else if (validTo) {
+    const end = new Date(validTo);
+    end.setDate(end.getDate() + 1);
+    filters["created_at"] = `lt.${end.toISOString().slice(0, ISO_DATE_LENGTH)}`;
+  }
+}
+
+function addAmountFilters(
+  filters: Record<string, string>,
+  amountMin: string | null,
+  amountMax: string | null,
+): void {
+  const validMin = amountMin && isValidAmount(amountMin) ? amountMin : null;
+  const validMax = amountMax && isValidAmount(amountMax) ? amountMax : null;
+  if (validMin && validMax) {
+    filters["total"] = `gte.${validMin}`;
+    const existing = filters["and"] ?? "";
+    filters["and"] = existing
+      ? `${existing},(total.lte.${validMax})`
+      : `(total.lte.${validMax})`;
+  } else if (validMin) {
+    filters["total"] = `gte.${validMin}`;
+  } else if (validMax) {
+    filters["total"] = `lte.${validMax}`;
+  }
+}
+
+function buildOrderFilters(
+  searchParams: URLSearchParams,
+): Record<string, string> {
+  const filters: Record<string, string> = {};
+  addDateFilters(
+    filters,
+    searchParams.get("dateFrom"),
+    searchParams.get("dateTo"),
+  );
+  addAmountFilters(
+    filters,
+    searchParams.get("amountMin"),
+    searchParams.get("amountMax"),
+  );
+  const status = searchParams.get("status");
+  const sellerId = searchParams.get("sellerId");
+  const buyerId = searchParams.get("buyerId");
+  const currency = searchParams.get("currency");
+  if (status) filters["payment_status"] = `eq.${status}`;
+  if (sellerId) filters["seller_id"] = `eq.${sellerId}`;
+  if (buyerId) filters["user_id"] = `eq.${buyerId}`;
+  if (currency) filters["currency"] = `eq.${currency}`;
+  return filters;
+}
+
+async function fetchOrderItems(
+  orderIds: string[],
+  productId: string | null,
+): Promise<OrderItemRow[]> {
+  const itemsQuery: Record<string, string> = {
+    select: ITEMS_SELECT,
+    order_id: `in.(${orderIds.join(",")})`,
+  };
+  if (productId) itemsQuery["product_id"] = `eq.${productId}`;
+  const response = await adminFetch(createRestPath("order_items", itemsQuery));
+  return response.json() as Promise<OrderItemRow[]>;
+}
+
+async function fetchProfileMap(
+  userIds: string[],
+): Promise<Map<string, UserProfileRow>> {
+  if (userIds.length === 0) return new Map();
+  const response = await adminFetch(
+    createRestPath("user_profiles", {
+      select: "id,email,display_name",
+      id: `in.(${userIds.join(",")})`,
+    }),
+  );
+  const profiles = (await response.json()) as UserProfileRow[];
+  return new Map(profiles.map((p) => [p.id, p]));
+}
+
+function buildXlsxResponse(buffer: ExcelJS.Buffer, date: string): Response {
+  return new Response(buffer, {
+    status: 200,
+    headers: {
+      "Content-Type": CONTENT_TYPE_XLSX,
+      "Content-Disposition": `attachment; filename="sales-report-${date}.xlsx"`,
+    },
+  });
+}
+
+async function buildEmptyExcelResponse(): Promise<Response> {
+  const workbook = new ExcelJS.Workbook();
+  workbook.addWorksheet("Sales Report").addRow(["No orders found"]);
+  const buffer = await workbook.xlsx.writeBuffer();
+  return buildXlsxResponse(
+    buffer,
+    new Date().toISOString().slice(0, ISO_DATE_LENGTH),
+  );
+}
+
+export async function GET(request: Request) {
+  const adminUserId = await getAuthorizedAdmin([ADMIN_REPORTS]);
+  if (!adminUserId) {
+    return NextResponse.json({ error: FORBIDDEN_ERROR }, { status: 403 });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const filters = buildOrderFilters(searchParams);
+    const productId = searchParams.get("productId");
+
+    const ordersResponse = await adminFetch(
+      createRestPath("orders", {
+        select: ORDERS_SELECT,
+        order: "created_at.desc",
+        limit: String(MAX_LIMIT),
+        ...filters,
+      }),
+    );
+    let orders = (await ordersResponse.json()) as OrderRow[];
+
+    const orderIds = orders.map((o) => o.id);
+    if (orderIds.length === 0) return buildEmptyExcelResponse();
+
+    const allItems = await fetchOrderItems(orderIds, productId);
+
+    if (productId) {
+      const withProduct = new Set(allItems.map((i) => i.order_id));
+      orders = orders.filter((o) => withProduct.has(o.id));
+    }
+
+    const userIdSet = new Set<string>();
+    for (const order of orders) {
+      userIdSet.add(order.user_id);
+      if (order.seller_id) userIdSet.add(order.seller_id);
+    }
+    const profileMap = await fetchProfileMap([...userIdSet]);
+
+    const itemsByOrder = new Map<string, OrderItemRow[]>();
+    for (const item of allItems) {
+      const existing = itemsByOrder.get(item.order_id) ?? [];
+      existing.push(item);
+      itemsByOrder.set(item.order_id, existing);
+    }
+
+    const workbook = await buildSalesWorkbook(orders, profileMap, itemsByOrder);
+    const buffer = await workbook.xlsx.writeBuffer();
+    const date = new Date().toISOString().slice(0, ISO_DATE_LENGTH);
+    return buildXlsxResponse(buffer, date);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to generate sales report" },
+      { status: INTERNAL_SERVER_ERROR_STATUS },
+    );
+  }
+}

--- a/apps/admin/src/features/reports/presentation/pages/ReportsPage.test.tsx
+++ b/apps/admin/src/features/reports/presentation/pages/ReportsPage.test.tsx
@@ -35,11 +35,6 @@ vi.mock("@/features/reports/application/hooks/useReportOrders", () => ({
   })),
 }));
 
-vi.mock("@/features/reports/application/utils/exportOrdersToExcel", () => ({
-  exportOrdersToExcel: vi.fn(() => "<Workbook/>"),
-  downloadExcel: vi.fn(),
-}));
-
 vi.mock("@/features/reports/presentation/components/ReportFiltersBar", () => ({
   ReportFiltersBar: ({
     onFiltersChange,
@@ -65,7 +60,6 @@ vi.mock("@/features/reports/presentation/components/ReportTable", () => ({
 import { ReportsPage } from "./ReportsPage";
 
 import { useReportOrders } from "@/features/reports/application/hooks/useReportOrders";
-import { exportOrdersToExcel } from "@/features/reports/application/utils/exportOrdersToExcel";
 
 describe("ReportsPage", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -233,7 +227,18 @@ describe("ReportsPage", () => {
     expect(screen.getByTestId("report-table-mock")).toBeInTheDocument();
   });
 
-  it("calls exportOrdersToExcel and downloadExcel when export button is clicked", async () => {
+  it("calls the export endpoint when export button is clicked", async () => {
+    const mockBlob = new Blob(["xlsx-data"], {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    });
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(mockBlob),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+    globalThis.URL.createObjectURL = vi.fn().mockReturnValue("blob:mock");
+    globalThis.URL.revokeObjectURL = vi.fn();
+
     vi.mocked(useReportOrders).mockReturnValue({
       orders: [
         {
@@ -271,8 +276,11 @@ describe("ReportsPage", () => {
     });
     render(<ReportsPage />);
     fireEvent.click(screen.getByTestId("reports-export-button"));
-    // Export is async — just verify it was initiated
-    expect(exportOrdersToExcel).toHaveBeenCalled();
+    await screen.findByTestId("reports-export-button");
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/admin/reports/export"),
+    );
+    vi.unstubAllGlobals();
   });
 
   it("calls setFilters when filters bar triggers change", () => {

--- a/apps/admin/src/features/reports/presentation/pages/ReportsPage.tsx
+++ b/apps/admin/src/features/reports/presentation/pages/ReportsPage.tsx
@@ -6,10 +6,6 @@ import { useCallback, useMemo, useState } from "react";
 import { tid } from "shared";
 
 import { useReportOrders } from "@/features/reports/application/hooks/useReportOrders";
-import {
-  downloadExcel,
-  exportOrdersToExcel,
-} from "@/features/reports/application/utils/exportOrdersToExcel";
 import type { ReportFilters } from "@/features/reports/domain/types";
 import { ReportFiltersBar } from "@/features/reports/presentation/components/ReportFiltersBar";
 import { ReportTable } from "@/features/reports/presentation/components/ReportTable";
@@ -41,15 +37,41 @@ export function ReportsPage() {
   const handleExport = useCallback(async () => {
     if (isExporting) return;
     setIsExporting(true);
-    const isoDateLength = 10;
     try {
-      const content = exportOrdersToExcel(orders);
-      const date = new Date().toISOString().slice(0, isoDateLength);
-      downloadExcel(content, `sales-report-${date}.xls`);
+      const params = new URLSearchParams();
+      if (filters.dateFrom) params.set("dateFrom", filters.dateFrom);
+      if (filters.dateTo) params.set("dateTo", filters.dateTo);
+      if (filters.status) params.set("status", filters.status);
+      if (filters.sellerId) params.set("sellerId", filters.sellerId);
+      if (filters.buyerId) params.set("buyerId", filters.buyerId);
+      if (filters.productId) params.set("productId", filters.productId);
+      if (filters.currency) params.set("currency", filters.currency);
+      if (filters.amountMin != null)
+        params.set("amountMin", String(filters.amountMin));
+      if (filters.amountMax != null)
+        params.set("amountMax", String(filters.amountMax));
+
+      const response = await fetch(
+        `/api/admin/reports/export?${params.toString()}`,
+      );
+      if (!response.ok) throw new Error("Export failed");
+
+      const blob = await response.blob();
+      const ISO_DATE_LENGTH = 10;
+      const date = new Date().toISOString().slice(0, ISO_DATE_LENGTH);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `sales-report-${date}.xlsx`;
+      link.style.visibility = "hidden";
+      document.body.append(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
     } finally {
       setIsExporting(false);
     }
-  }, [isExporting, orders]);
+  }, [isExporting, filters]);
 
   function renderContent() {
     if (isLoading) {

--- a/apps/auth/e2e/full-purchase-flow.spec.ts
+++ b/apps/auth/e2e/full-purchase-flow.spec.ts
@@ -391,13 +391,15 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
     });
     await snap(page, "checkout-two-sellers-loaded");
 
-    // Count only the outer card containers (not toggle buttons or status divs)
-    const sellerCards = page.getByTestId(/^seller-checkout-[^t]/);
+    // Count only the outer card containers (UUID-prefixed, excludes toggle- and submitted-)
+    const sellerCards = page.getByTestId(/^seller-checkout-[0-9a-f]/);
     await expect(sellerCards).toHaveCount(2, { timeout: ELEMENT_TIMEOUT_MS });
     await snap(page, "checkout-two-cards");
 
-    // ── Fill and submit Seller A's payment ─────────────────────
-    const cardASelect = page.getByTestId("payment-method-select").nth(0);
+    // ── Fill and submit first seller's payment ─────────────────
+    // Scope all selectors to the first card to avoid cross-card pollution
+    const firstCard = sellerCards.nth(0);
+    const cardASelect = firstCard.getByTestId("payment-method-select");
     await expect
       .poll(
         async () =>
@@ -409,14 +411,14 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
     await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "checkout-sellerA-method-selected");
 
-    await expect(page.getByTestId(/^display-block-/).first()).toBeVisible({
+    await expect(firstCard.getByTestId(/^display-block-/).first()).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
-    await expect(page.getByTestId(/^dynamic-field-/).first()).toBeVisible({
+    await expect(firstCard.getByTestId(/^dynamic-field-/).first()).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
 
-    await page
+    await firstCard
       .getByTestId(/^dynamic-field-/)
       .first()
       .locator("input, textarea")
@@ -424,14 +426,14 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
       .fill("NEQUI-A-001");
     await snap(page, "checkout-sellerA-field-filled");
 
-    const submitBtnA = page.getByTestId(/^submit-payment-/).first();
+    const submitBtnA = firstCard.getByTestId(/^submit-payment-/);
     await expect(submitBtnA).toBeEnabled({ timeout: ELEMENT_TIMEOUT_MS });
     await submitBtnA.click();
     await snap(page, "checkout-sellerA-submitted");
 
-    // ── Fill and submit Seller B's payment ─────────────────────
-    // After Seller A submits, their card no longer has a select — Seller B's is now first
-    const cardBSelect = page.getByTestId("payment-method-select").first();
+    // ── Fill and submit second seller's payment ─────────────────
+    const secondCard = sellerCards.nth(1);
+    const cardBSelect = secondCard.getByTestId("payment-method-select");
     await expect
       .poll(
         async () =>
@@ -443,11 +445,11 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
     await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "checkout-sellerB-method-selected");
 
-    await expect(page.getByTestId(/^dynamic-field-/).first()).toBeVisible({
-      timeout: ELEMENT_TIMEOUT_MS,
-    });
+    await expect(secondCard.getByTestId(/^dynamic-field-/).first()).toBeVisible(
+      { timeout: ELEMENT_TIMEOUT_MS },
+    );
 
-    await page
+    await secondCard
       .getByTestId(/^dynamic-field-/)
       .first()
       .locator("input, textarea")
@@ -455,7 +457,7 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
       .fill("BANCO-B-002");
     await snap(page, "checkout-sellerB-field-filled");
 
-    const submitBtnB = page.getByTestId(/^submit-payment-/).first();
+    const submitBtnB = secondCard.getByTestId(/^submit-payment-/);
     await expect(submitBtnB).toBeEnabled({ timeout: ELEMENT_TIMEOUT_MS });
     await submitBtnB.click();
     await snap(page, "checkout-sellerB-submitted");

--- a/apps/auth/e2e/permission-management.spec.ts
+++ b/apps/auth/e2e/permission-management.spec.ts
@@ -481,7 +481,7 @@ test.describe.serial("Permission management", () => {
     await expectVisible(page, "nav-link-landing");
     await expectVisible(page, "nav-link-store");
     await expectVisible(page, "nav-link-auth");
-    await expectVisible(page, "nav-link-playground");
+    await expectHidden(page, "nav-link-playground");
 
     await page.goto(`${APP_URLS.PAYMENTS}/en/checkout`);
     await expectVisible(page, "access-denied");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       cookies-next:
         specifier: ^6.1.1
         version: 6.1.1(next@16.2.0(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      exceljs:
+        specifier: ^4.4.0
+        version: 4.4.0
       lucide-react:
         specifier: ^0.511.0
         version: 0.511.0(react@19.2.5)
@@ -2040,6 +2043,12 @@ packages:
     resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
     engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
+  '@fast-csv/format@4.3.5':
+    resolution: {integrity: sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==}
+
+  '@fast-csv/parse@4.3.6':
+    resolution: {integrity: sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==}
+
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -3898,6 +3907,9 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/node@14.18.63':
+    resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -4266,6 +4278,18 @@ packages:
   app-module-path@2.2.0:
     resolution: {integrity: sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ==}
 
+  archiver-utils@2.1.0:
+    resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
+    engines: {node: '>= 6'}
+
+  archiver-utils@3.0.4:
+    resolution: {integrity: sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==}
+    engines: {node: '>= 10'}
+
+  archiver@5.3.2:
+    resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
+    engines: {node: '>= 10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -4351,6 +4375,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -4394,9 +4421,16 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
+
   bin-links@6.0.0:
     resolution: {integrity: sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  binary@0.3.0:
+    resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
 
   binaryextensions@6.11.0:
     resolution: {integrity: sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==}
@@ -4408,6 +4442,9 @@ packages:
   blamer@1.0.7:
     resolution: {integrity: sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA==}
     engines: {node: '>=8.9'}
+
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
@@ -4431,8 +4468,19 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-indexof-polyfill@1.0.2:
+    resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
+    engines: {node: '>=0.10'}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffers@0.1.1:
+    resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
+    engines: {node: '>=0.2.0'}
 
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -4478,6 +4526,9 @@ packages:
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
+
+  chainsaw@0.1.0:
+    resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
 
   chalk-template@1.1.2:
     resolution: {integrity: sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA==}
@@ -4614,6 +4665,10 @@ packages:
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
+  compress-commons@4.1.2:
+    resolution: {integrity: sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==}
+    engines: {node: '>= 10'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -4641,6 +4696,9 @@ packages:
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cosmiconfig@9.0.1:
     resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
     engines: {node: '>=14'}
@@ -4649,6 +4707,15 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@4.0.3:
+    resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
+    engines: {node: '>= 10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4792,6 +4859,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -4924,6 +4994,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  duplexer2@0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -5248,6 +5321,10 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  exceljs@4.4.0:
+    resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
+    engines: {node: '>=8.3.0'}
+
   execa@4.1.0:
     resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
     engines: {node: '>=10'}
@@ -5267,6 +5344,10 @@ packages:
   fast-check@4.7.0:
     resolution: {integrity: sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==}
     engines: {node: '>=12.17.0'}
+
+  fast-csv@4.3.6:
+    resolution: {integrity: sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==}
+    engines: {node: '>=10.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -5394,9 +5475,15 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -5407,6 +5494,11 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fstream@1.0.12:
+    resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
+    engines: {node: '>=0.6'}
+    deprecated: This package is no longer supported.
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -5487,6 +5579,10 @@ packages:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@5.0.0:
     resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
@@ -5671,6 +5767,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   immer@10.2.0:
     resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
 
@@ -5705,6 +5804,10 @@ packages:
 
   inflected@2.1.0:
     resolution: {integrity: sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -5896,6 +5999,9 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -6036,6 +6142,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -6061,6 +6170,10 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -6068,6 +6181,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -6154,6 +6270,9 @@ packages:
     engines: {node: '>=20.17'}
     hasBin: true
 
+  listenercount@1.0.1:
+    resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
+
   listr2@9.0.5:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
@@ -6165,8 +6284,42 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.difference@4.5.0:
+    resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.flatten@4.4.0:
+    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.groupby@4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
   lodash.isempty@4.4.0:
     resolution: {integrity: sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
+  lodash.isfunction@3.0.9:
+    resolution: {integrity: sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==}
+
+  lodash.isnil@4.0.0:
+    resolution: {integrity: sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isundefined@3.0.1:
+    resolution: {integrity: sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -6179,6 +6332,9 @@ packages:
 
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
+  lodash.union@4.6.0:
+    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
@@ -6318,6 +6474,10 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -6332,6 +6492,10 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
+
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
 
   module-definition@6.0.1:
     resolution: {integrity: sha512-FeVc50FTfVVQnolk/WQT8MX+2WVcDnTGiq6Wo+/+lJ2ET1bRVi3HG3YlJUfqagNMc/kUlFSoR96AJkxGpKz13g==}
@@ -6625,6 +6789,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -6654,6 +6821,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -6779,6 +6950,9 @@ packages:
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
@@ -6941,9 +7115,15 @@ packages:
     resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
     engines: {node: '>=18'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -7070,6 +7250,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rimraf@2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
   rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -7087,6 +7272,9 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -7112,6 +7300,10 @@ packages:
     resolution: {integrity: sha512-12dvZdQYTeKZ1ypjuiijZYuMZ1m0F+4+BkRX5yJi2WA9W3DBUrcdCt7bVuKlagHl11n8eYtalWDle+m98Ol2DA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  saxes@5.0.1:
+    resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
+    engines: {node: '>=10'}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -7152,6 +7344,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -7370,6 +7565,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -7575,6 +7773,10 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
@@ -7637,6 +7839,10 @@ packages:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
 
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -7662,6 +7868,9 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  traverse@0.3.9:
+    resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -7818,6 +8027,9 @@ packages:
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
+  unzipper@0.10.14:
+    resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -7872,6 +8084,10 @@ packages:
   utility-types@3.11.0:
     resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
     engines: {node: '>= 4'}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
 
   valibot@1.3.1:
     resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
@@ -8146,6 +8362,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zip-stream@4.1.1:
+    resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
+    engines: {node: '>= 10'}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -8897,6 +9117,25 @@ snapshots:
   '@exodus/schemasafe@1.3.0': {}
 
   '@faker-js/faker@9.9.0': {}
+
+  '@fast-csv/format@4.3.5':
+    dependencies:
+      '@types/node': 14.18.63
+      lodash.escaperegexp: 4.1.2
+      lodash.isboolean: 3.0.3
+      lodash.isequal: 4.5.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+
+  '@fast-csv/parse@4.3.6':
+    dependencies:
+      '@types/node': 14.18.63
+      lodash.escaperegexp: 4.1.2
+      lodash.groupby: 4.6.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+      lodash.isundefined: 3.0.1
+      lodash.uniq: 4.5.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -10728,6 +10967,8 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/node@14.18.63': {}
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -11140,6 +11381,42 @@ snapshots:
 
   app-module-path@2.2.0: {}
 
+  archiver-utils@2.1.0:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 2.3.8
+
+  archiver-utils@3.0.4:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
+  archiver@5.3.2:
+    dependencies:
+      archiver-utils: 2.1.0
+      async: 3.2.6
+      buffer-crc32: 0.2.13
+      readable-stream: 3.6.2
+      readdir-glob: 1.1.3
+      tar-stream: 2.2.0
+      zip-stream: 4.1.1
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -11245,6 +11522,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  async@3.2.6: {}
+
   asynckit@0.4.0: {}
 
   available-typed-arrays@1.0.7:
@@ -11282,6 +11561,8 @@ snapshots:
       require-from-string: 2.0.2
     optional: true
 
+  big-integer@1.6.52: {}
+
   bin-links@6.0.0:
     dependencies:
       cmd-shim: 8.0.0
@@ -11289,6 +11570,11 @@ snapshots:
       proc-log: 6.1.0
       read-cmd-shim: 6.0.0
       write-file-atomic: 7.0.1
+
+  binary@0.3.0:
+    dependencies:
+      buffers: 0.1.1
+      chainsaw: 0.1.0
 
   binaryextensions@6.11.0:
     dependencies:
@@ -11304,6 +11590,8 @@ snapshots:
     dependencies:
       execa: 4.1.0
       which: 2.0.2
+
+  bluebird@3.4.7: {}
 
   boundary@2.0.0: {}
 
@@ -11332,10 +11620,16 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-crc32@0.2.13: {}
+
+  buffer-indexof-polyfill@1.0.2: {}
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buffers@0.1.1: {}
 
   builtin-modules@3.3.0: {}
 
@@ -11383,6 +11677,10 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
+
+  chainsaw@0.1.0:
+    dependencies:
+      traverse: 0.3.9
 
   chalk-template@1.1.2:
     dependencies:
@@ -11494,6 +11792,13 @@ snapshots:
 
   compare-versions@6.1.1: {}
 
+  compress-commons@4.1.2:
+    dependencies:
+      buffer-crc32: 0.2.13
+      crc32-stream: 4.0.3
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
   concat-map@0.0.1: {}
 
   concurrently@9.2.1:
@@ -11524,6 +11829,8 @@ snapshots:
     dependencies:
       browserslist: 4.28.2
 
+  core-util-is@1.0.3: {}
+
   cosmiconfig@9.0.1(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
@@ -11532,6 +11839,13 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@4.0.3:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 3.6.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -11725,6 +12039,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dayjs@1.11.20: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -11853,6 +12169,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  duplexer2@0.1.4:
+    dependencies:
+      readable-stream: 2.3.8
 
   eastasianwidth@0.2.0: {}
 
@@ -12456,6 +12776,18 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  exceljs@4.4.0:
+    dependencies:
+      archiver: 5.3.2
+      dayjs: 1.11.20
+      fast-csv: 4.3.6
+      jszip: 3.10.1
+      readable-stream: 3.6.2
+      saxes: 5.0.1
+      tmp: 0.2.5
+      unzipper: 0.10.14
+      uuid: 8.3.2
+
   execa@4.1.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -12487,6 +12819,11 @@ snapshots:
   fast-check@4.7.0:
     dependencies:
       pure-rand: 8.4.0
+
+  fast-csv@4.3.6:
+    dependencies:
+      '@fast-csv/format': 4.3.5
+      '@fast-csv/parse': 4.3.6
 
   fast-deep-equal@3.1.3: {}
 
@@ -12620,17 +12957,28 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  fs-constants@1.0.0: {}
+
   fs-extra@11.3.4:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.2:
     optional: true
 
   fsevents@2.3.3:
     optional: true
+
+  fstream@1.0.12:
+    dependencies:
+      graceful-fs: 4.2.11
+      inherits: 2.0.4
+      mkdirp: 0.5.6
+      rimraf: 2.7.1
 
   function-bind@1.1.2: {}
 
@@ -12716,6 +13064,15 @@ snapshots:
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
 
   global-directory@5.0.0:
     dependencies:
@@ -12897,6 +13254,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   immer@10.2.0: {}
 
   immer@11.1.4: {}
@@ -12919,6 +13278,11 @@ snapshots:
   index-to-position@1.2.0: {}
 
   inflected@2.1.0: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
 
   inherits@2.0.4: {}
 
@@ -13093,6 +13457,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  isarray@1.0.0: {}
 
   isarray@2.0.5: {}
 
@@ -13278,6 +13644,13 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -13315,12 +13688,20 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   leven@3.1.0: {}
 
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -13386,6 +13767,8 @@ snapshots:
       tinyexec: 1.1.1
       yaml: 2.8.3
 
+  listenercount@1.0.1: {}
+
   listr2@9.0.5:
     dependencies:
       cli-truncate: 5.2.0
@@ -13401,7 +13784,29 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
+  lodash.defaults@4.2.0: {}
+
+  lodash.difference@4.5.0: {}
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.flatten@4.4.0: {}
+
+  lodash.groupby@4.6.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
   lodash.isempty@4.4.0: {}
+
+  lodash.isequal@4.5.0: {}
+
+  lodash.isfunction@3.0.9: {}
+
+  lodash.isnil@4.0.0: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isundefined@3.0.1: {}
 
   lodash.merge@4.6.2: {}
 
@@ -13410,6 +13815,8 @@ snapshots:
   lodash.topath@4.5.2: {}
 
   lodash.truncate@4.4.2: {}
+
+  lodash.union@4.6.0: {}
 
   lodash.uniq@4.5.0: {}
 
@@ -13544,6 +13951,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.14
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.0
@@ -13555,6 +13966,10 @@ snapshots:
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.3
+
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
 
   module-definition@6.0.1:
     dependencies:
@@ -13985,6 +14400,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -14018,6 +14435,8 @@ snapshots:
     optional: true
 
   path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -14132,6 +14551,8 @@ snapshots:
       parse-ms: 2.1.0
 
   proc-log@6.1.0: {}
+
+  process-nextick-args@2.0.1: {}
 
   promise@7.3.1:
     dependencies:
@@ -14317,11 +14738,25 @@ snapshots:
       type-fest: 4.41.0
       unicorn-magic: 0.1.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
 
   readdirp@4.1.2: {}
 
@@ -14452,6 +14887,10 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rimraf@2.7.1:
+    dependencies:
+      glob: 7.2.3
+
   rollup@4.60.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -14501,6 +14940,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
@@ -14526,6 +14967,10 @@ snapshots:
     dependencies:
       commander: 12.1.0
       enhanced-resolve: 5.20.1
+
+  saxes@5.0.1:
+    dependencies:
+      xmlchars: 2.2.0
 
   saxes@6.0.0:
     dependencies:
@@ -14579,6 +15024,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
 
   sharp@0.34.5:
     dependencies:
@@ -14851,6 +15298,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -15068,6 +15519,14 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar@7.5.13:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -15124,6 +15583,8 @@ snapshots:
     dependencies:
       tldts-core: 7.0.28
 
+  tmp@0.2.5: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -15148,6 +15609,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
     optional: true
+
+  traverse@0.3.9: {}
 
   tree-kill@1.2.2: {}
 
@@ -15329,6 +15792,19 @@ snapshots:
 
   until-async@3.0.2: {}
 
+  unzipper@0.10.14:
+    dependencies:
+      big-integer: 1.6.52
+      binary: 0.3.0
+      bluebird: 3.4.7
+      buffer-indexof-polyfill: 1.0.2
+      duplexer2: 0.1.4
+      fstream: 1.0.12
+      graceful-fs: 4.2.11
+      listenercount: 1.0.1
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -15376,6 +15852,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utility-types@3.11.0: {}
+
+  uuid@8.3.2: {}
 
   valibot@1.3.1(typescript@5.9.3):
     optionalDependencies:
@@ -15780,6 +16258,12 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zip-stream@4.1.1:
+    dependencies:
+      archiver-utils: 3.0.4
+      compress-commons: 4.1.2
+      readable-stream: 3.6.2
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -72,15 +72,21 @@ console.log(`\n🧪 e2e  env=${targetEnv}  app=${targetApp}\n`);
 let devProc = null;
 
 if (targetEnv === "dev") {
-  // 1. Supabase — use supabase:docker so config.toml is generated from the
-  //    template with OAuth providers (Google, Discord) properly configured.
-  console.log("▶ supabase:docker start --env dev");
-  spawnSync("pnpm", ["supabase:docker", "start", "--env", "dev"], {
-    cwd: rootDir,
-    stdio: "inherit",
-    env: process.env,
-    shell: true,
-  });
+  // 1. Start Supabase only when using local Docker (SUPABASE_PORT is a valid number)
+  const supabasePort = Number.parseInt(process.env.SUPABASE_PORT ?? "", 10);
+  const useLocalSupabase = !Number.isNaN(supabasePort) && supabasePort > 0;
+
+  if (useLocalSupabase) {
+    console.log("▶ supabase:docker start --env dev");
+    spawnSync("pnpm", ["supabase:docker", "start", "--env", "dev"], {
+      cwd: rootDir,
+      stdio: "inherit",
+      env: process.env,
+      shell: true,
+    });
+  } else {
+    console.log("✓ Using Supabase Cloud — skipping local Supabase start\n");
+  }
 
   // 2. Start dev servers if not already up
   const port = portForApp(targetApp);


### PR DESCRIPTION
## Summary

- Add `/api/admin/reports/export` endpoint: generates XLSX with embedded receipt images, dynamic `buyer_info` columns, and Raw Orders/Items sheets using `exceljs`
- Fix `e2e.mjs` to skip Supabase Docker when using Supabase Cloud (reads `SUPABASE_PORT` from env)
- Fix `full-purchase-flow` E2E: scope selectors to each seller's card container + use UUID regex to prevent cross-card pollution after first submit
- Fix `permission-management` E2E: `nav-link-playground` requires admin permissions (`expectHidden` for users with no perms)

## Test plan

- [x] All 42 auth E2E tests pass (3 OAuth skipped)
- [x] All 6 store E2E tests pass
- [x] Unit tests pass across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)