### PR TITLE
chore(release): v0.2.1

### DIFF
--- a/apps/admin/src/shared/infrastructure/auditRestClient.ts
+++ b/apps/admin/src/shared/infrastructure/auditRestClient.ts
@@ -45,9 +45,11 @@ export async function auditRestQuery(
       apikey: key,
       Authorization: `Bearer ${token}`,
       // logged_actions_with_user is exposed in the public schema via a proxy view
-      // (migration 20260421100000_expose_audit_view_in_public.sql). PostgREST's
-      // audit schema is not exposed, so Accept-Profile: audit would cause 406.
+      // (migration 20260421050000_expose_audit_view_in_public.sql). PostgREST's
+      // audit schema is not exposed, so specifying Accept-Profile: public ensures
+      // PostgREST resolves the view in the correct schema and avoids 406 errors.
       Accept: JSON_CONTENT_TYPE,
+      "Accept-Profile": "public",
     },
   });
 

--- a/apps/payments/src/features/assigned-orders/application/hooks/useAssignedOrders.ts
+++ b/apps/payments/src/features/assigned-orders/application/hooks/useAssignedOrders.ts
@@ -3,10 +3,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { useSupabase } from "shared";
 
-import { ASSIGNED_ORDERS_QUERY_KEY } from "@/features/assigned-orders/domain/constants";
+import {
+  ASSIGNED_ORDERS_QUERY_KEY,
+  ASSIGNED_ORDERS_STALE_TIME_MS,
+} from "@/features/assigned-orders/domain/constants";
 import { fetchAssignedOrders } from "@/features/received-orders/infrastructure/receivedOrderQueries";
-
-const ASSIGNED_ORDERS_STALE_TIME_MS = 30_000;
 
 export function useAssignedOrders() {
   const supabase = useSupabase();

--- a/apps/payments/src/features/assigned-orders/domain/constants.ts
+++ b/apps/payments/src/features/assigned-orders/domain/constants.ts
@@ -1,1 +1,4 @@
 export const ASSIGNED_ORDERS_QUERY_KEY = "assigned-orders";
+
+/** Stale time for assigned orders query (30 seconds) */
+export const ASSIGNED_ORDERS_STALE_TIME_MS = 30_000;

--- a/apps/payments/src/features/assigned-orders/presentation/pages/AssignedOrdersPageContent.tsx
+++ b/apps/payments/src/features/assigned-orders/presentation/pages/AssignedOrdersPageContent.tsx
@@ -35,7 +35,6 @@ export function AssignedOrdersPageContent() {
           >
             {t("title")}
           </h1>
-          <p className="mt-1 text-sm text-muted-foreground">{t("subtitle")}</p>
         </header>
 
         {isLoading && (

--- a/apps/payments/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/payments/src/shared/infrastructure/i18n/messages/en.json
@@ -127,7 +127,6 @@
   },
   "assignedOrders": {
     "title": "Assigned Items",
-    "subtitle": "Orders for items assigned to you by sellers",
     "noOrders": "No assigned orders",
     "noOrdersHint": "When a seller assigns you to one of their products, pending orders will appear here"
   },

--- a/apps/payments/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/payments/src/shared/infrastructure/i18n/messages/es.json
@@ -127,7 +127,6 @@
   },
   "assignedOrders": {
     "title": "Items Asignados",
-    "subtitle": "Ordenes de items que te han asignado los vendedores",
     "noOrders": "Sin ordenes asignadas",
     "noOrdersHint": "Cuando un vendedor te asigne a uno de sus productos, las ordenes pendientes apareceran aqui"
   },

--- a/scripts/seed-moonfest.mjs
+++ b/scripts/seed-moonfest.mjs
@@ -73,7 +73,80 @@ async function del(path) {
   if (!res.ok) throw new Error(`Delete ${path}: ${await res.text()}`);
 }
 
-// ─── Payment Method ──────────────────────────────────────────────────
+// ─── Payment Methods ─────────────────────────────────────────────────
+
+const CONSPACE_PAYMENT_METHOD = {
+  name_en: "Conspace (International)",
+  name_es: "Conspace (Internacional)",
+  is_active: true,
+  requires_receipt: true,
+  requires_transfer_number: true,
+  sort_order: 1,
+  display_blocks: [
+    {
+      id: "conspace-info",
+      type: "text",
+      content_en:
+        "For attendees **outside Colombia** who don't have a local bank account. Complete your payment securely through Conspace:",
+      content_es:
+        "Para asistentes **fuera de Colombia** que no tienen cuenta bancaria local. Completa tu pago de forma segura a traves de Conspace:",
+    },
+    {
+      id: "conspace-logo",
+      type: "image",
+      url: "https://filedn.com/leGgCrrYIXV0YvzNNKbdzBb/conspace.png",
+      alt_en: "Conspace payment platform",
+      alt_es: "Plataforma de pago Conspace",
+      href: "https://conspace.app/events/moonfest",
+      target: "_blank",
+      rel: "noopener noreferrer",
+    },
+    {
+      id: "conspace-link",
+      type: "link",
+      url: "https://conspace.app/events/moonfest",
+      label_en: "Pay via Conspace",
+      label_es: "Pagar via Conspace",
+    },
+    {
+      id: "conspace-instructions",
+      type: "text",
+      content_en:
+        "After completing your payment on Conspace, upload your payment receipt and fill in your details below so we can confirm your registration.",
+      content_es:
+        "Despues de completar tu pago en Conspace, sube tu comprobante de pago y completa tus datos para que podamos confirmar tu registro.",
+    },
+  ],
+  form_fields: [
+    {
+      id: "email",
+      type: "email",
+      label_en: "Email",
+      label_es: "Correo electronico",
+      placeholder_en: "your@email.com",
+      placeholder_es: "tu@correo.com",
+      required: true,
+    },
+    {
+      id: "display_name",
+      type: "text",
+      label_en: "Your name (alias or real) — how you'd like to be identified",
+      label_es: "Tu nombre (alias o real) — como te gustaria ser identificado",
+      placeholder_en: "e.g. Kira or Juan Perez",
+      placeholder_es: "Ej. Kira o Juan Perez",
+      required: true,
+    },
+    {
+      id: "tracking",
+      type: "text",
+      label_en: "Conspace order ID or confirmation number",
+      label_es: "ID de orden Conspace o numero de confirmacion",
+      placeholder_en: "e.g. CS-123456",
+      placeholder_es: "Ej. CS-123456",
+      required: true,
+    },
+  ],
+};
 
 const NEQUI_PAYMENT_METHOD = {
   name_en: "Nequi",
@@ -551,6 +624,25 @@ async function run() {
       seller_id: sellerId,
     });
     console.log("Nequi payment method created:", method[0].id);
+  }
+
+  // 6. Conspace payment method (upsert by seller + name)
+  const existingConspace = await query(
+    `seller_payment_methods?seller_id=eq.${sellerId}&name_en=eq.Conspace%20(International)&select=id`,
+  );
+  if (existingConspace.length > 0) {
+    const methodId = existingConspace[0].id;
+    await patch(
+      `seller_payment_methods?id=eq.${methodId}`,
+      CONSPACE_PAYMENT_METHOD,
+    );
+    console.log("Conspace payment method updated:", methodId);
+  } else {
+    const method = await insert("seller_payment_methods", {
+      ...CONSPACE_PAYMENT_METHOD,
+      seller_id: sellerId,
+    });
+    console.log("Conspace payment method created:", method[0].id);
   }
 
   console.log("\nDone! Product live at https://store.furrycolombia.com/store");

--- a/supabase/migrations/20260421120000_receipts_delegate_read.sql
+++ b/supabase/migrations/20260421120000_receipts_delegate_read.sql
@@ -1,0 +1,22 @@
+-- =============================================================================
+-- Allow delegates to generate signed URLs for receipts on orders they manage.
+--
+-- The receipts storage path is {orderId}/{filename}. Delegates can read orders
+-- via is_order_delegate(), but the receipts_read storage policy only checked
+-- has_permission(auth.uid(), 'receipts.read'), which delegates never hold.
+-- =============================================================================
+
+drop policy if exists "receipts_read" on storage.objects;
+
+create policy "receipts_read" on storage.objects
+  for select using (
+    bucket_id = 'receipts'
+    and (
+      has_permission(auth.uid(), 'receipts.read')
+      or (
+        -- Only attempt the UUID cast when the path actually starts with one
+        name ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/'
+        and public.is_order_delegate(split_part(name, '/', 1)::uuid)
+      )
+    )
+  );


### PR DESCRIPTION
## Release v0.2.1

### Changes

- **fix(audit)**: Resolve 406 PostgREST error on audit log — added `Accept-Profile: public` header to `auditRestClient`
- **feat(payments)**: Add Conspace (International) payment method to Moonfest with image block, link block (opens in new tab), receipt upload required, and transaction number required
- **fix(db)**: Add `receipts_delegate_read` migration so delegates can generate signed URLs for order receipts
- **chore(payments)**: Clean up assigned orders page — remove unused subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)