### PR TITLE
fix(docker): restore outputFileTracingRoot and unblock standalone node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
-# Dependencies
+# Dependencies — use specific paths, NOT **/node_modules.
+# .next/standalone/node_modules contains runtime deps that MUST be in the image.
 node_modules
-**/node_modules
+apps/*/node_modules
+packages/*/node_modules
 
 # Build outputs
 # NOTE: **/.next is intentionally NOT excluded — the production Dockerfile

--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
@@ -60,6 +61,7 @@ const nextConfig: NextConfig = {
   ...(isStandalone && {
     output: "standalone" as const,
     basePath: `${basePathPrefix}/admin`,
+    outputFileTracingRoot: path.join(__dirname, "../.."),
   }),
   transpilePackages: [
     "ui",

--- a/apps/auth/next.config.ts
+++ b/apps/auth/next.config.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
@@ -60,6 +61,7 @@ const nextConfig: NextConfig = {
   ...(isStandalone && {
     output: "standalone" as const,
     basePath: `${basePathPrefix}/auth`,
+    outputFileTracingRoot: path.join(__dirname, "../.."),
   }),
   transpilePackages: [
     "api",

--- a/apps/landing/next.config.ts
+++ b/apps/landing/next.config.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
@@ -64,6 +65,7 @@ const nextConfig: NextConfig = {
   ...(process.env.STANDALONE === "true" && {
     output: "standalone" as const,
     ...(basePathPrefix && { basePath: basePathPrefix }),
+    outputFileTracingRoot: path.join(__dirname, "../.."),
   }),
   transpilePackages: ["api", "ui", "shared", "@monorepo/app-components"],
   async headers() {

--- a/apps/payments/next.config.ts
+++ b/apps/payments/next.config.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
@@ -60,6 +61,7 @@ const nextConfig: NextConfig = {
   ...(isStandalone && {
     output: "standalone" as const,
     basePath: `${basePathPrefix}/payments`,
+    outputFileTracingRoot: path.join(__dirname, "../.."),
   }),
   transpilePackages: [
     "ui",

--- a/apps/playground/next.config.ts
+++ b/apps/playground/next.config.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
@@ -60,6 +61,7 @@ const nextConfig: NextConfig = {
   ...(isStandalone && {
     output: "standalone" as const,
     basePath: `${basePathPrefix}/playground`,
+    outputFileTracingRoot: path.join(__dirname, "../.."),
   }),
   transpilePackages: [
     "ui",

--- a/apps/store/next.config.ts
+++ b/apps/store/next.config.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
@@ -60,6 +61,7 @@ const nextConfig: NextConfig = {
   ...(isStandalone && {
     output: "standalone" as const,
     basePath: `${basePathPrefix}/store`,
+    outputFileTracingRoot: path.join(__dirname, "../.."),
   }),
   images: {
     remotePatterns: [

--- a/apps/studio/next.config.ts
+++ b/apps/studio/next.config.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
@@ -60,6 +61,7 @@ const nextConfig: NextConfig = {
   ...(isStandalone && {
     output: "standalone" as const,
     basePath: `${basePathPrefix}/studio`,
+    outputFileTracingRoot: path.join(__dirname, "../.."),
   }),
   // lucide-react v1.x ESM dist uses .ts imports in .js files — Turbopack
   // can't resolve those by default. This alias fixes it.


### PR DESCRIPTION
## Summary

Production is down (502 Bad Gateway on all apps). Two bugs in the Docker build setup caused all 7 Next.js apps to fail to start inside the container.

### Root Cause 1 — Missing `outputFileTracingRoot`

`supervisord.conf` starts each app with:
```
node /app/store/apps/store/server.js
```
This nested path is only produced when `outputFileTracingRoot` is set to the monorepo root in `next.config.ts`. Without it, Next.js standalone places `server.js` at the flat root of the standalone output — so after `COPY apps/store/.next/standalone /app/store/` it lands at `/app/store/server.js`, not the expected nested path. All 7 processes crashed immediately → nginx never got all 6 ports → 502.

**Fix:** Added `outputFileTracingRoot: path.join(__dirname, "../..")` (monorepo root) to every app's `next.config.ts`.

### Root Cause 2 — `**/node_modules` stripped standalone runtime deps

`.dockerignore` had:
```
node_modules
**/node_modules   ← matched apps/store/.next/standalone/node_modules/
```
This excluded the runtime `node_modules` that the standalone server needs to run from the Docker build context. Even if server.js were found, the apps would crash with `Cannot find module`.

**Fix:** Replaced `**/node_modules` with specific patterns `apps/*/node_modules` and `packages/*/node_modules` that skip workspace source deps but leave standalone output deps untouched.

## Files Changed

- `apps/{store,auth,admin,payments,playground,studio,landing}/next.config.ts` — add `outputFileTracingRoot`
- `.dockerignore` — scope node_modules exclusion

## Testing

Deploy will rebuild all apps with the corrected standalone structure and the Docker build context will include the runtime deps.