### PR TITLE
chore(release): v2026.04.24.3

### DIFF
--- a/.ai-context/task-outputs/GH-188/00-task-overview.md
+++ b/.ai-context/task-outputs/GH-188/00-task-overview.md
@@ -1,0 +1,82 @@
+# Task Overview: GH-188
+
+## Issue Details
+
+| Field        | Value                                                     |
+| ------------ | --------------------------------------------------------- |
+| **Issue**    | #188                                                      |
+| **Title**    | perf(ci): reduce deploy time from 26+ min to under 10 min |
+| **Type**     | feat (enhancement)                                        |
+| **Labels**   | enhancement                                               |
+| **Assignee** | —                                                         |
+| **Created**  | 2026-04-24                                                |
+| **URL**      | https://github.com/furrycolombia-sys/candyshop/issues/188 |
+
+## Description
+
+End-to-end deploy time regularly exceeds **26 minutes** — from merging a PR to the new
+version running in production. The target is under 10 minutes. Root causes are fully
+identified.
+
+## Measured Baseline
+
+| Job                                                    | Duration         |
+| ------------------------------------------------------ | ---------------- |
+| CI (parallel: quality + unit-tests + build + e2e)      | ~279s (~4.6 min) |
+| `deploy-production` → `ci-gate` job                    | ~367s (~6 min)   |
+| `deploy-production` → `deploy` job (server-side build) | up to 25 min     |
+| **Total worst case**                                   | **~31 min**      |
+
+## Root Causes & Fixes (Priority Order)
+
+### 1. Remove `ci-gate` job (saves ~6 min)
+
+`deploy-production.yml` runs a full duplicate of CI (install + typecheck + lint + test + build) after merging to `main`. Since PRs must pass CI before merge, this is pure redundancy.
+**Fix:** Delete the `ci-gate` job entirely.
+
+### 2. Transfer build artifacts to VPS instead of building on server (saves ~25 min)
+
+`deploy-production.sh` runs `pnpm build` on the production VPS — slow on low-resource hardware. The CI `build` job already produces `.next` artifacts.
+**Fix:** `rsync`/`scp` pre-built `.next` artifacts from CI runner to VPS; server only runs `pnpm install --prod` + `pm2 reload`.
+
+### 3. Remove E2E double-build (saves ~60–90s per CI run)
+
+`e2e-tests` job downloads build artifacts then immediately runs another full `pnpm build`.
+**Fix:** Remove the redundant "Rebuild E2E apps locally" step; use downloaded artifacts directly.
+
+### 4. Add `.next` build cache (incremental improvement)
+
+No build cache between CI runs — every run is cold.
+**Fix:** Add `actions/cache@v4` for `.next/cache` keyed on `pnpm-lock.yaml` + source hashes.
+
+### 5. Cache Playwright browsers in `e2e-tests` (saves ~60s)
+
+Chromium downloaded fresh every run. `docker-smoke-tests` already caches it correctly.
+**Fix:** Apply the same Playwright cache pattern to `e2e-tests`.
+
+### 6. Shared pnpm install (lowest priority)
+
+`pnpm install` runs in 5 parallel jobs independently.
+**Fix:** Shared `setup` job or pre-warm pnpm store cache.
+
+## Expected Outcome After Fixes
+
+| Bottleneck         | Before        | After                  |
+| ------------------ | ------------- | ---------------------- |
+| `ci-gate`          | ~6 min        | 0 min (removed)        |
+| Server-side build  | up to 25 min  | ~1 min (rsync)         |
+| E2E double-build   | 2×            | removed                |
+| `.next` cache      | cold          | warm on unchanged deps |
+| Playwright install | ~60s uncached | cached                 |
+| **Total target**   | **26–31 min** | **< 8 min**            |
+
+## Acceptance Criteria
+
+- [ ] Deploy time from PR merge to production is consistently under 10 minutes
+- [ ] `ci-gate` job removed from `deploy-production.yml`
+- [ ] Server-side build eliminated — VPS receives pre-built `.next` artifacts
+- [ ] E2E double-build removed from `ci.yml`
+- [ ] `.next` build cache added to `ci.yml`
+- [ ] Playwright browser cache added to `e2e-tests` job
+- [ ] All existing CI checks still pass
+- [ ] Production deploy still works correctly

--- a/.ai-context/task-outputs/GH-188/01-setup.md
+++ b/.ai-context/task-outputs/GH-188/01-setup.md
@@ -1,0 +1,33 @@
+# Setup: GH-188
+
+## Branch Information
+
+| Field         | Value                            |
+| ------------- | -------------------------------- |
+| **Branch**    | `feat/GH-188_Reduce-Deploy-Time` |
+| **Source**    | `develop`                        |
+| **PR Target** | `develop`                        |
+| **Created**   | 2026-04-24                       |
+
+## Environment
+
+- Node.js: 24
+- Package Manager: pnpm
+- Framework: Next.js (monorepo)
+
+## Quick Links
+
+- [GitHub Issue](https://github.com/furrycolombia-sys/candyshop/issues/188)
+- [ci.yml](.github/workflows/ci.yml)
+- [deploy-production.yml](.github/workflows/deploy-production.yml)
+- [deploy-production.sh](scripts/deploy-production.sh)
+
+## Next Steps
+
+1. Remove `ci-gate` from `deploy-production.yml`
+2. Add build job with prod secrets + artifact upload to `deploy-production.yml`
+3. Add rsync transfer step to `deploy` job
+4. Rewrite `deploy-production.sh` to receive artifacts (skip `pnpm build`)
+5. Remove "Rebuild E2E apps locally" step from `ci.yml`
+6. Add `.next` build cache to `build` job in `ci.yml`
+7. Add Playwright browser cache to `e2e-tests` job in `ci.yml`

--- a/.ai-context/task-outputs/GH-188/02-analysis.md
+++ b/.ai-context/task-outputs/GH-188/02-analysis.md
@@ -1,0 +1,206 @@
+# Analysis: GH-188
+
+## Branch Context
+
+| Field         | Value                            |
+| ------------- | -------------------------------- |
+| **Branch**    | `feat/GH-188_Reduce-Deploy-Time` |
+| **Type**      | `feat` (enhancement)             |
+| **Source**    | `develop`                        |
+| **PR Target** | `develop`                        |
+
+## Relevant Files
+
+| File                                      | Purpose                                                        | Action Needed                          |
+| ----------------------------------------- | -------------------------------------------------------------- | -------------------------------------- |
+| `.github/workflows/deploy-production.yml` | Triggers on push to `main`; contains `ci-gate` + `deploy` jobs | Rewrite                                |
+| `.github/workflows/ci.yml`                | PR CI — quality, unit-tests, build, e2e-tests, bundle-analysis | Fix E2E double-build + add caches      |
+| `scripts/deploy-production.sh`            | Server-side deploy script — currently runs `pnpm build` on VPS | Rewrite to receive pre-built artifacts |
+
+## Deep-Dive: What Each Fix Touches
+
+---
+
+### Fix 1 — Remove `ci-gate` (deploy-production.yml lines 27–74)
+
+The `ci-gate` job runs:
+
+- `pnpm install --frozen-lockfile`
+- `pnpm run typecheck`
+- `pnpm run lint`
+- `pnpm run test`
+- `pnpm run build` (with STANDALONE=true + prod secrets)
+
+Since only `release/*` or `fix/*` PRs can target `main`, and those PRs must pass `ci.yml` before merge, this is pure duplication.
+
+**Also noticed:** `ci-gate` uses Node **20** while `ci.yml` uses Node **24** — a version inconsistency.
+
+**Action:** Delete entire `ci-gate` job. Update `deploy` job's `needs:` to remove the dependency. Update `notify-failure` job's `needs:` and `if:` condition.
+
+---
+
+### Fix 2 — Transfer pre-built artifacts to server (biggest win)
+
+**Current flow:**
+
+```
+deploy-production.yml deploy job
+  → copies deploy-production.sh to server via SSH
+  → server runs: git pull + pnpm install + pnpm build (on slow VPS) + pm2 reload
+```
+
+**New flow:**
+
+```
+deploy-production.yml
+  → new "build" job: install + pnpm build (STANDALONE=true, prod secrets)
+  → new "transfer" step in deploy job: rsync .next/standalone dirs to VPS
+  → server runs: (no build) → pm2 reload (fast)
+```
+
+**Key implementation points:**
+
+1. **SSH + rsync is already plumbed** — the `deploy` job already installs `cloudflared`, sets up SSH keys, and has host/user secrets. Adding an `rsync` step is straightforward.
+
+2. **Standalone builds are self-contained** — `.next/standalone` includes all runtime Node.js deps. Server only needs to:
+   - Receive the standalone dir via rsync
+   - Copy static assets (`apps/<app>/.next/static → standalone/apps/<app>/.next/static`)
+   - Copy public dirs (`apps/<app>/public → standalone/apps/<app>/public`)
+   - `pm2 restart candyshop-<app>` (or `pm2 reload`)
+
+3. **Runtime env vars** — `NEXT_PUBLIC_*` are baked at build time (done in CI). Non-public vars (`SUPABASE_SERVICE_ROLE_KEY`, Telegram tokens) must be passed to PM2 at runtime. Currently the deploy script sources the env file before building — with artifact transfer, we write these to a `.env.production.local` on the server and configure PM2 to read them.
+
+4. **The env file write step** (`Write ephemeral env file on server`) already exists in the deploy job — we just need to ensure PM2 picks up the runtime vars. The simplest way: write the non-NEXT_PUBLIC vars to `.env.production.local` in the standalone dir.
+
+5. **Nginx config and health check** — these remain on the server-side script but are fast (seconds).
+
+**Modified `deploy-production.sh` scope after fix:**
+
+- Remove: `pnpm install`, `pnpm run build`, Turborepo cache clear
+- Keep: PM2 restart, static asset copying, Nginx config, health check, warm-up
+- Add: Acceptance of pre-built artifacts path
+
+---
+
+### Fix 3 — Remove E2E double-build (ci.yml lines 486–532)
+
+The `e2e-tests` job:
+
+1. Downloads build artifacts (store, admin, auth, landing, payments) — lines 451–484
+2. Then immediately runs "Rebuild E2E apps locally" — lines 486–532
+
+The rebuild step is a full `pnpm --filter <APP> build` for each changed app. This defeats the purpose of uploading/downloading artifacts.
+
+**Why does it exist?** Likely added as a workaround when artifact download alone wasn't sufficient (e.g., missing env bake, or `.next/standalone` vs regular `.next` mismatch).
+
+**Action:** Delete the "Rebuild E2E apps locally" step entirely. The `e2e-tests` already runs with `next start` (E2E Playwright config), which reads `.next` directly — the downloaded artifacts are sufficient.
+
+**Risk:** If E2E tests use features that require a fresh build (unlikely), this could break. Verify by checking if downloaded artifacts match what `next start` needs.
+
+---
+
+### Fix 4 — Add `.next` build cache to `build` job (ci.yml)
+
+The `docker-smoke-tests` job already has a Playwright cache pattern (lines 669–678). The `build` job has no cache.
+
+**Cache key pattern (from issue):**
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: apps/*/next/cache
+    key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/**/*.ts', 'apps/**/*.tsx') }}
+    restore-keys: |
+      ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
+      ${{ runner.os }}-nextjs-
+```
+
+**Note:** The correct path for Next.js build cache is `apps/*/.next/cache` (not `apps/*/next/cache` as written in the issue — slight typo).
+
+Place this step immediately after "Install dependencies" in the `build` job.
+
+---
+
+### Fix 5 — Cache Playwright browsers in `e2e-tests` (ci.yml)
+
+The `docker-smoke-tests` job already caches Playwright (lines 669–686):
+
+```yaml
+- name: Get Playwright version
+  id: playwright-version
+  run: echo "version=$(pnpm --filter store list @playwright/test --json | jq -r '.[0].devDependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+
+- name: Cache Playwright browsers
+  uses: actions/cache@v4
+  id: playwright-cache
+  with:
+    path: ~/.cache/ms-playwright
+    key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+- name: Install Playwright browsers
+  if: steps.playwright-cache.outputs.cache-hit != 'true'
+  run: pnpm --filter store exec playwright install --with-deps chromium
+
+- name: Install Playwright dependencies (if cached)
+  if: steps.playwright-cache.outputs.cache-hit == 'true'
+  run: pnpm --filter store exec playwright install-deps
+```
+
+The `e2e-tests` job currently has only:
+
+```yaml
+- name: Install Playwright browsers
+  run: pnpm --filter store exec playwright install --with-deps chromium
+```
+
+**Action:** Replace the single step with the full 4-step pattern from `docker-smoke-tests`.
+
+---
+
+## Requirements Analysis
+
+| Requirement                   | Existing Support                     | Gap/Action                                      |
+| ----------------------------- | ------------------------------------ | ----------------------------------------------- |
+| Remove ci-gate                | Exists (job to delete)               | Delete `ci-gate` job, update dependents         |
+| Build prod artifacts in CI    | ci-gate already does prod build      | Move build to standalone job in deploy workflow |
+| Transfer artifacts to VPS     | SSH already configured               | Add rsync step + rewrite deploy.sh              |
+| Remove E2E double-build       | Rebuild step exists and runs         | Delete "Rebuild E2E apps locally" step          |
+| `.next` build cache           | Not present                          | Add `actions/cache@v4` to build job             |
+| Playwright cache in e2e-tests | Pattern exists in docker-smoke-tests | Copy pattern to e2e-tests job                   |
+
+## Technical Considerations
+
+1. **Standalone output requires `STANDALONE=true` at build time** — the CI build job must set this env var along with all prod `NEXT_PUBLIC_*` secrets.
+
+2. **Runtime-only secrets** (not baked) — `SUPABASE_SERVICE_ROLE_KEY`, Telegram tokens, etc. must reach PM2 processes. Strategy: write them to `.env.production.local` in each app's standalone dir, which Next.js standalone runtime reads automatically.
+
+3. **Artifact size** — `.next/standalone` for 7 apps may be large. Actions artifacts have a 5GB limit per run. Should be fine but worth monitoring.
+
+4. **The `studio` app** — The build job in `ci.yml` does not include `studio` in its upload steps. Need to check if `deploy-production.sh` builds studio and include it.
+
+5. **`notify-failure` job update** — currently `needs: [ci-gate, deploy]`. After removing `ci-gate`, update to `needs: [build, deploy]` (or just `needs: [deploy]`).
+
+6. **`pnpm install` on server** — After artifact transfer, the server may still need `pnpm install --prod` for any server-side scripts that aren't bundled. For pure standalone, this is not needed. The Nginx config and PM2 watcher steps don't require pnpm.
+
+## Implementation Summary
+
+### Files to Modify
+
+- `.github/workflows/deploy-production.yml` — Delete `ci-gate`, add `build` job with standalone prod build + artifact upload, add rsync transfer in `deploy` job
+- `.github/workflows/ci.yml` — Delete "Rebuild E2E apps locally" step, add `.next` cache to `build` job, add Playwright cache to `e2e-tests` job
+- `scripts/deploy-production.sh` — Remove `pnpm install` + `pnpm build` + Turborepo clear; add logic to receive rsync'd artifacts and copy static assets; keep PM2 restart, Nginx, health check, warm-up
+
+### Implementation Order (matches priority in issue)
+
+1. `deploy-production.yml`: Remove `ci-gate` → update `deploy.needs` → update `notify-failure`
+2. `deploy-production.yml`: Add `build` job → add rsync in `deploy` job
+3. `deploy-production.sh`: Rewrite to skip build, receive artifacts, restart PM2
+4. `ci.yml`: Delete "Rebuild E2E apps locally" step
+5. `ci.yml`: Add `.next` build cache to `build` job
+6. `ci.yml`: Add Playwright browser cache to `e2e-tests` job
+
+## Questions/Blockers
+
+- [ ] Does the `studio` app need to be included in the artifact transfer? (It is built in deploy.sh but not in ci.yml artifact uploads — check if studio has E2E tests or just needs the build)
+- [ ] What is the rsync path on the VPS? (`/home/furrycolombia/candyshop` = `DEPLOY_DIR`)
+- [ ] Should PM2 use `reload` (zero-downtime) or `restart` for the new binaries? (Standalone server.js is a new process start, so `pm2 delete + start` as currently done)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,15 @@ jobs:
             pnpm install --no-frozen-lockfile
           }
 
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: apps/*/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/**/*.ts', 'apps/**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-
+
       - name: Build applications (scoped)
         run: |
           set -euo pipefail
@@ -441,8 +450,24 @@ jobs:
             pnpm install --no-frozen-lockfile
           }
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(pnpm --filter store list @playwright/test --json | jq -r '.[0].devDependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm --filter store exec playwright install --with-deps chromium
+
+      - name: Install Playwright dependencies (if cached)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter store exec playwright install-deps chromium
 
       - name: Start Supabase
         run: pnpm supabase start
@@ -482,54 +507,6 @@ jobs:
         with:
           name: build-payments
           path: apps/payments/.next/
-
-      - name: Rebuild E2E apps locally
-        run: |
-          set -euo pipefail
-
-          SELECT_OUTPUT=$(bash scripts/select-workspaces.sh \
-            "${{ needs.changes.outputs.store }}" \
-            "${{ needs.changes.outputs.landing }}" \
-            "${{ needs.changes.outputs.payments }}" \
-            "${{ needs.changes.outputs.admin }}" \
-            "${{ needs.changes.outputs.auth }}" \
-            "${{ needs.changes.outputs.playground }}" \
-            "${{ needs.changes.outputs.packages }}" \
-            "${{ needs.changes.outputs.tooling }}" \
-            "${{ needs.changes.outputs.studio }}")
-
-          APPS=$(echo "$SELECT_OUTPUT" | grep '^APPS=' | cut -d= -f2-)
-          [ -z "$APPS" ] && echo "No workspace apps selected for E2E rebuild." && exit 0
-
-          BUILD_TARGETS="$APPS"
-          BUILT_APPS=""
-
-          # Store E2E starts the landing app too, so keep both builds in sync.
-          if echo " $APPS " | grep -q " store "; then
-            BUILD_TARGETS="$BUILD_TARGETS landing"
-          fi
-
-          for APP in $BUILD_TARGETS; do
-            case " $BUILT_APPS " in
-              *" $APP "*) continue ;;
-            esac
-
-            echo "Building ${APP} for E2E startup"
-            pnpm --filter "${APP}" build
-            BUILT_APPS="$BUILT_APPS $APP"
-          done
-        env:
-          CI: "true"
-          TARGET_ENV: dev
-          NEXT_PUBLIC_API_BASE_URL: /api
-          NEXT_PUBLIC_ENABLE_TEST_IDS: "true"
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.DEV_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.DEV_SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.DEV_SUPABASE_SERVICE_ROLE_KEY }}
-          SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
-          SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
-          SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID }}
-          SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET }}
 
       - name: Run E2E tests (scoped)
         run: |

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -20,14 +20,18 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+env:
+  NODE_VERSION: "24"
+
 jobs:
   # ============================================
-  # Run CI checks before deploying
+  # Build all apps with production config
+  # (replaces the old ci-gate + server-side build)
   # ============================================
-  ci-gate:
-    name: CI Gate
+  build:
+    name: Build (Standalone Production)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,41 +42,100 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Type check
-        run: pnpm run typecheck
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: apps/*/.next/cache
+          key: ${{ runner.os }}-nextjs-prod-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/**/*.ts', 'apps/**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-prod-${{ hashFiles('pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-prod-
 
-      - name: Lint
-        run: pnpm run lint
-
-      - name: Unit tests
-        run: pnpm run test
-
-      - name: Build (validates env system works with prod secrets)
+      - name: Build all apps (standalone, production)
         run: pnpm run build
         env:
           CI: "true"
           TARGET_ENV: prod
           STANDALONE: "true"
-          BASE_PATH_PREFIX: ""
-          # Prod Supabase Cloud
-          NEXT_PUBLIC_SUPABASE_URL: https://olafyajipvsltohagiah.supabase.co
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
-          # App URLs (prod)
-          NEXT_PUBLIC_STORE_URL: https://store.furrycolombia.com/store
-          NEXT_PUBLIC_ADMIN_URL: https://store.furrycolombia.com/admin
-          NEXT_PUBLIC_AUTH_URL: https://store.furrycolombia.com/auth
-          NEXT_PUBLIC_AUTH_HOST_URL: https://store.furrycolombia.com/auth
-          NEXT_PUBLIC_LANDING_URL: https://store.furrycolombia.com
-          NEXT_PUBLIC_PAYMENTS_URL: https://store.furrycolombia.com/payments
-          NEXT_PUBLIC_PLAYGROUND_URL: https://store.furrycolombia.com/playground
-          NEXT_PUBLIC_STUDIO_URL: https://store.furrycolombia.com/studio
+          # Expose secrets under the names .env.prod uses in its $secret:KEY references.
+          # load-env.mjs reads .env.prod and resolves $secret:KEY from process.env.
+          # All other prod vars (NEXT_PUBLIC_* URLs, etc.) come from .env.prod directly.
+          PROD_SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
+          PROD_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
+          TALLY_FORM_ID: ${{ secrets.TALLY_FORM_ID }}
+          SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
+          SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
+          SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID }}
+          SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET }}
+
+      - name: Upload store build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-store
+          path: apps/store/.next/
+          retention-days: 1
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - name: Upload admin build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-admin
+          path: apps/admin/.next/
+          retention-days: 1
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - name: Upload auth build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-auth
+          path: apps/auth/.next/
+          retention-days: 1
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - name: Upload landing build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-landing
+          path: apps/landing/.next/
+          retention-days: 1
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - name: Upload payments build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-payments
+          path: apps/payments/.next/
+          retention-days: 1
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - name: Upload studio build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-studio
+          path: apps/studio/.next/
+          retention-days: 1
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - name: Upload playground build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-playground
+          path: apps/playground/.next/
+          retention-days: 1
+          if-no-files-found: error
+          include-hidden-files: true
 
   # ============================================
   # Deploy to production server via SSH
@@ -80,8 +143,8 @@ jobs:
   deploy:
     name: Deploy to Server
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: ci-gate
+    timeout-minutes: 15
+    needs: build
     environment: production
     env:
       SSH_OPTS: "-o StrictHostKeyChecking=no -o ProxyCommand='cloudflared access ssh --hostname %h'"
@@ -123,31 +186,75 @@ jobs:
           echo "App version: $VERSION"
 
       - name: Write ephemeral env file on server
+        env:
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_THREAD_ID: ${{ secrets.TELEGRAM_THREAD_ID }}
+          TELEGRAM_CRITICAL_THREAD_ID: ${{ secrets.TELEGRAM_CRITICAL_THREAD_ID }}
         run: |
-          ssh ${{ secrets.PROD_SERVER_HOST }} \
-            'cat > /tmp/.candyshop-build.env << ENVEOF
-          CI=true
-          TARGET_ENV=prod
-          STANDALONE=true
-          BASE_PATH_PREFIX=
-          NEXT_PUBLIC_SUPABASE_URL=https://olafyajipvsltohagiah.supabase.co
-          NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.PROD_SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY=${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
-          NEXT_PUBLIC_STORE_URL=https://store.furrycolombia.com/store
-          NEXT_PUBLIC_ADMIN_URL=https://store.furrycolombia.com/admin
-          NEXT_PUBLIC_AUTH_URL=https://store.furrycolombia.com/auth
-          NEXT_PUBLIC_AUTH_HOST_URL=https://store.furrycolombia.com/auth
-          NEXT_PUBLIC_LANDING_URL=https://store.furrycolombia.com
-          NEXT_PUBLIC_PAYMENTS_URL=https://store.furrycolombia.com/payments
-          NEXT_PUBLIC_PLAYGROUND_URL=https://store.furrycolombia.com/playground
-          NEXT_PUBLIC_STUDIO_URL=https://store.furrycolombia.com/studio
-          TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID=${{ secrets.TELEGRAM_CHAT_ID }}
-          TELEGRAM_THREAD_ID=${{ secrets.TELEGRAM_THREAD_ID }}
-          TELEGRAM_CRITICAL_THREAD_ID=${{ secrets.TELEGRAM_CRITICAL_THREAD_ID }}
-          NEXT_PUBLIC_APP_VERSION=${{ steps.app_version.outputs.value }}
-          NEXT_PUBLIC_TALLY_FORM_ID=${{ secrets.TALLY_FORM_ID }}
-          ENVEOF'
+          # Pipe via stdin so secret values never appear in command-line arguments or SSH logs.
+          {
+            printf 'SUPABASE_SERVICE_ROLE_KEY=%s\n'      "$SUPABASE_SERVICE_ROLE_KEY"
+            printf 'TELEGRAM_BOT_TOKEN=%s\n'             "$TELEGRAM_BOT_TOKEN"
+            printf 'TELEGRAM_CHAT_ID=%s\n'               "$TELEGRAM_CHAT_ID"
+            printf 'TELEGRAM_THREAD_ID=%s\n'             "$TELEGRAM_THREAD_ID"
+            printf 'TELEGRAM_CRITICAL_THREAD_ID=%s\n'   "$TELEGRAM_CRITICAL_THREAD_ID"
+            printf 'NEXT_PUBLIC_APP_VERSION=%s\n'        "${{ steps.app_version.outputs.value }}"
+          } | ssh ${{ secrets.PROD_SERVER_HOST }} 'cat > /tmp/.candyshop-build.env'
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-store
+          path: apps/store/.next/
+
+      - name: Download admin build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-admin
+          path: apps/admin/.next/
+
+      - name: Download auth build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-auth
+          path: apps/auth/.next/
+
+      - name: Download landing build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-landing
+          path: apps/landing/.next/
+
+      - name: Download payments build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-payments
+          path: apps/payments/.next/
+
+      - name: Download studio build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-studio
+          path: apps/studio/.next/
+
+      - name: Download playground build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-playground
+          path: apps/playground/.next/
+
+      - name: Sync build artifacts to server
+        run: |
+          # Rsync each app's .next dir to the server, excluding the build cache
+          # (standalone + static are what the server needs; cache is CI-only)
+          for APP in store admin auth landing payments studio playground; do
+            echo "Syncing .next for ${APP}..."
+            rsync -az --delete --exclude=cache \
+              "apps/${APP}/.next/" \
+              "${{ secrets.PROD_SERVER_HOST }}:/home/furrycolombia/candyshop/apps/${APP}/.next/"
+          done
 
       - name: Copy deploy script to server
         run: |
@@ -172,10 +279,11 @@ jobs:
 
       - name: Wait for deployment
         run: |
-          # Poll every 30s via short-lived SSH connections (max 25 min).
-          for i in $(seq 1 50); do
-            sleep 30
-            echo "--- log tail [poll $i/50] ---"
+          # Poll every 15s via short-lived SSH connections (max 5 min).
+          # Server-side work is now fast (no build): git pull + PM2 restart + health check.
+          for i in $(seq 1 20); do
+            sleep 15
+            echo "--- log tail [poll $i/20] ---"
             ssh ${{ secrets.PROD_SERVER_HOST }} \
               "tail -25 /tmp/deploy-candyshop.log 2>/dev/null" || true
             RESULT=$(ssh ${{ secrets.PROD_SERVER_HOST }} \
@@ -185,7 +293,7 @@ jobs:
               [ "$RESULT" = "0" ] && exit 0 || exit 1
             fi
           done
-          echo "Timed out after 25 minutes waiting for deployment"
+          echo "Timed out after 5 minutes waiting for deployment"
           exit 1
 
       - name: Verify deployment
@@ -202,16 +310,15 @@ jobs:
 
   # ============================================
   # Alert Telegram when any deploy job fails
-  # (ci-gate failures are silent otherwise)
   # ============================================
   notify-failure:
     name: Notify Deploy Failure
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    needs: [ci-gate, deploy]
+    needs: [build, deploy]
     # always() lets this job run even when upstream jobs are skipped due to failure;
     # the explicit result checks ensure we only fire on actual failures, not cancellations.
-    if: ${{ always() && (needs.ci-gate.result == 'failure' || needs.deploy.result == 'failure') }}
+    if: ${{ always() && (needs.build.result == 'failure' || needs.deploy.result == 'failure') }}
     steps:
       - name: Send Telegram alert
         env:

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -150,49 +150,28 @@ DEPLOY_COMMIT=$(git log --format="%h %s" -1 2>/dev/null || true)
 log "Checked out $DEPLOY_COMMIT"
 notify_telegram "$(printf '📥 <b>Code pulled</b> (%s)\nCommit: <code>%s</code>' "$(_dur $_STEP_START)" "$DEPLOY_COMMIT")"
 
-# =============================================================================
-# Install dependencies
-# =============================================================================
-_STEP_START=$(date +%s)
-log "Installing dependencies..."
-pnpm install --frozen-lockfile --prod=false
-notify_telegram "$(printf '📦 <b>Dependencies installed</b> (%s)' "$(_dur $_STEP_START)")"
+# Remove .secrets — builds now happen in CI, not on this server.
+# The file is gitignored so git clean -fd doesn't touch it; delete explicitly
+# so it doesn't linger on disk and expand the attack surface.
+rm -f "$DEPLOY_DIR/.secrets"
 
 # =============================================================================
-# Load build env vars (written by CI, deleted after deploy)
+# Load runtime env vars (written by CI, deleted after deploy)
+# Build artifacts are pre-built in CI and rsync'd to this server before this
+# script runs — NEXT_PUBLIC_* vars are already baked into the JS bundles.
+# We source the env file here so PM2 processes inherit runtime-only secrets
+# (SUPABASE_SERVICE_ROLE_KEY, Telegram tokens, etc.).
 # =============================================================================
 ENV_FILE="${ENV_FILE:-/tmp/.candyshop-build.env}"
 if [ -f "$ENV_FILE" ]; then
-  log "Loading build env from $ENV_FILE"
-  cp "$ENV_FILE" "$DEPLOY_DIR/.env"
-  # Source env vars into the current shell so child processes (pnpm build) inherit them.
-  # This is required for load-env.mjs to detect CI=true and resolve $secret: references.
+  log "Loading runtime env from $ENV_FILE"
   set -o allexport
   # shellcheck source=/dev/null
   source "$ENV_FILE"
   set +o allexport
 else
-  warn "No env file found at $ENV_FILE — building with defaults"
+  warn "No env file found at $ENV_FILE — PM2 processes may lack runtime secrets"
 fi
-
-# =============================================================================
-# Build all apps (standalone mode for path-based routing)
-# =============================================================================
-_STEP_START=$(date +%s)
-log "Building all applications in standalone mode..."
-export STANDALONE=true
-
-# Clear the local Turborepo cache to ensure a fresh standalone build.
-# Without this, a prior non-standalone cache hit would restore output that
-# lacks the .next/standalone directory.
-rm -rf "$DEPLOY_DIR/.turbo"
-
-notify_telegram "$(printf '🔨 <b>Building all apps…</b>\n<i>Takes ~3–4 min</i>')"
-pnpm run build
-
-# Clean up env file (secrets should not persist on disk)
-rm -f "$ENV_FILE" "$DEPLOY_DIR/.env"
-notify_telegram "$(printf '✅ <b>Build complete</b> (%s)' "$(_dur $_STEP_START)")"
 
 # =============================================================================
 # Start/restart apps with PM2
@@ -253,6 +232,9 @@ pm2 save
 log "All applications started!"
 pm2 list
 notify_telegram "$(printf '🔄 <b>%d apps restarted with PM2</b> (%s)' "${#APPS[@]}" "$(_dur $_STEP_START)")"
+
+# Clean up env file — secrets must not persist on disk
+rm -f "$ENV_FILE"
 
 # =============================================================================
 # Deploy Nginx config


### PR DESCRIPTION
## Production Release

**Release:** `v2026.04.24.3`

---

## Changes Included

- `38fed27c` perf(ci): reduce deploy time via CI build artifacts + secret hardening [GH-188] (#194)

---

## Summary

- Eliminates redundant `ci-gate` job from `deploy-production.yml`
- Builds all 7 apps in CI with standalone mode; rsync `.next/` to VPS (no `pnpm build` on server)
- Adds Next.js `.next/cache` and Playwright browser cache to `ci.yml`
- Removes E2E double-build step
- Hardens secret handling: `env:` blocks + stdin pipe (no inline secrets in SSH commands)
- `rm -f .secrets` on VPS after git pull (gitignored file was surviving `git clean -fd`)

---

## Pre-Release Checklist

- [x] All PRs merged to develop have been reviewed
- [x] CI checks passed on PR #194
- [x] Secret hardening verified

---

Generated with [Claude Code](https://claude.com/claude-code)