### PR TITLE
fix(deploy): ensure static/public dirs survive artifact ZIP round-trip

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -87,6 +87,22 @@ jobs:
           SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET }}
           NEXT_PUBLIC_APP_VERSION: ${{ steps.app_version.outputs.value }}
 
+      - name: Ensure artifact directories are non-empty
+        # actions/upload-artifact@v4 uses ZIP format which silently drops empty
+        # directories. If an app has no static assets, its .next/static dir is
+        # empty after build and won't be included in the artifact. When the
+        # deploy job downloads and rsyncs these artifacts, rsync --delete then
+        # removes the missing dirs from the server, causing "docker COPY: not
+        # found" at build time. A placeholder file ensures the dir survives ZIP
+        # round-trip and rsync.
+        run: |
+          for app in store admin auth landing payments studio playground; do
+            mkdir -p "apps/$app/.next/static"
+            touch "apps/$app/.next/static/.artifact-placeholder"
+            mkdir -p "apps/$app/public"
+            touch "apps/$app/public/.artifact-placeholder"
+          done
+
       - name: Upload store build artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- `actions/upload-artifact@v4` uses ZIP format which silently drops empty directories
- If an app (e.g. `studio`) has no static assets, its `.next/static` dir is empty after build and is missing from the artifact
- The deploy job downloads artifacts and rsyncs with `--delete`, which removes the missing dir from the server
- `docker build` then fails with `"/apps/studio/.next/static": not found`

## Fix

Add a step after `Build all apps` that touches a placeholder file in every app's `.next/static` and `public` directories before artifact upload. This guarantees the paths exist on the server when `docker build` runs.

## Root Cause Analysis

The `mkdir -p` fix in `deploy-production.sh` (PR #204) was insufficient because `git clean -fd` earlier in the same script removes gitignored directories (including `.next/`), running after `git checkout`. The mkdir ran before docker build but after git clean had already removed the dirs that rsync hadn't restored. The real fix must be upstream in CI, before artifacts are uploaded.

## Test Plan

- [ ] CI passes on this PR
- [ ] Production deploy succeeds after merge (check Telegram for ✅ Deploy complete)