### PR TITLE
fix(deploy): remove pnpm stub node_modules from standalone builds

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -44,6 +44,18 @@ COPY docker/prod/nginx.conf           /etc/nginx/nginx.conf
 COPY docker/prod/supervisord.conf     /etc/supervisor/conf.d/supervisord.conf
 COPY docker/watcher.mjs               /app/watcher.mjs
 
+# pnpm workspace linking creates stub node_modules inside each app directory
+# (package.json only, no dist/) that shadow the complete packages at the
+# standalone root node_modules/. Remove them so Node resolves from root.
+RUN rm -rf \
+    /app/store/apps/store/node_modules \
+    /app/auth/apps/auth/node_modules \
+    /app/admin/apps/admin/node_modules \
+    /app/landing/apps/landing/node_modules \
+    /app/payments/apps/payments/node_modules \
+    /app/playground/apps/playground/node_modules \
+    /app/studio/apps/studio/node_modules
+
 EXPOSE 80
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]


### PR DESCRIPTION
## What

Removes per-app pnpm stub node_modules from each standalone build in the Dockerfile.

## Why

pnpm workspace linking creates stub `package.json` files inside each app's
`node_modules` directory (e.g. `apps/store/node_modules/next/package.json`)
**without** the actual `dist/` files. The real `next` package sits at the
standalone root `node_modules/next/dist/`.

When `outputFileTracingRoot` mirrors the full monorepo path into the standalone
output, Node.js finds the **stub** `package.json` first (closer up the directory
tree), reads its `main: "dist/server/next.js"`, then crashes:

```
Error: Cannot find module '/app/store/apps/store/node_modules/next/dist/server/next.js'
```

This was causing all 7 apps to enter FATAL state on startup → nginx never received
all ports → 502 for every request.

## Fix

One `RUN rm -rf` after all `COPY` statements removes the per-app stubs, so Node
falls through to the complete packages at `/app/{app}/node_modules/next/dist/`.

## Verified

Confirmed via `docker logs candyshop-prod` on the live server that exactly this
error was killing all apps after PR #208 deployed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)