### PR TITLE
chore(release): v2026.04.22.1

### DIFF
--- a/apps/landing/src/features/home/presentation/components/FeaturesSection.tsx
+++ b/apps/landing/src/features/home/presentation/components/FeaturesSection.tsx
@@ -131,7 +131,7 @@ export function FeaturesSection() {
                     </span>
                   </div>
                   <div className="mt-auto pr-10">
-                    <p className="max-w-full text-pretty font-display text-[1.55rem] leading-[0.94] font-extrabold uppercase sm:text-[1.8rem] lg:text-[2rem]">
+                    <p className="max-w-full wrap-break-word text-pretty font-display text-[1.2rem] leading-[1.1] font-extrabold uppercase sm:text-[1.4rem] lg:text-[1.6rem]">
                       {t(key)}
                     </p>
                     <div

--- a/apps/landing/src/features/home/presentation/components/HomeSections.test.tsx
+++ b/apps/landing/src/features/home/presentation/components/HomeSections.test.tsx
@@ -62,14 +62,14 @@ describe("HomeSections", () => {
     expect(screen.getByTestId("category-digital")).toBeInTheDocument();
   });
 
-  it("renders both role cards with store links", () => {
+  it("renders both role cards — artists has coming-soon badge, fans has store link", () => {
     render(<RolesSection />);
 
     expect(screen.getByTestId("roles-section")).toBeInTheDocument();
     expect(screen.getByTestId("role-artists")).toBeInTheDocument();
     expect(screen.getByTestId("role-fans")).toBeInTheDocument();
-    expect(screen.getAllByRole("link")).toHaveLength(2);
+    // Artists card is "coming soon" — no link, only the fans card links to the store
+    expect(screen.getAllByRole("link")).toHaveLength(1);
     expect(screen.getAllByRole("link")[0]).toHaveAttribute("href", "/store");
-    expect(screen.getAllByRole("link")[1]).toHaveAttribute("href", "/store");
   });
 });

--- a/apps/landing/src/features/home/presentation/components/RolesSection.tsx
+++ b/apps/landing/src/features/home/presentation/components/RolesSection.tsx
@@ -7,34 +7,9 @@ import { tid } from "shared";
 
 import { appUrls } from "@/shared/infrastructure/config";
 
-interface RoleCard {
-  key: string;
-  cardBg: string;
-  cardText: string;
-  btnBg: string;
-  btnText: string;
-}
-
 const DEFAULT_CANDY_TEXT = "var(--candy-text)";
 const LEMON_CANDY_TEXT = "var(--candy-text-on-lemon)";
 const PINK_BG = "var(--pink)";
-
-const ROLES: RoleCard[] = [
-  {
-    key: "artists",
-    cardBg: PINK_BG,
-    cardText: DEFAULT_CANDY_TEXT,
-    btnBg: "var(--lemon)",
-    btnText: LEMON_CANDY_TEXT,
-  },
-  {
-    key: "fans",
-    cardBg: "var(--mint)",
-    cardText: DEFAULT_CANDY_TEXT,
-    btnBg: PINK_BG,
-    btnText: DEFAULT_CANDY_TEXT,
-  },
-];
 
 export function RolesSection() {
   const t = useTranslations("landing.split");
@@ -51,48 +26,78 @@ export function RolesSection() {
       </h2>
       <div className="mx-auto max-w-6xl px-6 lg:px-8">
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-          {ROLES.map(({ key, cardBg, cardText, btnBg, btnText }) => (
-            /* Static card container — no cursor-pointer, no hover translate */
-            <div
-              key={key}
-              role="group"
-              aria-labelledby={`${key}-heading`}
-              className="shadow-brutal-lg flex flex-col border-strong border-foreground p-8 lg:p-10"
-              style={{ backgroundColor: cardBg, color: cardText }}
-              {...tid(`role-${key}`)}
+          {/* Artists card */}
+          <div
+            role="group"
+            aria-labelledby="artists-heading"
+            className="shadow-brutal-lg flex flex-col border-strong border-foreground p-8 lg:p-10"
+            style={{ backgroundColor: PINK_BG, color: DEFAULT_CANDY_TEXT }}
+            {...tid("role-artists")}
+          >
+            <p className="mb-3 text-xs font-bold uppercase tracking-section">
+              {t("artists.label")}
+            </p>
+            <h3
+              id="artists-heading"
+              className="mb-4 font-display text-3xl/tight font-extrabold uppercase lg:text-4xl"
             >
-              <p className="mb-3 text-xs font-bold uppercase tracking-section">
-                {t(`${key}.label`)}
-              </p>
-              <h3
-                id={`${key}-heading`}
-                className="mb-4 font-display text-3xl/tight font-extrabold uppercase lg:text-4xl"
-              >
-                {t(`${key}.title`)}
-              </h3>
-              <p className="mb-8 text-base/relaxed opacity-90">
-                {t(`${key}.description`)}
-              </p>
-              {/* The only interactive element — explicitly a button */}
-              <Link
-                href={appUrls.store}
-                className="button-brutal button-press-sm shadow-brutal-sm mt-auto inline-flex self-start px-6 py-3 text-sm font-extrabold"
-                style={{
-                  backgroundColor: btnBg,
-                  color: btnText,
-                  borderColor: cardText,
-                  outlineColor: cardText,
-                }}
-              >
-                {t(`${key}.cta`)}
-                <ArrowRight
-                  aria-hidden="true"
-                  className="size-4"
-                  strokeWidth={2.5}
-                />
-              </Link>
-            </div>
-          ))}
+              {t("artists.title")}
+            </h3>
+            <p className="mb-8 text-base/relaxed opacity-90">
+              {t("artists.description")}
+            </p>
+            <span
+              className="shadow-brutal-sm mt-auto inline-flex self-start border-strong border-foreground px-6 py-3 text-sm font-extrabold uppercase tracking-wider opacity-70"
+              style={{
+                backgroundColor: "var(--lemon)",
+                color: LEMON_CANDY_TEXT,
+              }}
+            >
+              {t("artists.comingSoon")}
+            </span>
+          </div>
+
+          {/* Fans card */}
+          <div
+            role="group"
+            aria-labelledby="fans-heading"
+            className="shadow-brutal-lg flex flex-col border-strong border-foreground p-8 lg:p-10"
+            style={{
+              backgroundColor: "var(--mint)",
+              color: DEFAULT_CANDY_TEXT,
+            }}
+            {...tid("role-fans")}
+          >
+            <p className="mb-3 text-xs font-bold uppercase tracking-section">
+              {t("fans.label")}
+            </p>
+            <h3
+              id="fans-heading"
+              className="mb-4 font-display text-3xl/tight font-extrabold uppercase lg:text-4xl"
+            >
+              {t("fans.title")}
+            </h3>
+            <p className="mb-8 text-base/relaxed opacity-90">
+              {t("fans.description")}
+            </p>
+            <Link
+              href={appUrls.store}
+              className="button-brutal button-press-sm shadow-brutal-sm mt-auto inline-flex self-start px-6 py-3 text-sm font-extrabold"
+              style={{
+                backgroundColor: PINK_BG,
+                color: DEFAULT_CANDY_TEXT,
+                borderColor: DEFAULT_CANDY_TEXT,
+                outlineColor: DEFAULT_CANDY_TEXT,
+              }}
+            >
+              {t("fans.cta")}
+              <ArrowRight
+                aria-hidden="true"
+                className="size-4"
+                strokeWidth={2.5}
+              />
+            </Link>
+          </div>
         </div>
       </div>
     </section>

--- a/apps/landing/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/landing/src/shared/infrastructure/i18n/messages/en.json
@@ -32,7 +32,8 @@
         "label": "For creators",
         "title": "Your art deserves a real home.",
         "description": "Sell commissions, manage your queue, ship merch, and grow your audience — without platform fees eating your work.",
-        "cta": "Start selling"
+        "cta": "Start selling",
+        "comingSoon": "Coming soon"
       },
       "fans": {
         "label": "For collectors",

--- a/apps/landing/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/landing/src/shared/infrastructure/i18n/messages/es.json
@@ -32,7 +32,8 @@
         "label": "Para creadores",
         "title": "Tu arte merece un verdadero hogar.",
         "description": "Vende comisiones, gestiona tu cola, envía merch y crece tu audiencia — sin que las comisiones de plataforma se coman tu trabajo.",
-        "cta": "Empezar a vender"
+        "cta": "Empezar a vender",
+        "comingSoon": "Próximamente"
       },
       "fans": {
         "label": "Para coleccionistas",

--- a/apps/payments/src/features/assigned-orders/domain/constants.ts
+++ b/apps/payments/src/features/assigned-orders/domain/constants.ts
@@ -2,3 +2,15 @@ export const ASSIGNED_ORDERS_QUERY_KEY = "assigned-orders";
 
 /** Stale time for assigned orders query (30 seconds) */
 export const ASSIGNED_ORDERS_STALE_TIME_MS = 30_000;
+
+export const ASSIGNED_FILTER_STATUSES = [
+  "actionable",
+  "all",
+  "pending_verification",
+  "evidence_requested",
+  "approved",
+  "rejected",
+  "expired",
+] as const;
+
+export type AssignedFilterStatus = (typeof ASSIGNED_FILTER_STATUSES)[number];

--- a/apps/payments/src/features/assigned-orders/domain/searchParams.ts
+++ b/apps/payments/src/features/assigned-orders/domain/searchParams.ts
@@ -1,0 +1,12 @@
+import { parseAsStringEnum } from "nuqs";
+
+import {
+  ASSIGNED_FILTER_STATUSES,
+  type AssignedFilterStatus,
+} from "@/features/assigned-orders/domain/constants";
+
+export const assignedOrdersSearchParams = {
+  filter: parseAsStringEnum<AssignedFilterStatus>([
+    ...ASSIGNED_FILTER_STATUSES,
+  ]).withDefault("actionable"),
+};

--- a/apps/payments/src/features/assigned-orders/presentation/pages/AssignedOrdersPageContent.tsx
+++ b/apps/payments/src/features/assigned-orders/presentation/pages/AssignedOrdersPageContent.tsx
@@ -2,18 +2,35 @@
 
 import { Package } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useCallback } from "react";
+import { useQueryStates } from "nuqs";
+import { useCallback, useMemo } from "react";
 import { tid } from "shared";
+import { cn } from "ui";
 
 import { useAssignedOrders } from "@/features/assigned-orders/application/hooks/useAssignedOrders";
+import { ASSIGNED_FILTER_STATUSES } from "@/features/assigned-orders/domain/constants";
+import { assignedOrdersSearchParams } from "@/features/assigned-orders/domain/searchParams";
 import { useOrderActions } from "@/features/received-orders/application/hooks/useOrderActions";
+import { canActOnOrder } from "@/features/received-orders/domain/types";
 import type { SellerAction } from "@/features/received-orders/domain/types";
 import { ReceivedOrderCard } from "@/features/received-orders/presentation/components/ReceivedOrderCard";
 
 export function AssignedOrdersPageContent() {
   const t = useTranslations("assignedOrders");
-  const { data: orders, isLoading } = useAssignedOrders();
+
+  const [params, setParams] = useQueryStates(assignedOrdersSearchParams);
+  const activeFilter = params.filter;
+
+  const { data: allOrders, isLoading } = useAssignedOrders();
   const { mutate: executeAction, isPending } = useOrderActions();
+
+  const orders = useMemo(() => {
+    if (!allOrders) return allOrders;
+    if (activeFilter === "all") return allOrders;
+    if (activeFilter === "actionable")
+      return allOrders.filter((o) => canActOnOrder(o.payment_status));
+    return allOrders.filter((o) => o.payment_status === activeFilter);
+  }, [allOrders, activeFilter]);
 
   const handleAction = useCallback(
     (orderId: string, action: SellerAction, note?: string) => {
@@ -36,6 +53,28 @@ export function AssignedOrdersPageContent() {
             {t("title")}
           </h1>
         </header>
+
+        <div
+          className="flex flex-wrap items-center gap-2"
+          {...tid("assigned-orders-filters")}
+        >
+          {ASSIGNED_FILTER_STATUSES.map((status) => (
+            <button
+              key={status}
+              type="button"
+              onClick={() => setParams({ filter: status }, { history: "push" })}
+              className={cn(
+                "rounded-lg border-strong border-foreground px-3 py-1 font-display text-xs font-bold uppercase tracking-wider transition-colors",
+                activeFilter === status
+                  ? "bg-foreground text-background"
+                  : "bg-background text-foreground hover:bg-muted",
+              )}
+              {...tid(`assigned-filter-${status}`)}
+            >
+              {t(`filters.${status}`)}
+            </button>
+          ))}
+        </div>
 
         {isLoading && (
           <div className="flex items-center justify-center py-16">

--- a/apps/payments/src/features/received-orders/domain/types.ts
+++ b/apps/payments/src/features/received-orders/domain/types.ts
@@ -20,6 +20,8 @@ export interface ReceivedOrder {
   items: OrderItem[];
   /** Non-null when the order belongs to a seller who delegated to the current user */
   seller_name: string | null;
+  /** Set on delegated orders — true if the delegate holds management permissions */
+  can_manage?: boolean;
 }
 
 export type SellerAction = "approved" | "rejected" | "evidence_requested";

--- a/apps/payments/src/features/received-orders/infrastructure/receivedOrderQueries.ts
+++ b/apps/payments/src/features/received-orders/infrastructure/receivedOrderQueries.ts
@@ -36,17 +36,12 @@ const ORDER_SELECT = `
   )
 `;
 
-/** Statuses that delegates can act on */
-const ACTIONABLE_STATUSES = [
-  "pending_verification",
-  "evidence_requested",
-] as const;
-
 async function mapRowToOrder(
   supabase: SupabaseClient,
   row: OrderRow,
   buyerMap: Record<string, string>,
   sellerName: string | null,
+  canManage?: boolean,
 ): Promise<ReceivedOrder> {
   return {
     id: row.id,
@@ -68,62 +63,48 @@ async function mapRowToOrder(
     buyer_name: buyerMap[row.user_id] ?? FALLBACK_BUYER_NAME,
     items: row.order_items as OrderItem[],
     seller_name: sellerName,
+    can_manage: canManage,
   };
 }
 
-/** Check whether a filter value targets an actionable status. */
-function isActionableFilter(
-  filter?: string,
-): filter is (typeof ACTIONABLE_STATUSES)[number] {
-  return (
-    !!filter &&
-    filter !== "all" &&
-    ACTIONABLE_STATUSES.includes(filter as (typeof ACTIONABLE_STATUSES)[number])
-  );
-}
-
 /**
- * Fetch actionable orders from sellers who delegated to `userId`,
- * together with a map of seller display names.
+ * Fetch all orders from sellers who delegated to `userId`, together with
+ * seller display names and per-seller management permissions.
  */
 async function fetchDelegatedOrderRows(
   supabase: SupabaseClient,
   userId: string,
-  filter?: string,
-): Promise<{ rows: OrderRow[]; sellerNameMap: Record<string, string> }> {
+): Promise<{
+  rows: OrderRow[];
+  sellerNameMap: Record<string, string>;
+  sellerPermissionsMap: Record<string, string[]>;
+}> {
   const { data: delegations, error: delegationsError } = await supabase
     .from("seller_admins")
-    .select("seller_id")
+    .select("seller_id, permissions")
     .eq("admin_user_id", userId);
 
   if (delegationsError) throw delegationsError;
 
-  const delegatedSellerIds = (delegations ?? []).map((d) => d.seller_id);
+  const delegationRows = delegations ?? [];
 
-  if (delegatedSellerIds.length === 0) {
-    return { rows: [], sellerNameMap: {} };
+  if (delegationRows.length === 0) {
+    return { rows: [], sellerNameMap: {}, sellerPermissionsMap: {} };
   }
 
-  // Non-actionable filter → no delegated orders can match
-  if (filter && filter !== "all" && !isActionableFilter(filter)) {
-    return { rows: [], sellerNameMap: {} };
+  const delegatedSellerIds = delegationRows.map((d) => d.seller_id);
+
+  const sellerPermissionsMap: Record<string, string[]> = {};
+  for (const d of delegationRows) {
+    sellerPermissionsMap[d.seller_id] = (d.permissions as string[]) ?? [];
   }
 
-  let delegatedQuery = supabase
+  const { data, error } = await supabase
     .from("orders")
     .select(ORDER_SELECT)
     .in("seller_id", delegatedSellerIds)
-    .in("payment_status", [...ACTIONABLE_STATUSES])
     .order("created_at", { ascending: false });
 
-  if (isActionableFilter(filter)) {
-    delegatedQuery = delegatedQuery.eq(
-      "payment_status",
-      filter as "pending_verification" | "evidence_requested",
-    );
-  }
-
-  const { data, error } = await delegatedQuery;
   if (error) throw error;
 
   const rows = (data ?? []) as OrderRow[];
@@ -133,11 +114,13 @@ async function fetchDelegatedOrderRows(
       ? await fetchUserDisplayNames(supabase, delegatedSellerIds, "Seller")
       : {};
 
-  return { rows, sellerNameMap };
+  return { rows, sellerNameMap, sellerPermissionsMap };
 }
 
 /**
- * Fetch only the actionable orders delegated to the current user via seller_admins.
+ * Fetch all orders delegated to the current user via seller_admins.
+ * Each order carries `can_manage` based on the delegate's permissions for
+ * that seller (requires orders.approve or orders.request_proof).
  */
 export async function fetchAssignedOrders(
   supabase: SupabaseClient,
@@ -147,10 +130,8 @@ export async function fetchAssignedOrders(
   } = await supabase.auth.getUser();
   if (!user) return [];
 
-  const { rows, sellerNameMap } = await fetchDelegatedOrderRows(
-    supabase,
-    user.id,
-  );
+  const { rows, sellerNameMap, sellerPermissionsMap } =
+    await fetchDelegatedOrderRows(supabase, user.id);
 
   if (rows.length === 0) return [];
 
@@ -162,14 +143,19 @@ export async function fetchAssignedOrders(
   );
 
   return Promise.all(
-    rows.map((row) =>
-      mapRowToOrder(
+    rows.map((row) => {
+      const permissions = sellerPermissionsMap[row.seller_id ?? ""] ?? [];
+      const canManage =
+        permissions.includes("orders.approve") ||
+        permissions.includes("orders.request_proof");
+      return mapRowToOrder(
         supabase,
         row,
         buyerMap,
         sellerNameMap[row.seller_id ?? ""] ?? "Seller",
-      ),
-    ),
+        canManage,
+      );
+    }),
   );
 }
 

--- a/apps/payments/src/features/received-orders/presentation/components/ActionButtons.tsx
+++ b/apps/payments/src/features/received-orders/presentation/components/ActionButtons.tsx
@@ -21,6 +21,7 @@ interface ActionButtonsProps {
   status: OrderStatus;
   onAction: (action: SellerAction, note?: string) => void;
   isPending: boolean;
+  canManage?: boolean;
 }
 
 type ActionMode = "approve" | "reject" | "evidence" | null;
@@ -30,6 +31,7 @@ export function ActionButtons({
   status,
   onAction,
   isPending,
+  canManage = true,
 }: ActionButtonsProps) {
   const t = useTranslations("receivedOrders");
   const [mode, setMode] = useState<ActionMode>(null);
@@ -55,7 +57,7 @@ export function ActionButtons({
     [mode, onAction],
   );
 
-  if (!canApprove && !canReject) return null;
+  if (!canManage || (!canApprove && !canReject)) return null;
 
   // Approve — inline confirmation with checkbox
   if (mode === "approve") {

--- a/apps/payments/src/features/received-orders/presentation/components/ReceivedOrderCard.tsx
+++ b/apps/payments/src/features/received-orders/presentation/components/ReceivedOrderCard.tsx
@@ -204,6 +204,7 @@ export function ReceivedOrderCard({
           status={order.payment_status}
           onAction={handleAction}
           isPending={isPending}
+          canManage={order.can_manage ?? true}
         />
       </div>
     </div>

--- a/apps/payments/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/payments/src/shared/infrastructure/i18n/messages/en.json
@@ -128,7 +128,16 @@
   "assignedOrders": {
     "title": "Assigned Items",
     "noOrders": "No assigned orders",
-    "noOrdersHint": "When a seller assigns you to one of their products, pending orders will appear here"
+    "noOrdersHint": "When a seller assigns you to one of their products, pending orders will appear here",
+    "filters": {
+      "actionable": "To do",
+      "all": "All",
+      "pending_verification": "Pending",
+      "evidence_requested": "Evidence",
+      "approved": "Approved",
+      "rejected": "Rejected",
+      "expired": "Expired"
+    }
   },
   "receivedOrders": {
     "title": "Received Orders",

--- a/apps/payments/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/payments/src/shared/infrastructure/i18n/messages/es.json
@@ -128,7 +128,16 @@
   "assignedOrders": {
     "title": "Items Asignados",
     "noOrders": "Sin ordenes asignadas",
-    "noOrdersHint": "Cuando un vendedor te asigne a uno de sus productos, las ordenes pendientes apareceran aqui"
+    "noOrdersHint": "Cuando un vendedor te asigne a uno de sus productos, las ordenes pendientes apareceran aqui",
+    "filters": {
+      "actionable": "Por hacer",
+      "all": "Todas",
+      "pending_verification": "Pendiente",
+      "evidence_requested": "Evidencia",
+      "approved": "Aprobadas",
+      "rejected": "Rechazadas",
+      "expired": "Expiradas"
+    }
   },
   "receivedOrders": {
     "title": "Ordenes Recibidas",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "candyshop",
-  "version": "0.2.0",
+  "version": "2026.04.22.1",
   "private": true,
   "scripts": {
     "dev": "node scripts/start.mjs",

--- a/supabase/migrations/20260422000000_orders_delegate_read_all.sql
+++ b/supabase/migrations/20260422000000_orders_delegate_read_all.sql
@@ -1,0 +1,35 @@
+-- =============================================================================
+-- Allow delegates to read ALL orders from sellers they manage, not only
+-- actionable ones. Tighten the update policy to require at least one
+-- management permission (orders.approve OR orders.request_proof).
+-- =============================================================================
+
+-- Read: no status filter — delegates can see full order history
+drop policy if exists "orders_delegate_read" on public.orders;
+
+create policy "orders_delegate_read" on public.orders
+  for select using (
+    exists (
+      select 1 from public.seller_admins sa
+      where sa.admin_user_id = auth.uid()
+        and sa.seller_id = orders.seller_id
+    )
+  );
+
+-- Update: still limited to actionable statuses, but now also requires
+-- the delegate to hold orders.approve or orders.request_proof
+drop policy if exists "orders_delegate_update" on public.orders;
+
+create policy "orders_delegate_update" on public.orders
+  for update using (
+    payment_status in ('pending_verification', 'evidence_requested')
+    and exists (
+      select 1 from public.seller_admins sa
+      where sa.admin_user_id = auth.uid()
+        and sa.seller_id = orders.seller_id
+        and (
+          'orders.approve'       = any(sa.permissions)
+          or 'orders.request_proof' = any(sa.permissions)
+        )
+    )
+  );


### PR DESCRIPTION
## Release v2026.04.22.1

### Changes
- feat(payments): delegate full order history + filter bar with actionable default (#144)
  - Delegates see all orders (not just actionable ones) from their assigned sellers
  - Delegate actions (approve/reject/request evidence) gated by seller_admins.permissions
  - AssignedOrdersPageContent: filter bar with pending/evidence/approved/rejected/expired filters
  - New "actionable" filter as URL-persisted default (pending_verification + evidence_requested)
  - RolesSection artists card changed to coming-soon badge

- fix(audit,payments): resolve 406 on audit REST query, add Conspace payment method (#142)

### Migration
- `20260422000000_orders_delegate_read_all.sql` — relaxed delegate read policy, tightened update policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)