### PR TITLE
fix(ci): resolve deploy broken-pipe and invalid @v6 action refs [GH-158]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       docs-only: ${{ steps.check.outputs.docs-only }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Detect file changes
         uses: dorny/paths-filter@v3
@@ -101,13 +101,13 @@ jobs:
     if: needs.changes.outputs.docs-only == 'false'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -203,13 +203,13 @@ jobs:
     if: needs.changes.outputs.docs-only == 'false'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -301,13 +301,13 @@ jobs:
     if: needs.changes.outputs.docs-only == 'false'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -423,13 +423,13 @@ jobs:
         shell: bash
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -608,13 +608,13 @@ jobs:
     if: needs.changes.outputs.docs-only == 'false' && github.event_name == 'pull_request'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -648,13 +648,13 @@ jobs:
     if: needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.deploy == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -108,7 +108,7 @@ jobs:
       docs-only: ${{ steps.check.outputs.docs-only }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Detect file changes
         uses: dorny/paths-filter@v3
@@ -168,13 +168,13 @@ jobs:
     if: needs.changes.outputs.docs-only == 'false'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -214,13 +214,13 @@ jobs:
     if: needs.changes.outputs.store == 'true' || needs.changes.outputs.packages == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -279,13 +279,13 @@ jobs:
     if: needs.changes.outputs.store == 'true' || needs.changes.outputs.packages == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"

--- a/.github/workflows/pr-freshness.yml
+++ b/.github/workflows/pr-freshness.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -6,6 +6,44 @@ set -euo pipefail
 # Runs ON the server via SSH from GitHub Actions
 # =============================================================================
 
+# ─── Cloudflare Access SSH disconnect guard ───────────────────────────────────
+# Building 7 Next.js apps takes 3-4 minutes. The Cloudflare Access WebSocket
+# proxy drops idle TCP connections before the build finishes, causing
+# "client_loop: send disconnect: Broken pipe" in CI.
+#
+# Fix: on first invocation, re-launch ourselves detached from the SSH session
+# via nohup, then tail the log back through the same connection so CI output
+# keeps flowing. Even if SSH drops after this, the build continues on-server.
+# ─────────────────────────────────────────────────────────────────────────────
+if [ -z "${DEPLOY_DETACHED:-}" ]; then
+  DEPLOY_LOG=/tmp/deploy-candyshop.log
+  DEPLOY_DONE=/tmp/deploy-candyshop.done
+  rm -f "$DEPLOY_LOG" "$DEPLOY_DONE"
+
+  DEPLOY_DETACHED=1 nohup bash "$0" "$@" >"$DEPLOY_LOG" 2>&1 &
+  BG_PID=$!
+
+  # Stream log back — keeps the SSH/WebSocket alive AND surfaces build output.
+  # GNU tail exits automatically when the watched PID exits (Linux coreutils).
+  if tail -f "$DEPLOY_LOG" --pid="$BG_PID" 2>/dev/null; then
+    :
+  else
+    # Fallback for non-GNU tail: background-tail + manual wait
+    tail -f "$DEPLOY_LOG" &
+    TAIL_PID=$!
+    while kill -0 "$BG_PID" 2>/dev/null; do sleep 5; done
+    sleep 2
+    kill "$TAIL_PID" 2>/dev/null || true
+  fi
+
+  DEPLOY_EXIT=$(cat "$DEPLOY_DONE" 2>/dev/null || echo 1)
+  exit "$DEPLOY_EXIT"
+fi
+
+# Write exit code on completion so the wrapper above can relay it
+_write_done() { echo $? >/tmp/deploy-candyshop.done; }
+trap _write_done EXIT
+
 DEPLOY_DIR="/home/furrycolombia/candyshop"
 REPO_URL="${REPO_URL:-}"
 BRANCH="${BRANCH:-main}"


### PR DESCRIPTION
## Summary

- Fixes `client_loop: send disconnect: Broken pipe` killing the production deploy mid-build
- Fixes CI and PR checks failing immediately due to non-existent `@v6` GitHub Actions

## Related Issue

Closes #158

## Changes

**`scripts/deploy-production.sh`** — Cloudflare Access SSH disconnect guard
- On first invocation, the script relaunches itself detached via `nohup` and tails its own log back through the same SSH session
- Keeps data flowing through the Cloudflare WebSocket tunnel during the 3-4 minute Next.js build, preventing idle-timeout kills
- Even if SSH drops after the handoff, the build continues on-server and exits with the correct code

**`.github/workflows/ci.yml`, `pr-checks.yml`, `pr-freshness.yml`** — Fix invalid action versions
- Replaced 30 occurrences of `actions/checkout@v6`, `actions/setup-node@v6`, `pnpm/action-setup@v6` with the correct `@v4` versions
- These `@v6` tags do not exist, causing all CI jobs to fail at the setup step

## Testing

- Merge to develop → trigger a release to verify deploy completes without broken pipe
- Open any PR to verify CI jobs (quality, unit-tests, build) now reach the actual checks instead of failing at checkout

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)