### PR TITLE
fix(db): switch audit proxy view to SECURITY INVOKER

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "candyshop",
-  "version": "0.2.0",
+  "version": "2026.04.22.2",
   "private": true,
   "scripts": {
     "dev": "node scripts/start.mjs",

--- a/supabase/migrations/20260422100000_audit_view_security_invoker.sql
+++ b/supabase/migrations/20260422100000_audit_view_security_invoker.sql
@@ -1,0 +1,13 @@
+-- Fix: public.logged_actions_with_user was implicitly SECURITY DEFINER because
+-- it proxies a view in the audit schema. Switch to SECURITY INVOKER so Postgres
+-- enforces the querying user's own permissions instead of the view owner's.
+-- Grant USAGE on audit schema so authenticated users can resolve the underlying view.
+
+grant usage on schema audit to authenticated;
+
+create or replace view public.logged_actions_with_user
+  with (security_invoker = true)
+as
+select * from audit.logged_actions_with_user;
+
+grant select on public.logged_actions_with_user to authenticated;


### PR DESCRIPTION
## Summary

- Adds `WITH (security_invoker = true)` to `public.logged_actions_with_user`, fixing the Supabase security advisor warning
- Grants `USAGE ON SCHEMA audit TO authenticated` so the view resolves correctly under the querying user's permissions
- Migration already applied to both dev and prod

## Why

Supabase flagged the view as SECURITY DEFINER because it proxies `audit.logged_actions_with_user` (a different schema). With SECURITY DEFINER, the view runs as its owner and bypasses the querying user's RLS/permissions. Switching to SECURITY INVOKER is the correct posture — the view should respect the caller's access.

## Test plan

- [ ] Supabase security advisor no longer flags `public.logged_actions_with_user`
- [ ] Admin audit log page still loads correctly for users with `audit.read` permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)