### PR TITLE
fix(infra): add health watcher, Telegram alerts, and i18n permissions keys [GH-161]

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -125,6 +125,9 @@ jobs:
           NEXT_PUBLIC_PAYMENTS_URL=https://store.furrycolombia.com/payments
           NEXT_PUBLIC_PLAYGROUND_URL=https://store.furrycolombia.com/playground
           NEXT_PUBLIC_STUDIO_URL=https://store.furrycolombia.com/studio
+          TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID=${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_THREAD_ID=${{ secrets.TELEGRAM_THREAD_ID }}
           ENVEOF'
 
       - name: Copy deploy script to server

--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -47,6 +47,9 @@ jobs:
           CLOUDFLARED_CONFIG: ${{ secrets.CLOUDFLARED_CONFIG }}
           GOOGLE_TEST_EMAIL: ${{ secrets.GOOGLE_TEST_EMAIL }}
           GOOGLE_TEST_PASSWORD: ${{ secrets.GOOGLE_TEST_PASSWORD }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_THREAD_ID: ${{ secrets.TELEGRAM_THREAD_ID }}
         shell: bash
         run: |
           # Validate required secrets are present
@@ -114,6 +117,11 @@ jobs:
             echo "# ─── E2E Google test account ─────────────────────────────────────"
             echo "GOOGLE_TEST_EMAIL=${GOOGLE_TEST_EMAIL}"
             echo "GOOGLE_TEST_PASSWORD=${GOOGLE_TEST_PASSWORD}"
+            echo ""
+            echo "# ─── Telegram alerting (health watcher) ──────────────────────────"
+            echo "TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}"
+            echo "TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}"
+            echo "TELEGRAM_THREAD_ID=${TELEGRAM_THREAD_ID}"
           } > secrets-plain.txt
 
       - name: Encrypt secrets file

--- a/apps/admin/src/app/health/route.ts
+++ b/apps/admin/src/app/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json(
+    { status: "ok", timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/apps/admin/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/admin/src/shared/infrastructure/i18n/messages/en.json
@@ -250,7 +250,9 @@
     "orders": {
       "create": "Place Orders",
       "read": "View Orders",
-      "update": "Manage Orders"
+      "update": "Manage Orders",
+      "approve": "Approve Orders",
+      "request_proof": "Request Payment Proof"
     },
     "receipts": {
       "create": "Upload Receipts",

--- a/apps/admin/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/admin/src/shared/infrastructure/i18n/messages/es.json
@@ -252,7 +252,9 @@
     "orders": {
       "create": "Hacer Pedidos",
       "read": "Ver Pedidos",
-      "update": "Gestionar Pedidos"
+      "update": "Gestionar Pedidos",
+      "approve": "Aprobar Pedidos",
+      "request_proof": "Solicitar Comprobante"
     },
     "receipts": {
       "create": "Subir Recibos",

--- a/apps/auth/src/app/health/route.ts
+++ b/apps/auth/src/app/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json(
+    { status: "ok", timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/apps/landing/src/app/health/route.ts
+++ b/apps/landing/src/app/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json(
+    { status: "ok", timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/apps/payments/src/app/health/route.ts
+++ b/apps/payments/src/app/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json(
+    { status: "ok", timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/apps/studio/src/app/health/route.ts
+++ b/apps/studio/src/app/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json(
+    { status: "ok", timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -28,6 +28,10 @@ services:
       # These are only injected when the variables are set in the host env.
       - SUPABASE_URL_INTERNAL=${SUPABASE_URL_INTERNAL:-}
       - SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY:-}
+      # Telegram alerting for the in-container health watcher (optional).
+      # Set both variables to enable; leave empty to keep alerts disabled.
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
+      - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-}
     extra_hosts:
       # Allow the container to reach host-local services (e.g. Supabase on
       # localhost:64321) via host.docker.internal on Linux/Windows/Mac.

--- a/docker/prod/supervisord.conf
+++ b/docker/prod/supervisord.conf
@@ -120,3 +120,17 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:watcher]
+command=node /app/watcher.mjs
+directory=/app
+user=nextjs
+autostart=true
+autorestart=true
+startretries=3
+startsecs=5
+stopwaitsecs=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/smoke/Dockerfile
+++ b/docker/smoke/Dockerfile
@@ -111,6 +111,9 @@ COPY --from=builder /app/apps/studio/public             /app/studio/apps/studio/
 COPY docker/prod/nginx.conf /etc/nginx/nginx.conf
 COPY docker/prod/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
+# Copy the in-container health watcher
+COPY docker/watcher.mjs /app/watcher.mjs
+
 EXPOSE 80
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/docker/watcher.mjs
+++ b/docker/watcher.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+/**
+ * watcher.mjs — in-process health watcher
+ *
+ * Runs via PM2 alongside all the Next.js apps.
+ * Pings each app's /health endpoint at a random 5–10 minute interval.
+ * Also monitors system resources (RAM, disk) and the Cloudflare tunnel.
+ * Detects up→down and down→up transitions and (optionally) alerts via Telegram.
+ *
+ * Telegram env vars (set in compose.yml or the server env):
+ *   TELEGRAM_BOT_TOKEN  — bot token from @BotFather
+ *   TELEGRAM_CHAT_ID    — chat or group ID to send alerts to
+ *   TELEGRAM_THREAD_ID  — (optional) forum topic thread ID for supergroups
+ *
+ * Tuning (optional):
+ *   WATCHER_MIN_MS  — minimum interval in ms  (default: 300_000 = 5 min)
+ *   WATCHER_MAX_MS  — maximum interval in ms  (default: 600_000 = 10 min)
+ */
+
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+const MIN_MS = Number(process.env.WATCHER_MIN_MS ?? 300_000);
+const MAX_MS = Number(process.env.WATCHER_MAX_MS ?? 600_000);
+const TIMEOUT_MS = 8_000;
+const STARTUP_GRACE_MS = 90_000; // wait before first check so apps can boot
+
+// Re-alert on a persistent problem at most once per 2 hours
+const REPEAT_ALERT_MS = 2 * 60 * 60 * 1_000;
+
+// System resource thresholds
+const RAM_CRITICAL_MB = 200;
+const RAM_WARN_MB     = 400;
+const DISK_CRITICAL_PCT = 90;
+const DISK_WARN_PCT     = 80;
+
+const TELEGRAM_TOKEN  = process.env.TELEGRAM_BOT_TOKEN  ?? "";
+const TELEGRAM_CHAT   = process.env.TELEGRAM_CHAT_ID    ?? "";
+const TELEGRAM_THREAD = process.env.TELEGRAM_THREAD_ID  ?? "";
+
+// Internal ports — watcher talks directly to each Node.js process,
+// bypassing nginx so we catch per-app failures accurately.
+const APPS = [
+  { name: "store",      url: "http://127.0.0.1:5001/store/health"      },
+  { name: "auth",       url: "http://127.0.0.1:5000/auth/health"       },
+  { name: "admin",      url: "http://127.0.0.1:5002/admin/health"      },
+  { name: "landing",    url: "http://127.0.0.1:5004/health"            },
+  { name: "payments",   url: "http://127.0.0.1:5005/payments/health"   },
+  { name: "studio",     url: "http://127.0.0.1:5006/studio/health"     },
+  { name: "playground", url: "http://127.0.0.1:5003/playground/health" },
+];
+
+// ── State tracking ────────────────────────────────────────────────────────────
+
+// Possible values: "unknown" | "up" | "down"
+const state = Object.fromEntries(APPS.map((a) => [a.name, "unknown"]));
+
+// System state: "unknown" | "ok" | "warning" | "critical"
+const sysState = { ram: "unknown", disk: "unknown", tunnel: "unknown" };
+
+// Cooldown map: key → timestamp of last alert sent for that key
+const lastAlerted = new Map();
+
+// ── Telegram ──────────────────────────────────────────────────────────────────
+
+async function sendTelegram(text) {
+  if (!TELEGRAM_TOKEN || !TELEGRAM_CHAT) return;
+  try {
+    const res = await fetch(
+      `https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chat_id: TELEGRAM_CHAT,
+          text,
+          parse_mode: "HTML",
+          ...(TELEGRAM_THREAD ? { message_thread_id: Number(TELEGRAM_THREAD) } : {}),
+        }),
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+    if (!res.ok) {
+      const body = await res.text();
+      console.error(`[watcher] telegram error ${res.status}: ${body}`);
+    }
+  } catch (err) {
+    console.error(`[watcher] telegram send failed: ${err.message}`);
+  }
+}
+
+/**
+ * Alert on transition OR repeat a persistent alert after the cooldown window.
+ * @param {string} key    — unique identifier for the alert category
+ * @param {boolean} isNew — true if this is a new transition (prev state was ok/unknown)
+ * @param {string} text   — HTML message to send
+ */
+async function maybeAlert(key, isNew, text) {
+  const now = Date.now();
+  if (isNew) {
+    lastAlerted.set(key, now);
+    await sendTelegram(text);
+    return;
+  }
+  // Persistent problem — re-alert only after cooldown
+  const last = lastAlerted.get(key) ?? 0;
+  if (now - last >= REPEAT_ALERT_MS) {
+    lastAlerted.set(key, now);
+    await sendTelegram(text);
+  }
+}
+
+// ── System health checks ──────────────────────────────────────────────────────
+
+function readRamFreeBytes() {
+  try {
+    const meminfo = readFileSync("/proc/meminfo", "utf8");
+    // MemAvailable is the best indicator of free+reclaimable RAM
+    const match = meminfo.match(/^MemAvailable:\s+(\d+)\s+kB/m);
+    if (match) return Number(match[1]) * 1024;
+    // Fallback: MemFree
+    const fallback = meminfo.match(/^MemFree:\s+(\d+)\s+kB/m);
+    if (fallback) return Number(fallback[1]) * 1024;
+  } catch {
+    // not Linux or no /proc — ignore
+  }
+  return null;
+}
+
+function readDiskUsedPct() {
+  try {
+    const result = spawnSync("df", ["-P", "/"], { encoding: "utf8", timeout: 5_000 });
+    if (result.status !== 0) return null;
+    // Output: Filesystem  1024-blocks  Used  Available  Capacity%  Mounted
+    const lines = result.stdout.trim().split("\n");
+    const data = lines[1];
+    const match = data?.match(/(\d+)%/);
+    if (match) return Number(match[1]);
+  } catch {
+    // df not available
+  }
+  return null;
+}
+
+function isTunnelRunning() {
+  try {
+    const result = spawnSync("pgrep", ["-x", "cloudflared"], {
+      encoding: "utf8",
+      timeout: 3_000,
+    });
+    return result.status === 0;
+  } catch {
+    return null; // unknown
+  }
+}
+
+async function checkSystem() {
+  // ── RAM ──
+  const ramBytes = readRamFreeBytes();
+  if (ramBytes !== null) {
+    const ramMB = ramBytes / (1024 * 1024);
+    const prev = sysState.ram;
+    let next;
+    if (ramMB < RAM_CRITICAL_MB) next = "critical";
+    else if (ramMB < RAM_WARN_MB) next = "warning";
+    else next = "ok";
+
+    if (next !== "ok") {
+      const icon = next === "critical" ? "🔴" : "🟡";
+      const severity = next === "critical" ? "CRITICAL" : "warning";
+      const msg = `${icon} <b>RAM ${severity}</b>\nAvailable: <code>${ramMB.toFixed(0)} MB</code>`;
+      await maybeAlert("ram", prev === "ok" || prev === "unknown", msg);
+      console.error(`[watcher] RAM ${next}: ${ramMB.toFixed(0)} MB available`);
+    } else if (prev === "warning" || prev === "critical") {
+      await sendTelegram(`✅ <b>RAM recovered</b>\nAvailable: <code>${ramMB.toFixed(0)} MB</code>`);
+      console.log(`[watcher] RAM recovered: ${ramMB.toFixed(0)} MB`);
+    } else {
+      console.log(`[watcher] RAM ok: ${ramMB.toFixed(0)} MB`);
+    }
+    sysState.ram = next;
+  }
+
+  // ── Disk ──
+  const diskPct = readDiskUsedPct();
+  if (diskPct !== null) {
+    const prev = sysState.disk;
+    let next;
+    if (diskPct >= DISK_CRITICAL_PCT) next = "critical";
+    else if (diskPct >= DISK_WARN_PCT) next = "warning";
+    else next = "ok";
+
+    if (next !== "ok") {
+      const icon = next === "critical" ? "🔴" : "🟡";
+      const severity = next === "critical" ? "CRITICAL" : "warning";
+      const msg = `${icon} <b>Disk ${severity}</b>\nUsed: <code>${diskPct}%</code> of root filesystem`;
+      await maybeAlert("disk", prev === "ok" || prev === "unknown", msg);
+      console.error(`[watcher] Disk ${next}: ${diskPct}% used`);
+    } else if (prev === "warning" || prev === "critical") {
+      await sendTelegram(`✅ <b>Disk recovered</b>\nUsed: <code>${diskPct}%</code>`);
+      console.log(`[watcher] Disk recovered: ${diskPct}%`);
+    } else {
+      console.log(`[watcher] Disk ok: ${diskPct}%`);
+    }
+    sysState.disk = next;
+  }
+
+  // ── Cloudflare tunnel ──
+  const tunnelUp = isTunnelRunning();
+  if (tunnelUp !== null) {
+    const prev = sysState.tunnel;
+    const next = tunnelUp ? "ok" : "critical";
+
+    if (next === "critical") {
+      const msg = `🔴 <b>Cloudflare tunnel is DOWN</b>\n<code>cloudflared</code> process not found — SSH access and public routing may be unavailable`;
+      await maybeAlert("tunnel", prev !== "critical", msg);
+      console.error("[watcher] Cloudflare tunnel: DOWN");
+    } else if (prev === "critical") {
+      await sendTelegram(`✅ <b>Cloudflare tunnel recovered</b>\n<code>cloudflared</code> is running again`);
+      console.log("[watcher] Cloudflare tunnel: recovered");
+    } else if (prev === "unknown") {
+      console.log("[watcher] Cloudflare tunnel: ok");
+    } else {
+      console.log("[watcher] Cloudflare tunnel: ok");
+    }
+    sysState.tunnel = next;
+  }
+}
+
+// ── Ping one app ──────────────────────────────────────────────────────────────
+
+async function ping(app) {
+  const prev = state[app.name];
+
+  try {
+    const res = await fetch(app.url, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    if (prev === "down") {
+      console.log(`[watcher] ${app.name}: ✓ recovered`);
+      state[app.name] = "up";
+      await sendTelegram(`✅ <b>${app.name}</b> is back up`);
+    } else {
+      console.log(`[watcher] ${app.name}: ok`);
+      state[app.name] = "up";
+    }
+  } catch (err) {
+    state[app.name] = "down";
+
+    if (prev === "up") {
+      console.error(`[watcher] ${app.name}: ✗ DOWN — ${err.message}`);
+      await sendTelegram(
+        `🔴 <b>${app.name}</b> is not responding\n<code>${err.message}</code>`,
+      );
+    } else if (prev === "unknown") {
+      console.error(`[watcher] ${app.name}: ✗ unreachable on first check — ${err.message}`);
+    } else {
+      console.error(`[watcher] ${app.name}: ✗ still down — ${err.message}`);
+    }
+  }
+}
+
+// ── Main loop ─────────────────────────────────────────────────────────────────
+
+function randomInterval() {
+  return MIN_MS + Math.floor(Math.random() * (MAX_MS - MIN_MS));
+}
+
+async function tick() {
+  const ts = new Date().toISOString();
+  console.log(`[watcher] checking all apps and system at ${ts}`);
+
+  await Promise.all(APPS.map(ping));
+  await checkSystem();
+
+  const next = randomInterval();
+  console.log(`[watcher] next check in ${Math.round(next / 60_000)} min`);
+  setTimeout(tick, next);
+}
+
+// Allow apps to finish booting before the first check
+console.log(
+  `[watcher] started — first check in ${STARTUP_GRACE_MS / 1000}s ` +
+  `(telegram: ${TELEGRAM_TOKEN ? `enabled, thread: ${TELEGRAM_THREAD || "none"}` : "disabled"})`,
+);
+setTimeout(tick, STARTUP_GRACE_MS);

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -40,9 +40,56 @@ if [ -z "${DEPLOY_DETACHED:-}" ]; then
   exit "$DEPLOY_EXIT"
 fi
 
-# Write exit code on completion so the wrapper above can relay it
-_write_done() { echo $? >/tmp/deploy-candyshop.done; }
-trap _write_done EXIT
+# ─── Telegram deploy notifications ───────────────────────────────────────────
+# Extract Telegram vars early from the env file so we can notify before the full
+# env is sourced (which happens later, just before the build step).
+_tg_env="${ENV_FILE:-/tmp/.candyshop-build.env}"
+if [ -f "$_tg_env" ]; then
+  TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-$(grep '^TELEGRAM_BOT_TOKEN=' "$_tg_env" | cut -d= -f2- 2>/dev/null || true)}"
+  TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-$(grep '^TELEGRAM_CHAT_ID=' "$_tg_env" | cut -d= -f2- 2>/dev/null || true)}"
+  TELEGRAM_THREAD_ID="${TELEGRAM_THREAD_ID:-$(grep '^TELEGRAM_THREAD_ID=' "$_tg_env" | cut -d= -f2- 2>/dev/null || true)}"
+fi
+
+notify_telegram() {
+  [ -n "${TELEGRAM_BOT_TOKEN:-}" ] || return 0
+  [ -n "${TELEGRAM_CHAT_ID:-}" ] || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+  local payload
+  payload=$(python3 -c "
+import json, sys
+d = {'chat_id': sys.argv[1], 'text': sys.argv[2], 'parse_mode': 'HTML'}
+if sys.argv[3]:
+    d['message_thread_id'] = int(sys.argv[3])
+print(json.dumps(d))" "$TELEGRAM_CHAT_ID" "$1" "${TELEGRAM_THREAD_ID:-}") || return 0
+  curl -sf --max-time 10 -X POST \
+    "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    -H 'Content-Type: application/json' \
+    -d "$payload" >/dev/null 2>&1 || true
+}
+
+# Write exit code + send deploy result notification
+DEPLOY_START=$(date +%s)
+_on_exit() {
+  local code=$?
+  echo $code >/tmp/deploy-candyshop.done
+  local elapsed=$(( $(date +%s) - DEPLOY_START ))
+  local dur
+  if [ "$elapsed" -ge 60 ]; then
+    dur="$(( elapsed / 60 ))m $(( elapsed % 60 ))s"
+  else
+    dur="${elapsed}s"
+  fi
+  local commit="${DEPLOY_COMMIT:-unknown}"
+  if [ "$code" -eq 0 ]; then
+    notify_telegram "$(printf '✅ <b>Deploy complete</b>\nBranch: <code>%s</code>\nCommit: <code>%s</code>\nDuration: %s' \
+      "$BRANCH" "$commit" "$dur")"
+  else
+    notify_telegram "$(printf '❌ <b>Deploy FAILED</b> (exit %s)\nBranch: <code>%s</code>\nCommit: <code>%s</code>\nDuration: %s' \
+      "$code" "$BRANCH" "$commit" "$dur")"
+  fi
+}
+trap _on_exit EXIT
+# ─────────────────────────────────────────────────────────────────────────────
 
 DEPLOY_DIR="/home/furrycolombia/candyshop"
 REPO_URL="${REPO_URL:-}"
@@ -64,6 +111,7 @@ export NVM_DIR="$HOME/.nvm"
 nvm use 22 --silent || err "Node 22 not available via nvm"
 
 log "Node $(node --version) | pnpm $(pnpm --version) | PM2 $(pm2 --version)"
+notify_telegram "$(printf '🚀 <b>Deploy started</b>\nBranch: <code>%s</code>' "$BRANCH")"
 
 # =============================================================================
 # Clone or pull
@@ -81,7 +129,8 @@ else
 fi
 
 cd "$DEPLOY_DIR"
-log "Checked out $(git log --oneline -1)"
+DEPLOY_COMMIT=$(git log --format="%h %s" -1 2>/dev/null || true)
+log "Checked out $DEPLOY_COMMIT"
 
 # =============================================================================
 # Install dependencies
@@ -167,6 +216,12 @@ for APP_ENTRY in "${APPS[@]}"; do
   PORT=$APP_PORT HOSTNAME=0.0.0.0 pm2 start "$SERVER_JS" \
     --name "$PM2_NAME"
 done
+
+log "Starting health watcher..."
+pm2 delete candyshop-watcher 2>/dev/null || true
+pm2 start "$DEPLOY_DIR/docker/watcher.mjs" \
+  --name candyshop-watcher \
+  --env "TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-},TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-},TELEGRAM_THREAD_ID=${TELEGRAM_THREAD_ID:-}"
 
 # Save PM2 process list for auto-restart on reboot
 pm2 save


### PR DESCRIPTION
## Summary

- Add in-process health watcher (`docker/watcher.mjs`) that pings each app's `/health` endpoint and monitors RAM, disk, and Cloudflare tunnel — sends Telegram alerts on transitions with 2h cooldown for persistent issues
- Wire watcher into PM2 via `deploy-production.sh` and into Docker via supervisord
- Add `/health` routes for admin, auth, landing, payments, and studio apps
- Add Telegram deploy start/finish notifications to `scripts/deploy-production.sh` with branch, commit, and duration
- Propagate `TELEGRAM_CHAT_ID`, `TELEGRAM_THREAD_ID`, `TELEGRAM_BOT_TOKEN` through GitHub workflows (`deploy-production.yml`, `sync-secrets.yml`) and push to GitHub secrets
- Fix missing `permissions.orders.approve` and `permissions.orders.request_proof` i18n keys in admin app

## Related Issue

Closes #161

## Test plan

- [ ] Deploy to production and verify Telegram "Deploy started" / "Deploy complete" messages appear in the Server Notifications topic
- [ ] Verify watcher starts via PM2 and logs heartbeats
- [ ] Verify `/health` endpoints return 200 on all apps