### PR TITLE
fix(deploy): add SSH keepalive to prevent broken pipe during Docker build

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -102,6 +102,8 @@ jobs:
             IdentityFile ~/.ssh/deploy_key
             StrictHostKeyChecking no
             ProxyCommand cloudflared access ssh --hostname %h
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
           EOF
 
       - name: Write ephemeral env file on server
@@ -141,7 +143,7 @@ jobs:
       - name: Verify deployment
         run: |
           ssh ${{ secrets.PROD_SERVER_HOST }} \
-            'export NVM_DIR="$HOME/.nvm" && source "$NVM_DIR/nvm.sh" && pm2 list'
+            'docker ps --filter name=candyshop-prod --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"'
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
## Problem

Every production deploy fails with:
```
client_loop: send disconnect: Broken pipe
Process completed with exit code 255.
```

The Docker build takes ~5 minutes. The SSH tunnel over cloudflared has no keepalive, so it silently drops mid-build.

Additionally, the Verify step was running \`pm2 list\` — the server uses Docker, not pm2, so it would fail even when the deploy succeeded.

## Fix

- Add \`ServerAliveInterval 30\` + \`ServerAliveCountMax 20\` to the SSH config so the cloudflared tunnel survives the Docker build (up to 10 minutes of keepalive)
- Fix Verify step: \`docker ps --filter name=candyshop-prod\` instead of \`pm2 list\`