### PR TITLE
chore(release): v2026.04.24.1

### DIFF
--- a/apps/payments/src/features/checkout/infrastructure/receiptStorage.test.ts
+++ b/apps/payments/src/features/checkout/infrastructure/receiptStorage.test.ts
@@ -1,4 +1,14 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { signReceiptUrlMock } = vi.hoisted(() => ({
+  signReceiptUrlMock: vi.fn(async (path: string) =>
+    path ? `https://example.com/signed/${path}` : null,
+  ),
+}));
+
+vi.mock("@/shared/infrastructure/receiptSignAction", () => ({
+  signReceiptUrl: signReceiptUrlMock,
+}));
 
 import { deleteReceipt, getReceiptUrl, uploadReceipt } from "./receiptStorage";
 
@@ -89,59 +99,30 @@ describe("deleteReceipt", () => {
 });
 
 describe("getReceiptUrl", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    vi.unstubAllEnvs();
+  beforeEach(() => {
+    signReceiptUrlMock.mockClear();
   });
 
-  it("returns null when no storage path is provided", async () => {
+  it("returns null without calling the server action when no path is given", async () => {
     await expect(getReceiptUrl(null)).resolves.toBeNull();
+    expect(signReceiptUrlMock).not.toHaveBeenCalled();
   });
 
-  it("returns null when service role env vars are not configured", async () => {
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.example.com");
-    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "");
+  it("delegates to signReceiptUrl and returns the signed url", async () => {
+    const url = await getReceiptUrl("order-123/receipt.png");
+    expect(signReceiptUrlMock).toHaveBeenCalledWith("order-123/receipt.png");
+    expect(url).toBe("https://example.com/signed/order-123/receipt.png");
+  });
+
+  it("propagates null from signReceiptUrl when signing fails", async () => {
+    signReceiptUrlMock.mockResolvedValueOnce(null);
     await expect(getReceiptUrl("order-123/receipt.png")).resolves.toBeNull();
   });
 
-  it("returns a signed url for valid storage paths", async () => {
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.example.com");
-    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service_key_test");
-
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          signedURL:
-            "/storage/v1/object/sign/receipts/order-123/receipt.png?token=abc",
-        }),
-      }),
+  it("returns null when signReceiptUrl throws (e.g. Server Action proxy error)", async () => {
+    signReceiptUrlMock.mockRejectedValueOnce(
+      new Error("Server Action proxy error"),
     );
-
-    await expect(getReceiptUrl("order-123/receipt.png")).resolves.toBe(
-      "https://supabase.example.com/storage/v1/object/sign/receipts/order-123/receipt.png?token=abc",
-    );
-  });
-
-  it("returns null when the storage API responds with an error", async () => {
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.example.com");
-    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service_key_test");
-
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
-
-    await expect(getReceiptUrl("order-123/receipt.png")).resolves.toBeNull();
-  });
-
-  it("returns null when the fetch call throws", async () => {
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.example.com");
-    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service_key_test");
-
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockRejectedValue(new Error("Network error")),
-    );
-
     await expect(getReceiptUrl("order-123/receipt.png")).resolves.toBeNull();
   });
 });

--- a/apps/payments/src/shared/infrastructure/receiptSignAction.test.ts
+++ b/apps/payments/src/shared/infrastructure/receiptSignAction.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { signReceiptUrl } from "./receiptSignAction";
+
+describe("signReceiptUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("returns null when the storage API responds with an error status", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.example.com");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service_key_test");
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+
+    await expect(signReceiptUrl("order-123/receipt.png")).resolves.toBeNull();
+  });
+
+  it("returns null when the fetch call throws", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.example.com");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service_key_test");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("Network error")),
+    );
+
+    await expect(signReceiptUrl("order-123/receipt.png")).resolves.toBeNull();
+  });
+
+  it("returns null when service role env vars are not configured", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.example.com");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "");
+
+    await expect(signReceiptUrl("order-123/receipt.png")).resolves.toBeNull();
+  });
+
+  it("returns a fully-qualified signed url for valid storage paths", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.example.com");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service_key_test");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          signedURL:
+            "/storage/v1/object/sign/receipts/order-123/receipt.png?token=abc",
+        }),
+      }),
+    );
+
+    await expect(signReceiptUrl("order-123/receipt.png")).resolves.toBe(
+      "https://supabase.example.com/storage/v1/object/sign/receipts/order-123/receipt.png?token=abc",
+    );
+  });
+
+  it("normalises signedURL from local Supabase CLI (missing /storage/v1 prefix)", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.example.com");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service_key_test");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          // Local Supabase CLI omits /storage/v1 in the returned path
+          signedURL: "/object/sign/receipts/order-123/receipt.png?token=abc",
+        }),
+      }),
+    );
+
+    await expect(signReceiptUrl("order-123/receipt.png")).resolves.toBe(
+      "https://supabase.example.com/storage/v1/object/sign/receipts/order-123/receipt.png?token=abc",
+    );
+  });
+
+  it("returns null when the API response has no signedURL field", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.example.com");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service_key_test");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      }),
+    );
+
+    await expect(signReceiptUrl("order-123/receipt.png")).resolves.toBeNull();
+  });
+
+  it("uses SUPABASE_URL_INTERNAL as the fetch target when set", async () => {
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- internal Docker hostname, not a real plaintext connection
+    const internalUrl = "http://internal-host:5432";
+    vi.stubEnv("SUPABASE_URL_INTERNAL", internalUrl);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.example.com");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service_key_test");
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        signedURL:
+          "/storage/v1/object/sign/receipts/order-123/receipt.png?token=xyz",
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await signReceiptUrl("order-123/receipt.png");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining(internalUrl),
+      expect.any(Object),
+    );
+  });
+});

--- a/apps/payments/src/shared/infrastructure/receiptSignAction.ts
+++ b/apps/payments/src/shared/infrastructure/receiptSignAction.ts
@@ -1,0 +1,55 @@
+"use server";
+
+/* eslint-disable i18next/no-literal-string -- infrastructure file: Supabase storage paths and API keys */
+import {
+  RECEIPTS_BUCKET,
+  RECEIPT_URL_TTL_SECONDS,
+} from "@/shared/domain/constants";
+
+/**
+ * Generate a signed receipt URL on the server using the service role key.
+ * Running server-side guarantees access to SUPABASE_SERVICE_ROLE_KEY and
+ * bypasses RLS, so both owning sellers and their delegates can fetch the URL.
+ * Authorization is enforced upstream at the orders query layer.
+ */
+export async function signReceiptUrl(
+  storagePath: string,
+): Promise<string | null> {
+  const internalUrl =
+    process.env.SUPABASE_URL_INTERNAL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const publicUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!internalUrl || !publicUrl || !serviceKey) return null;
+
+  try {
+    const response = await fetch(
+      `${internalUrl}/storage/v1/object/sign/${RECEIPTS_BUCKET}/${storagePath}`,
+      {
+        method: "POST",
+        headers: {
+          apikey: serviceKey,
+          Authorization: `Bearer ${serviceKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ expiresIn: RECEIPT_URL_TTL_SECONDS }),
+        cache: "no-store",
+      },
+    );
+
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as { signedURL?: string };
+    if (!data.signedURL) return null;
+
+    // signedURL is a relative path. Local Supabase CLI omits the /storage/v1
+    // prefix that Supabase Cloud includes — normalise before prepending.
+    const signedPath = data.signedURL.startsWith("/storage/v1")
+      ? data.signedURL
+      : `/storage/v1${data.signedURL}`;
+
+    return `${publicUrl}${signedPath}`;
+  } catch {
+    return null;
+  }
+}

--- a/apps/payments/src/shared/infrastructure/receiptStorage.ts
+++ b/apps/payments/src/shared/infrastructure/receiptStorage.ts
@@ -1,13 +1,10 @@
-/* eslint-disable i18next/no-literal-string -- infrastructure file: Supabase storage paths and API keys */
-import {
-  RECEIPTS_BUCKET,
-  RECEIPT_URL_TTL_SECONDS,
-} from "@/shared/domain/constants";
+import { RECEIPTS_BUCKET } from "@/shared/domain/constants";
 import {
   assertValidReceiptFile,
   buildReceiptStoragePath,
 } from "@/shared/domain/receipt";
 import type { SupabaseClient } from "@/shared/domain/types";
+import { signReceiptUrl } from "@/shared/infrastructure/receiptSignAction";
 
 export async function uploadReceipt(
   supabase: SupabaseClient,
@@ -27,48 +24,16 @@ export async function uploadReceipt(
 }
 
 /**
- * Generate a signed receipt URL using the service role key so that both
- * sellers and delegates can access receipts. RLS is bypassed here because
- * authorization is already enforced at the orders query layer — only callers
- * that already retrieved the order row (and therefore passed orders RLS) can
- * reach this function with a non-null storagePath.
+ * Generate a signed receipt URL. Delegates to a Server Action so the service
+ * role key is never exposed to the browser, regardless of whether the caller
+ * is a Client Component hook or a Server Component.
  */
 export async function getReceiptUrl(
   storagePath: string | null,
 ): Promise<string | null> {
   if (!storagePath) return null;
-
-  // Dynamic key access prevents Turbopack from inlining at build time
-  const internalUrl =
-    process.env["SUPABASE_URL_INTERNAL"] ||
-    process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const publicUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env["SUPABASE_SERVICE_ROLE_KEY"];
-
-  if (!internalUrl || !publicUrl || !serviceKey) return null;
-
   try {
-    const response = await fetch(
-      `${internalUrl}/storage/v1/object/sign/${RECEIPTS_BUCKET}/${storagePath}`,
-      {
-        method: "POST",
-        headers: {
-          apikey: serviceKey,
-          Authorization: `Bearer ${serviceKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ expiresIn: RECEIPT_URL_TTL_SECONDS }),
-        cache: "no-store",
-      },
-    );
-
-    if (!response.ok) return null;
-
-    const data = (await response.json()) as { signedURL?: string };
-    if (!data.signedURL) return null;
-
-    // signedURL is a relative path — prepend the public URL so the browser can reach it
-    return `${publicUrl}${data.signedURL}`;
+    return await signReceiptUrl(storagePath);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Production Release

**Release:** \`v2026.04.24.1\`

---

## Changes Included

- d67105df fix(payments): Server Action receipt signing + signedURL path fix [GH-185] (#189)

---

## Summary

Fixes a critical receipt-signing bug:

1. **Security**: `getReceiptUrl` now delegates to a `"use server"` Server Action so `SUPABASE_SERVICE_ROLE_KEY` never reaches the browser bundle
2. **Staging-parity bug**: Local Supabase CLI omits `/storage/v1` from returned `signedURL` paths — path is now normalised before constructing the signed URL (this was why the bug wasn't caught in staging)

---

## Pre-Release Checklist

- [x] All PRs merged to develop have been reviewed
- [x] Quality checks passed (340 unit tests, all 6 E2E phases)
- [x] QA testing complete (E2E on staging)

---

## Post-Merge Actions

After merging:

1. Monitor deployment
2. Verify production receipt signing works
3. Check error monitoring