### PR TITLE
fix(deploy): stop .dockerignore from excluding .next/ from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,10 @@ node_modules
 **/node_modules
 
 # Build outputs
-**/.next
+# NOTE: **/.next is intentionally NOT excluded — the production Dockerfile
+# copies pre-built .next/standalone and .next/static dirs from the build
+# context (rsynced by CI). Only the Next.js build cache is excluded.
+**/.next/cache
 **/dist
 **/build
 


### PR DESCRIPTION
## Root Cause

`**/.next` in `.dockerignore` was excluding **every** `.next/` directory from the Docker build context. The production `Dockerfile` COPYs pre-built `.next/standalone` and `.next/static` dirs that CI rsyncs to the server before `docker build` runs. With `**/.next` in `.dockerignore`, Docker never saw those paths — hence the repeated `"not found"` errors.

This was the real root cause all along. The previous fixes (PR #204, #205) were working around a symptom (empty dirs) while this was silently blocking everything.

## Fix

Replace `**/.next` with `**/.next/cache` — excludes only the Next.js build cache (CI-only, large, not needed in the image) while allowing `standalone/` and `static/` through to the build context.

## Test Plan

- [ ] CI passes
- [ ] Production deploy succeeds (Telegram: ✅ Deploy complete)