### PR TITLE
fix(deploy): use node-linker=hoisted to survive ZIP artifact round-trip

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,12 @@ packages/*/node_modules
 # node_modules above excludes standalone/node_modules; **/dist then re-excludes
 # next/dist/, react/cjs/, etc. inside it. These final re-includes restore all of
 # standalone/node_modules so the production container can find 'next', 'react', etc.
+#
+# NOTE: .npmrc sets node-linker=hoisted so pnpm creates real directories (not
+# symlinks) in node_modules. This is required because actions/upload-artifact uses
+# ZIP format which strips symlinks — without hoisted linker the top-level
+# `node_modules/next` symlink is lost in the CI artifact round-trip and the
+# container cannot find the 'next' module at runtime.
 !apps/**/.next/standalone/node_modules
 !apps/**/.next/standalone/node_modules/**
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/scripts/docker-health-check.sh
+++ b/scripts/docker-health-check.sh
@@ -59,13 +59,13 @@ for (const k of keys) {
 EOF
 )
 
-# ── Windows: clean pnpm .ignored_api files before building ───────────────────
-# pnpm creates node_modules/.ignored_api with restricted NTFS permissions that
-# prevent Docker Desktop's build context sender from enumerating them — even
-# though apps/*/node_modules is excluded in .dockerignore, the sender must stat
-# every file before applying exclusion rules. The files are pnpm-internal
-# markers that pnpm recreates on the next install; deleting them is safe.
-find . -name ".ignored_api" -delete 2>/dev/null || true
+# ── Windows: clean pnpm .ignored_* files before building ─────────────────────
+# pnpm creates node_modules/.ignored_api, .ignored_auth, etc. with restricted
+# NTFS permissions that prevent Docker Desktop's build context sender from
+# enumerating them — even though apps/*/node_modules is excluded in
+# .dockerignore, the sender must stat every file before applying exclusion
+# rules. These files are pnpm-internal markers; deleting them is safe.
+find . -name ".ignored_*" -delete 2>/dev/null || true
 
 echo "Building Docker image: $IMAGE_NAME..."
 # shellcheck disable=SC2086


### PR DESCRIPTION
## Summary

- Adds `.npmrc` with `node-linker=hoisted` so pnpm creates real directories instead of symlinks in `node_modules`
- Extends `.ignored_*` cleanup in `docker-health-check.sh` to cover all pnpm NTFS marker files (not just `.ignored_api`)

## Root Cause

`actions/upload-artifact@v4` uses ZIP format which strips symlinks. pnpm's default isolated linker creates `node_modules/next` as a symlink → `.pnpm/next@version/.../next`. After the ZIP round-trip (upload → download → rsync), the `.pnpm/` real files arrive on the server but the top-level symlinks are gone. The Docker image builds without them, so `require('next')` fails at runtime with `Cannot find module 'next'`.

With `node-linker=hoisted`, pnpm writes real directories (like npm/yarn), which survive ZIP artifacts intact.

## Test plan

- [x] Pre-push hook ran full Docker health check and passed
- [x] All unit tests pass (store, landing, payments, admin, auth)
- [ ] After merge, next production deploy will build with hoisted linker — standalone `node_modules` will be real directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)