### PR TITLE
fix(watcher): prevent false-positive cloudflared DOWN alerts [GH-166]

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -9,6 +9,8 @@ on:
       - "packages/**"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "docker/**"
+      - "scripts/**"
   workflow_dispatch:
 
 concurrency:

--- a/docker/watcher.mjs
+++ b/docker/watcher.mjs
@@ -40,6 +40,10 @@ const TELEGRAM_TOKEN  = process.env.TELEGRAM_BOT_TOKEN  ?? "";
 const TELEGRAM_CHAT   = process.env.TELEGRAM_CHAT_ID    ?? "";
 const TELEGRAM_THREAD = process.env.TELEGRAM_THREAD_ID  ?? "";
 
+// Consecutive tunnel-detection failures required before alerting (avoids
+// false positives when pgrep can't see a Docker/systemd-managed process on first check)
+let tunnelFailStreak = 0;
+
 // Internal ports — watcher talks directly to each Node.js process,
 // bypassing nginx so we catch per-app failures accurately.
 const APPS = [
@@ -145,15 +149,25 @@ function readDiskUsedPct() {
 }
 
 function isTunnelRunning() {
+  // Method 1: exact process name (native install)
   try {
-    const result = spawnSync("pgrep", ["-x", "cloudflared"], {
-      encoding: "utf8",
-      timeout: 3_000,
-    });
-    return result.status === 0;
-  } catch {
-    return null; // unknown
-  }
+    const r = spawnSync("pgrep", ["-x", "cloudflared"], { encoding: "utf8", timeout: 3_000 });
+    if (r.status === 0) return true;
+  } catch { /* ignore */ }
+
+  // Method 2: full command-line match (handles systemd ExecStart paths, wrappers)
+  try {
+    const r = spawnSync("pgrep", ["-f", "cloudflared tunnel"], { encoding: "utf8", timeout: 3_000 });
+    if (r.status === 0) return true;
+  } catch { /* ignore */ }
+
+  // Method 3: systemd service
+  try {
+    const r = spawnSync("systemctl", ["is-active", "--quiet", "cloudflared"], { encoding: "utf8", timeout: 3_000 });
+    if (r.status === 0) return true;
+  } catch { /* ignore */ }
+
+  return false;
 }
 
 async function checkSystem() {
@@ -210,21 +224,31 @@ async function checkSystem() {
   const tunnelUp = isTunnelRunning();
   if (tunnelUp !== null) {
     const prev = sysState.tunnel;
-    const next = tunnelUp ? "ok" : "critical";
 
-    if (next === "critical") {
-      const msg = `🔴 <b>Cloudflare tunnel is DOWN</b>\n<code>cloudflared</code> process not found — SSH access and public routing may be unavailable`;
-      await maybeAlert("tunnel", prev !== "critical", msg);
-      console.error("[watcher] Cloudflare tunnel: DOWN");
-    } else if (prev === "critical") {
-      await sendTelegram(`✅ <b>Cloudflare tunnel recovered</b>\n<code>cloudflared</code> is running again`);
-      console.log("[watcher] Cloudflare tunnel: recovered");
-    } else if (prev === "unknown") {
-      console.log("[watcher] Cloudflare tunnel: ok");
+    if (!tunnelUp) {
+      tunnelFailStreak++;
+      // Require 2 consecutive failures before marking as critical / alerting.
+      // This prevents false positives on the first check after a watcher restart
+      // when pgrep transiently can't see the process.
+      if (tunnelFailStreak >= 2) {
+        sysState.tunnel = "critical";
+        const msg = `🔴 <b>Cloudflare tunnel is DOWN</b>\n<code>cloudflared</code> process not found — SSH access and public routing may be unavailable`;
+        await maybeAlert("tunnel", prev !== "critical", msg);
+        console.error("[watcher] Cloudflare tunnel: DOWN");
+      } else {
+        console.warn(`[watcher] Cloudflare tunnel: detection failed (${tunnelFailStreak}/2 — not alerting yet)`);
+      }
     } else {
-      console.log("[watcher] Cloudflare tunnel: ok");
+      const wasDown = prev === "critical";
+      tunnelFailStreak = 0;
+      sysState.tunnel = "ok";
+      if (wasDown) {
+        await sendTelegram(`✅ <b>Cloudflare tunnel recovered</b>\n<code>cloudflared</code> is running again`);
+        console.log("[watcher] Cloudflare tunnel: recovered");
+      } else {
+        console.log("[watcher] Cloudflare tunnel: ok");
+      }
     }
-    sysState.tunnel = next;
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixes false-positive 🔴 Cloudflare tunnel DOWN alerts that fire every time the watcher restarts after a deploy
- Adds `docker/**` and `scripts/**` to deploy trigger paths so this and future watcher changes auto-trigger production deploy

## Root cause

`isTunnelRunning()` used only `pgrep -x cloudflared` (exact name match). If cloudflared runs as a systemd service, the name may not match. Combined with `sysState.tunnel = 'unknown'` on cold start, any negative result on the **first check** immediately fired an alert.

## Changes

**`docker/watcher.mjs`**
- 3-method detection: `pgrep -x`, `pgrep -f 'cloudflared tunnel'`, `systemctl is-active cloudflared`
- Two-strike rule: requires 2 consecutive failures before marking DOWN and alerting

**`.github/workflows/deploy-production.yml`**
- Added `docker/**` and `scripts/**` to `paths:` trigger so watcher/deploy-script changes cause a production deploy

## Test plan
- [ ] After next deploy, watcher should log "detection failed (1/2)" on first check without alerting
- [ ] If cloudflared is genuinely down, second consecutive check fires the alert
- [ ] If cloudflared recovers between checks, `tunnelFailStreak` resets to 0, no alert

Closes #166