### PR TITLE
fix(deploy): ensure .next/static and public dirs exist before docker build

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -184,6 +184,13 @@ log "Building Docker image from pre-built artifacts..."
 _STEP_START=$(date +%s)
 IMAGE_TAG="candyshop-prod:$(git rev-parse --short HEAD 2>/dev/null || date +%s)"
 
+# CI artifacts silently drop empty directories; docker COPY fails on missing paths.
+# Ensure every path the Dockerfile COPYs exists before building.
+for APP in store auth admin landing payments studio playground; do
+  mkdir -p "$DEPLOY_DIR/apps/$APP/.next/static"
+  mkdir -p "$DEPLOY_DIR/apps/$APP/public"
+done
+
 docker build \
   -f "$DEPLOY_DIR/docker/prod/Dockerfile" \
   -t "$IMAGE_TAG" \


### PR DESCRIPTION
## Problem

Production deploy failed immediately after the v2026.04.25.1 release:

```
ERROR: "/apps/studio/.next/static": not found
```

Docker \`COPY\` fails hard if the source path doesn't exist in the build context.

## Root Cause

GitHub Actions artifacts silently drop empty directories. If an app's \`.next/static\` or \`public\` directory is empty (or contains only hidden files), it won't be included in the uploaded artifact. The subsequent \`rsync --delete\` then removes it from the server, leaving nothing for \`docker build\` to COPY.

## Fix

Add a \`mkdir -p\` guard in \`deploy-production.sh\` before \`docker build\` to ensure all COPY source paths exist:

\`\`\`bash
for APP in store auth admin landing payments studio playground; do
  mkdir -p "$DEPLOY_DIR/apps/$APP/.next/static"
  mkdir -p "$DEPLOY_DIR/apps/$APP/public"
done
\`\`\`

Safe to run unconditionally — if the dir already exists with content, \`mkdir -p\` is a no-op.

---

Generated with [Claude Code](https://claude.com/claude-code)