### PR TITLE
feat(feedback): add Tally feedback widget as shared component [GH-176]

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -50,6 +50,9 @@ SUPABASE_AUTH_SITE_URL=http://localhost:5000/auth/callback
 # --- Build flags ---------------------------------------------------------------
 NEXT_PUBLIC_ENABLE_TEST_IDS=true
 NEXT_PUBLIC_BUILD_HASH=local
+
+# --- Tally feedback widget -----------------------------------------------------
+NEXT_PUBLIC_TALLY_FORM_ID=$secret:TALLY_FORM_ID
 ENV_DEBUG=true
 
 # --- Cloudflare tunnels --------------------------------------------------------

--- a/.env.prod
+++ b/.env.prod
@@ -48,6 +48,9 @@ SUPABASE_AUTH_SITE_URL=https://store.furrycolombia.com/auth/callback
 # ─── Build flags ──────────────────────────────────────────────────
 NEXT_PUBLIC_ENABLE_TEST_IDS=false
 NEXT_PUBLIC_BUILD_HASH=prod
+
+# ─── Tally feedback widget ────────────────────────────────────────
+NEXT_PUBLIC_TALLY_FORM_ID=$secret:TALLY_FORM_ID
 ENV_DEBUG=false
 
 # ─── Cloudflare tunnels ───────────────────────────────────────────

--- a/.env.staging
+++ b/.env.staging
@@ -48,6 +48,9 @@ SUPABASE_AUTH_SITE_URL=https://store.ffxivbe.org/auth/callback
 # ─── Build flags ──────────────────────────────────────────────────
 NEXT_PUBLIC_ENABLE_TEST_IDS=true
 NEXT_PUBLIC_BUILD_HASH=staging
+
+# ─── Tally feedback widget ────────────────────────────────────────
+NEXT_PUBLIC_TALLY_FORM_ID=$secret:TALLY_FORM_ID
 ENV_DEBUG=true
 
 # ─── Cloudflare tunnels ───────────────────────────────────────────

--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -51,6 +51,7 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           TELEGRAM_THREAD_ID: ${{ secrets.TELEGRAM_THREAD_ID }}
           TELEGRAM_CRITICAL_THREAD_ID: ${{ secrets.TELEGRAM_CRITICAL_THREAD_ID }}
+          TALLY_FORM_ID: ${{ secrets.TALLY_FORM_ID }}
         shell: bash
         run: |
           # Validate required secrets are present
@@ -124,6 +125,9 @@ jobs:
             echo "TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}"
             echo "TELEGRAM_THREAD_ID=${TELEGRAM_THREAD_ID}"
             echo "TELEGRAM_CRITICAL_THREAD_ID=${TELEGRAM_CRITICAL_THREAD_ID}"
+            echo ""
+            echo "# ─── Tally feedback widget ───────────────────────────────────────"
+            echo "TALLY_FORM_ID=${TALLY_FORM_ID}"
           } > secrets-plain.txt
 
       - name: Encrypt secrets file

--- a/apps/admin/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/admin/src/shared/infrastructure/i18n/messages/en.json
@@ -446,6 +446,7 @@
     },
     "language": {
       "select": "Select language"
-    }
+    },
+    "feedback": "Feedback"
   }
 }

--- a/apps/admin/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/admin/src/shared/infrastructure/i18n/messages/es.json
@@ -448,6 +448,7 @@
     },
     "language": {
       "select": "Seleccionar idioma"
-    }
+    },
+    "feedback": "Comentarios"
   }
 }

--- a/apps/auth/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/auth/src/shared/infrastructure/i18n/messages/en.json
@@ -66,6 +66,7 @@
     },
     "language": {
       "select": "Select language"
-    }
+    },
+    "feedback": "Feedback"
   }
 }

--- a/apps/auth/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/auth/src/shared/infrastructure/i18n/messages/es.json
@@ -66,6 +66,7 @@
     },
     "language": {
       "select": "Seleccionar idioma"
-    }
+    },
+    "feedback": "Comentarios"
   }
 }

--- a/apps/landing/next.config.ts
+++ b/apps/landing/next.config.ts
@@ -43,7 +43,7 @@ const securityHeaders = [
   },
   {
     key: "Content-Security-Policy",
-    value: `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src ${cspConnectSrc} https://cloudflareinsights.com; frame-ancestors 'none'; object-src 'none';`,
+    value: `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com https://tally.so; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src ${cspConnectSrc} https://cloudflareinsights.com https://*.tally.so; frame-src https://tally.so; frame-ancestors 'none'; object-src 'none';`,
   },
 ];
 

--- a/apps/landing/src/app/[locale]/layout.tsx
+++ b/apps/landing/src/app/[locale]/layout.tsx
@@ -1,3 +1,4 @@
+import { TallyFeedbackButton } from "@monorepo/app-components";
 import { getServerUserEmail } from "api/supabase/server";
 import type { Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
@@ -56,6 +57,7 @@ export default async function LocaleLayout({
             userEmail={userEmail}
           />
           {children}
+          <TallyFeedbackButton />
         </Providers>
       </NextIntlClientProvider>
     </ThemeProvider>

--- a/apps/landing/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/landing/src/shared/infrastructure/i18n/messages/en.json
@@ -68,6 +68,7 @@
     },
     "language": {
       "select": "Select language"
-    }
+    },
+    "feedback": "Feedback"
   }
 }

--- a/apps/landing/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/landing/src/shared/infrastructure/i18n/messages/es.json
@@ -68,6 +68,7 @@
     },
     "language": {
       "select": "Seleccionar idioma"
-    }
+    },
+    "feedback": "Comentarios"
   }
 }

--- a/apps/payments/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/payments/src/shared/infrastructure/i18n/messages/en.json
@@ -308,6 +308,7 @@
     },
     "language": {
       "select": "Select language"
-    }
+    },
+    "feedback": "Feedback"
   }
 }

--- a/apps/payments/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/payments/src/shared/infrastructure/i18n/messages/es.json
@@ -308,6 +308,7 @@
     },
     "language": {
       "select": "Seleccionar idioma"
-    }
+    },
+    "feedback": "Comentarios"
   }
 }

--- a/apps/playground/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/playground/src/shared/infrastructure/i18n/messages/en.json
@@ -27,6 +27,7 @@
     },
     "language": {
       "select": "Select language"
-    }
+    },
+    "feedback": "Feedback"
   }
 }

--- a/apps/playground/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/playground/src/shared/infrastructure/i18n/messages/es.json
@@ -27,6 +27,7 @@
     },
     "language": {
       "select": "Seleccionar idioma"
-    }
+    },
+    "feedback": "Comentarios"
   }
 }

--- a/apps/store/next.config.ts
+++ b/apps/store/next.config.ts
@@ -43,7 +43,7 @@ const securityHeaders = [
   },
   {
     key: "Content-Security-Policy",
-    value: `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src ${cspConnectSrc} https://cloudflareinsights.com; frame-ancestors 'none'; object-src 'none';`,
+    value: `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com https://tally.so; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src ${cspConnectSrc} https://cloudflareinsights.com https://*.tally.so; frame-src https://tally.so; frame-ancestors 'none'; object-src 'none';`,
   },
 ];
 

--- a/apps/store/src/app/[locale]/layout.tsx
+++ b/apps/store/src/app/[locale]/layout.tsx
@@ -1,3 +1,4 @@
+import { TallyFeedbackButton } from "@monorepo/app-components";
 import { getServerUserEmail } from "api/supabase/server";
 import type { Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
@@ -63,6 +64,7 @@ export default async function LocaleLayout({
             </ProtectedRoute>
             <CartDrawer />
           </div>
+          <TallyFeedbackButton />
         </Providers>
       </NextIntlClientProvider>
     </ThemeProvider>

--- a/apps/store/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/store/src/shared/infrastructure/i18n/messages/en.json
@@ -36,7 +36,8 @@
     },
     "language": {
       "select": "Select language"
-    }
+    },
+    "feedback": "Feedback"
   },
   "products": {
     "title": "Products",

--- a/apps/store/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/store/src/shared/infrastructure/i18n/messages/es.json
@@ -36,7 +36,8 @@
     },
     "language": {
       "select": "Seleccionar idioma"
-    }
+    },
+    "feedback": "Comentarios"
   },
   "products": {
     "title": "Productos",

--- a/apps/studio/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/studio/src/shared/infrastructure/i18n/messages/en.json
@@ -49,7 +49,8 @@
     },
     "language": {
       "select": "Select language"
-    }
+    },
+    "feedback": "Feedback"
   },
   "products": {
     "title": "Products",

--- a/apps/studio/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/studio/src/shared/infrastructure/i18n/messages/es.json
@@ -49,7 +49,8 @@
     },
     "language": {
       "select": "Seleccionar idioma"
-    }
+    },
+    "feedback": "Comentarios"
   },
   "products": {
     "title": "Productos",

--- a/packages/app-components/src/components/TallyFeedbackButton.tsx
+++ b/packages/app-components/src/components/TallyFeedbackButton.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { MessageCircle } from "lucide-react";
+import Script from "next/script";
+import { useTranslations } from "next-intl";
+import { getRuntimeEnv } from "shared/config/environment";
+
+export function TallyFeedbackButton() {
+  const formId = getRuntimeEnv().tallyFormId;
+  const t = useTranslations("common");
+
+  if (!formId) return null;
+
+  return (
+    <>
+      <Script
+        src="https://tally.so/widgets/embed.js"
+        strategy="afterInteractive"
+      />
+      <button
+        type="button"
+        data-tally-open={formId}
+        data-tally-layout="modal"
+        data-tally-align-left="1"
+        aria-label={t("feedback")}
+        className="fixed bottom-6 left-6 z-50 flex size-12 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-opacity hover:opacity-90"
+      >
+        <MessageCircle className="size-5" />
+      </button>
+    </>
+  );
+}

--- a/packages/app-components/src/components/index.ts
+++ b/packages/app-components/src/components/index.ts
@@ -10,3 +10,4 @@ export { LoadingState } from "./LoadingState";
 export { ErrorState } from "./ErrorState";
 export { EmptyState } from "./EmptyState";
 export { ExportDropdown, type ExportDropdownProps } from "./ExportDropdown";
+export { TallyFeedbackButton } from "./TallyFeedbackButton";

--- a/packages/shared/src/config/environment.ts
+++ b/packages/shared/src/config/environment.ts
@@ -24,6 +24,7 @@ type RuntimeEnv = {
   buildHash: string;
   landingUrl: string;
   authHostUrl: string;
+  tallyFormId: string;
 };
 
 function readRuntimeEnv() {
@@ -40,6 +41,7 @@ function readRuntimeEnv() {
     buildHash: process.env.NEXT_PUBLIC_BUILD_HASH ?? "dev",
     landingUrl: DEFAULT_LANDING_URL,
     authHostUrl: DEFAULT_AUTH_HOST_URL,
+    tallyFormId: process.env.NEXT_PUBLIC_TALLY_FORM_ID ?? "",
   } as RuntimeEnv;
 }
 


### PR DESCRIPTION
## Summary

- Adds a shared `TallyFeedbackButton` component in `packages/app-components`, used in landing and store layouts
- Wires `TALLY_FORM_ID` secret through `sync-secrets.yml` and exposes it as `NEXT_PUBLIC_TALLY_FORM_ID` via `getRuntimeEnv().tallyFormId`
- Adds `feedback` i18n key to all 7 apps (en + es)
- Fixes CSP headers in landing and store to allow Tally scripts, frames, and API calls

## Related Issue

Closes #176

## Changes

- `packages/app-components/src/components/TallyFeedbackButton.tsx` — new shared component with `MessageCircle` icon, bottom-left position, `afterInteractive` script strategy
- `packages/shared/src/config/environment.ts` — adds `tallyFormId` to `RuntimeEnv` type
- `.env.dev` / `.env.prod` / `.env.staging` — `NEXT_PUBLIC_TALLY_FORM_ID=$secret:TALLY_FORM_ID`
- `.github/workflows/sync-secrets.yml` — registers `TALLY_FORM_ID` in env + write blocks
- `apps/landing/next.config.ts` + `apps/store/next.config.ts` — CSP: adds `https://tally.so` to `script-src`, `frame-src`, and `connect-src`
- All 14 locale files — adds `"feedback": "Feedback"` (en) / `"feedback": "Comentarios"` (es)

## Testing

1. Start dev servers: `pnpm dev`
2. Open store (`localhost:5001`) or landing (`localhost:5004`)
3. Click the chat-bubble button in the bottom-left corner — Tally modal should open
4. Verify no CSP errors in the browser console

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)