### PR TITLE
fix(deploy): route failure alerts to Telegram critical channel [GH-174]

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -130,6 +130,7 @@ jobs:
           TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID=${{ secrets.TELEGRAM_CHAT_ID }}
           TELEGRAM_THREAD_ID=${{ secrets.TELEGRAM_THREAD_ID }}
+          TELEGRAM_CRITICAL_THREAD_ID=${{ secrets.TELEGRAM_CRITICAL_THREAD_ID }}
           ENVEOF'
 
       - name: Copy deploy script to server

--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -50,6 +50,7 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           TELEGRAM_THREAD_ID: ${{ secrets.TELEGRAM_THREAD_ID }}
+          TELEGRAM_CRITICAL_THREAD_ID: ${{ secrets.TELEGRAM_CRITICAL_THREAD_ID }}
         shell: bash
         run: |
           # Validate required secrets are present
@@ -122,6 +123,7 @@ jobs:
             echo "TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}"
             echo "TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}"
             echo "TELEGRAM_THREAD_ID=${TELEGRAM_THREAD_ID}"
+            echo "TELEGRAM_CRITICAL_THREAD_ID=${TELEGRAM_CRITICAL_THREAD_ID}"
           } > secrets-plain.txt
 
       - name: Encrypt secrets file

--- a/docker/watcher.mjs
+++ b/docker/watcher.mjs
@@ -36,9 +36,10 @@ const RAM_WARN_MB     = 400;
 const DISK_CRITICAL_PCT = 90;
 const DISK_WARN_PCT     = 80;
 
-const TELEGRAM_TOKEN  = process.env.TELEGRAM_BOT_TOKEN  ?? "";
-const TELEGRAM_CHAT   = process.env.TELEGRAM_CHAT_ID    ?? "";
-const TELEGRAM_THREAD = process.env.TELEGRAM_THREAD_ID  ?? "";
+const TELEGRAM_TOKEN           = process.env.TELEGRAM_BOT_TOKEN          ?? "";
+const TELEGRAM_CHAT            = process.env.TELEGRAM_CHAT_ID             ?? "";
+const TELEGRAM_THREAD          = process.env.TELEGRAM_THREAD_ID           ?? "";
+const TELEGRAM_CRITICAL_THREAD = process.env.TELEGRAM_CRITICAL_THREAD_ID ?? TELEGRAM_THREAD;
 
 // Consecutive tunnel-detection failures required before alerting (avoids
 // false positives when pgrep can't see a Docker/systemd-managed process on first check)
@@ -69,7 +70,7 @@ const lastAlerted = new Map();
 
 // ── Telegram ──────────────────────────────────────────────────────────────────
 
-async function sendTelegram(text) {
+async function sendTelegramTo(text, threadId) {
   if (!TELEGRAM_TOKEN || !TELEGRAM_CHAT) return;
   try {
     const res = await fetch(
@@ -81,7 +82,7 @@ async function sendTelegram(text) {
           chat_id: TELEGRAM_CHAT,
           text,
           parse_mode: "HTML",
-          ...(TELEGRAM_THREAD ? { message_thread_id: Number(TELEGRAM_THREAD) } : {}),
+          ...(threadId ? { message_thread_id: Number(threadId) } : {}),
         }),
         signal: AbortSignal.timeout(10_000),
       },
@@ -95,6 +96,16 @@ async function sendTelegram(text) {
   }
 }
 
+// Regular channel — deploy steps, recoveries, info
+async function sendTelegram(text) {
+  return sendTelegramTo(text, TELEGRAM_THREAD || null);
+}
+
+// Critical channel — DOWN alerts, resource warnings, failures
+async function sendTelegramCritical(text) {
+  return sendTelegramTo(text, TELEGRAM_CRITICAL_THREAD || TELEGRAM_THREAD || null);
+}
+
 /**
  * Alert on transition OR repeat a persistent alert after the cooldown window.
  * @param {string} key    — unique identifier for the alert category
@@ -105,14 +116,14 @@ async function maybeAlert(key, isNew, text) {
   const now = Date.now();
   if (isNew) {
     lastAlerted.set(key, now);
-    await sendTelegram(text);
+    await sendTelegramCritical(text);
     return;
   }
   // Persistent problem — re-alert only after cooldown
   const last = lastAlerted.get(key) ?? 0;
   if (now - last >= REPEAT_ALERT_MS) {
     lastAlerted.set(key, now);
-    await sendTelegram(text);
+    await sendTelegramCritical(text);
   }
 }
 
@@ -275,7 +286,7 @@ async function ping(app) {
 
     if (prev === "up") {
       console.error(`[watcher] ${app.name}: ✗ DOWN — ${err.message}`);
-      await sendTelegram(
+      await sendTelegramCritical(
         `🔴 <b>${app.name}</b> is not responding\n<code>${err.message}</code>`,
       );
     } else if (prev === "unknown") {

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -50,7 +50,8 @@ if [ -f "$_tg_env" ]; then
   TELEGRAM_THREAD_ID="${TELEGRAM_THREAD_ID:-$(grep '^TELEGRAM_THREAD_ID=' "$_tg_env" | cut -d= -f2- 2>/dev/null || true)}"
 fi
 
-notify_telegram() {
+_telegram_send() {
+  local thread_id="$1" text="$2"
   [ -n "${TELEGRAM_BOT_TOKEN:-}" ] || return 0
   [ -n "${TELEGRAM_CHAT_ID:-}" ] || return 0
   command -v python3 >/dev/null 2>&1 || return 0
@@ -60,11 +61,21 @@ import json, sys
 d = {'chat_id': sys.argv[1], 'text': sys.argv[2], 'parse_mode': 'HTML'}
 if sys.argv[3]:
     d['message_thread_id'] = int(sys.argv[3])
-print(json.dumps(d))" "$TELEGRAM_CHAT_ID" "$1" "${TELEGRAM_THREAD_ID:-}") || return 0
+print(json.dumps(d))" "$TELEGRAM_CHAT_ID" "$text" "$thread_id") || return 0
   curl -sf --max-time 10 -X POST \
     "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
     -H 'Content-Type: application/json' \
     -d "$payload" >/dev/null 2>&1 || true
+}
+
+# Regular channel — deploy steps, recoveries
+notify_telegram() {
+  _telegram_send "${TELEGRAM_THREAD_ID:-}" "$1"
+}
+
+# Critical channel — failures, health warnings, warm-up errors
+notify_telegram_critical() {
+  _telegram_send "${TELEGRAM_CRITICAL_THREAD_ID:-${TELEGRAM_THREAD_ID:-}}" "$1"
 }
 
 # Returns human-readable duration from a start timestamp: "2m 14s" or "38s"
@@ -89,7 +100,7 @@ _on_exit() {
     notify_telegram "$(printf '✅ <b>Deploy complete</b>\nBranch: <code>%s</code>\nCommit: <code>%s</code>\nTotal: %s' \
       "$BRANCH" "$commit" "$dur")"
   else
-    notify_telegram "$(printf '❌ <b>Deploy FAILED</b> (exit %s)\nBranch: <code>%s</code>\nCommit: <code>%s</code>\nTotal: %s' \
+    notify_telegram_critical "$(printf '❌ <b>Deploy FAILED</b> (exit %s)\nBranch: <code>%s</code>\nCommit: <code>%s</code>\nTotal: %s' \
       "$code" "$BRANCH" "$commit" "$dur")"
   fi
 }
@@ -343,7 +354,7 @@ for APP_ENTRY in "${APPS[@]}"; do
 done
 
 if [ "$FAILED" -gt 0 ]; then
-  notify_telegram "$(printf '⚠️ <b>Health check: %d/%d apps not responding</b>\nDeploy complete with warnings.\n<i>Check: pm2 logs</i>' "$FAILED" "${#APPS[@]}")"
+  notify_telegram_critical "$(printf '⚠️ <b>Health check: %d/%d apps not responding</b>\nDeploy complete with warnings.\n<i>Check: pm2 logs</i>' "$FAILED" "${#APPS[@]}")"
   warn "$FAILED app(s) not responding. Skipping warm-up."
   log "Deployment complete (with warnings)."
   exit 0
@@ -401,7 +412,7 @@ rm -f "$_WARM_FAIL_LOG"
 if [ -n "$_failed_urls" ]; then
   _fail_count=$(echo "$_failed_urls" | wc -l | tr -d ' ')
   _fail_list=$(echo "$_failed_urls" | sed 's|http://localhost:[0-9]*/||' | tr '\n' ' ' | sed 's/ $//')
-  notify_telegram "$(printf '⚠️ <b>JIT warm-up incomplete</b> (%s)\n%s route(s) failed after 3 attempts:\n<code>%s</code>\nFirst visit to these routes may be slow.' "$_warm_dur" "$_fail_count" "$_fail_list")"
+  notify_telegram_critical "$(printf '⚠️ <b>JIT warm-up incomplete</b> (%s)\n%s route(s) failed after 3 attempts:\n<code>%s</code>\nFirst visit to these routes may be slow.' "$_warm_dur" "$_fail_count" "$_fail_list")"
   warn "Warm-up incomplete — $_fail_count route(s) unreachable: $_fail_list"
 else
   log "Warm-up complete — all routes pre-compiled."


### PR DESCRIPTION
## Summary

- Failure/critical notifications (DOWN alerts, health-check failures, JIT warm-up errors, RAM/disk/tunnel warnings) now route to **thread 2** ("Critical Notifications") via `TELEGRAM_CRITICAL_THREAD_ID`
- Step-by-step deploy progress and recovery messages continue going to the regular deploy channel (**thread 6**)
- Added `TELEGRAM_CRITICAL_THREAD_ID` to `deploy-production.yml` env file and `sync-secrets.yml`

## Changes

- **`scripts/deploy-production.sh`**: refactored `notify_telegram()` into `_telegram_send(thread_id, text)` base + `notify_telegram` (regular) / `notify_telegram_critical` (critical) wrappers; health-check failure, warm-up failure, and deploy failure notifications use critical channel
- **`docker/watcher.mjs`**: added `sendTelegramCritical()` targeting `TELEGRAM_CRITICAL_THREAD_ID`; DOWN/RAM/disk/tunnel alerts use it; recovery messages stay on regular channel
- **`.github/workflows/deploy-production.yml`**: passes `TELEGRAM_CRITICAL_THREAD_ID` secret to server env file
- **`.github/workflows/sync-secrets.yml`**: includes `TELEGRAM_CRITICAL_THREAD_ID` in secret sync