### PR TITLE
fix(deploy): use basePath-aware health URLs in production health checks

### DIFF
--- a/apps/playground/src/app/health/route.ts
+++ b/apps/playground/src/app/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json(
+    { status: "ok", timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -180,18 +180,18 @@ log "Starting applications with PM2..."
 _STEP_START=$(date +%s)
 
 APPS=(
-  "auth:5000"
-  "store:5001"
-  "admin:5002"
-  "playground:5003"
-  "landing:5004"
-  "payments:5005"
-  "studio:5006"
+  "auth:5000:/auth/health"
+  "store:5001:/store/health"
+  "admin:5002:/admin/health"
+  "playground:5003:/playground/health"
+  "landing:5004:/health"
+  "payments:5005:/payments/health"
+  "studio:5006:/studio/health"
 )
 
 for APP_ENTRY in "${APPS[@]}"; do
   APP_NAME="${APP_ENTRY%%:*}"
-  APP_PORT="${APP_ENTRY##*:}"
+  _rest="${APP_ENTRY#*:}"; APP_PORT="${_rest%%:*}"
   PM2_NAME="candyshop-${APP_NAME}"
 
   log "Starting $PM2_NAME on port $APP_PORT..."
@@ -324,9 +324,9 @@ FAILED=0
 HEALTHY=0
 for APP_ENTRY in "${APPS[@]}"; do
   APP_NAME="${APP_ENTRY%%:*}"
-  APP_PORT="${APP_ENTRY##*:}"
+  _rest="${APP_ENTRY#*:}"; APP_PORT="${_rest%%:*}"; APP_HEALTH_PATH="${_rest#*:}"
 
-  if curl -sf --max-time 15 "http://localhost:${APP_PORT}" > /dev/null 2>&1; then
+  if curl -sf --max-time 15 "http://localhost:${APP_PORT}${APP_HEALTH_PATH}" > /dev/null 2>&1; then
     log "  ✓ $APP_NAME (port $APP_PORT) — accepting connections"
     HEALTHY=$(( HEALTHY + 1 ))
   else


### PR DESCRIPTION
## Summary

- Health checks were hitting bare `/` on each app, but 6 of 7 apps have `basePath` configured (e.g. `/store`, `/auth`) so they return HTTP 404 — causing `curl -sf` to fail and report all apps as unhealthy after every deploy
- Encodes the health path as a third field in the `APPS` array entries
- Updates the PM2 start loop to parse port correctly (previously `##*:` would grab the health path instead of port)
- Updates health check `curl` to use the correct basePath-aware URL per app
- Adds missing `/playground/health` route (the Docker watcher already expected this endpoint)

## Changes

- `scripts/deploy-production.sh` — APPS array now `name:port:/path`, health check uses full URL, PM2 loop port extraction updated
- `apps/playground/src/app/health/route.ts` — new health route matching all other apps

## Testing

All other apps already have matching `/[basePath]/health` routes. The `docker/watcher.mjs` already used these same paths — the deploy script was the only inconsistency.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)