### PR TITLE
fix(payments): hide expiration warning on non-pending orders

### DIFF
--- a/apps/payments/src/features/received-orders/presentation/components/ReceivedOrderCard.tsx
+++ b/apps/payments/src/features/received-orders/presentation/components/ReceivedOrderCard.tsx
@@ -187,8 +187,8 @@ export function ReceivedOrderCard({
         </div>
       )}
 
-      {/* Expiration warning */}
-      {expiresAt && isExpiringSoon && (
+      {/* Expiration warning — only relevant while the order is still pending */}
+      {expiresAt && isExpiringSoon && order.payment_status === "pending" && (
         <div className="flex items-center gap-2 border-b-2 border-dashed border-warning/30 bg-warning/5 px-4 py-2">
           <Clock className="size-4 text-warning" />
           <span className="font-display text-xs font-bold text-warning">


### PR DESCRIPTION
## Summary
- Expiration warning banner was showing on approved/rejected orders when their `expires_at` was within 6 hours of now
- Added `order.payment_status === 'pending'` guard so the warning only renders while the order still needs action

## Test plan
- [ ] Verify approved/rejected orders no longer show the clock warning banner
- [ ] Verify pending orders near expiry still show the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)