### PR TITLE
fix(deploy): sync SSH keepalive hotfix to develop

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -102,6 +102,8 @@ jobs:
             IdentityFile ~/.ssh/deploy_key
             StrictHostKeyChecking no
             ProxyCommand cloudflared access ssh --hostname %h
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
           EOF
 
       - name: Write ephemeral env file on server
@@ -141,7 +143,7 @@ jobs:
       - name: Verify deployment
         run: |
           ssh ${{ secrets.PROD_SERVER_HOST }} \
-            'export NVM_DIR="$HOME/.nvm" && source "$NVM_DIR/nvm.sh" && pm2 list'
+            'docker ps --filter name=candyshop-prod --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"'
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
## Summary

Syncs the SSH keepalive hotfix from main (PR #133) back to develop.

## Changes

- Added `ServerAliveInterval 30` and `ServerAliveCountMax 20` to the SSH config in `deploy-production.yml`
- Changed verify step from `pm2 list` to `docker ps` (correct for our Docker-based deploy)

## Why

The hotfix was merged directly to main to unblock production deployments. This PR brings develop in sync so future releases include the fix.

Closes related: #133