### PR TITLE
fix(deploy): allow standalone node_modules in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,12 @@ node_modules
 apps/*/node_modules
 packages/*/node_modules
 
+# Re-include standalone runtime deps traced by Next.js build.
+# The .next/standalone/node_modules directory is required for production —
+# .dockerignore would otherwise strip it out during COPY.
+!apps/**/.next/standalone/node_modules
+!apps/**/.next/standalone/node_modules/**
+
 # Build outputs
 # NOTE: **/.next is intentionally NOT excluded — the production Dockerfile
 # copies pre-built .next/standalone and .next/static dirs from the build

--- a/docker/watcher.mjs
+++ b/docker/watcher.mjs
@@ -17,7 +17,7 @@
  *   WATCHER_MAX_MS  — maximum interval in ms  (default: 600_000 = 10 min)
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 
 // ── Configuration ─────────────────────────────────────────────────────────────
@@ -191,6 +191,13 @@ function readDiskUsedPct() {
 }
 
 function isTunnelRunning() {
+  // Inside a Docker container, host processes are not visible via PID namespace
+  // isolation — pgrep and systemctl will never find the host's cloudflared.
+  // Return null to skip the check entirely rather than sending false DOWN alerts.
+  try {
+    if (existsSync("/.dockerenv")) return null;
+  } catch { /* ignore */ }
+
   // Method 1: exact process name (native install)
   try {
     const r = spawnSync("pgrep", ["-x", "cloudflared"], { encoding: "utf8", timeout: 3_000 });


### PR DESCRIPTION
## Root Cause

`.dockerignore` had `**/node_modules` which stripped out the traced runtime deps from `.next/standalone/node_modules/` during `COPY`. This caused all 7 apps to fail on startup with:

```
Error: Cannot find module 'next'
Require stack: - /app/store/apps/store/server.js
```

The standalone build traces all dependencies and places them in `.next/standalone/node_modules/`. The CI rsyncs this to the server. But Docker's COPY excluded the entire directory because of the broad `**/node_modules` pattern.

## Fix

Replace `**/node_modules` with explicit paths:
- `apps/*/node_modules` — workspace stubs (should stay excluded)
- `packages/*/node_modules` — package deps (should stay excluded)

Add `!` exceptions to explicitly re-include standalone runtime deps:
- `!apps/**/.next/standalone/node_modules`
- `!apps/**/.next/standalone/node_modules/**`

Also includes `watcher.mjs` fix: return `null` from `isTunnelRunning()` when running inside Docker (detected via `/.dockerenv`), preventing false "Cloudflare tunnel DOWN" alerts due to PID namespace isolation.

## Testing

This is a deploy infrastructure fix. The Docker build validates the change via CI.