### PR TITLE
fix(ci): prevent broken-pipe by fire-and-forget SSH + polling deploy [GH-163]

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -135,18 +135,44 @@ jobs:
           cat scripts/deploy-production.sh | ssh ${{ secrets.PROD_SERVER_HOST }} \
             'cat > /tmp/deploy-production.sh && chmod +x /tmp/deploy-production.sh'
 
-      - name: Run deployment
+      - name: Start deployment
         run: |
-          ssh ${{ secrets.PROD_SERVER_HOST }} \
-            "REPO_URL='https://github.com/${{ github.repository }}.git' \
-             BRANCH='${{ github.ref_name }}' \
-             ENV_FILE='/tmp/.candyshop-build.env' \
-             bash /tmp/deploy-production.sh"
+          # Fire-and-forget: start the deploy in background and disconnect immediately.
+          # The Cloudflare Access proxy drops long-lived SSH WebSockets mid-build,
+          # so we never keep a connection open for more than a few seconds.
+          ssh ${{ secrets.PROD_SERVER_HOST }} "
+            rm -f /tmp/deploy-candyshop.done /tmp/deploy-candyshop.log
+            REPO_URL='https://github.com/${{ github.repository }}.git' \
+            BRANCH='${{ github.ref_name }}' \
+            ENV_FILE='/tmp/.candyshop-build.env' \
+            DEPLOY_DETACHED=1 \
+            nohup bash /tmp/deploy-production.sh > /tmp/deploy-candyshop.log 2>&1 &
+            disown
+          "
+          echo "Deploy process started on server — polling for result..."
+
+      - name: Wait for deployment
+        run: |
+          # Poll every 30s via short-lived SSH connections (max 25 min).
+          for i in $(seq 1 50); do
+            sleep 30
+            echo "--- log tail [poll $i/50] ---"
+            ssh ${{ secrets.PROD_SERVER_HOST }} \
+              "tail -25 /tmp/deploy-candyshop.log 2>/dev/null" || true
+            RESULT=$(ssh ${{ secrets.PROD_SERVER_HOST }} \
+              "cat /tmp/deploy-candyshop.done 2>/dev/null || echo pending" || echo pending)
+            if [ "$RESULT" != "pending" ]; then
+              echo "Deploy finished with exit code: $RESULT"
+              [ "$RESULT" = "0" ] && exit 0 || exit 1
+            fi
+          done
+          echo "Timed out after 25 minutes waiting for deployment"
+          exit 1
 
       - name: Verify deployment
         run: |
           ssh ${{ secrets.PROD_SERVER_HOST }} \
-            'docker ps --filter name=candyshop-prod --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"'
+            'pm2 list --no-color 2>/dev/null || true'
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
## Summary

- Replace the long-lived SSH connection (dropped by Cloudflare Access proxy mid-build) with two steps: fire-and-forget start via `nohup`/`disown`, then a 30s polling loop using short-lived SSH calls to read `/tmp/deploy-candyshop.done`
- Fix `Verify deployment` step which was checking `docker ps` — server uses PM2, not Docker

## Root cause

The Cloudflare Access WebSocket proxy drops idle TCP connections before the 4-minute build finishes. The previous `tail -f` approach kept the SSH session alive, but when the proxy dropped it, the GHA step exited 255 (SSH disconnect) before the done file was written — causing a false failure even though the deploy continued on-server.

## Related

Addresses failure in release #163