### PR TITLE
chore(ci): purge Cloudflare cache after every production deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -330,6 +330,17 @@ jobs:
           ssh ${{ secrets.PROD_SERVER_HOST }} \
             'docker ps --filter name=candyshop-prod --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || true'
 
+      - name: Purge Cloudflare cache
+        env:
+          CF_API_TOKEN: ${{ secrets.PROD_CF_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.PROD_CF_ZONE_ID }}
+        run: |
+          curl -s -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}'
+
       - name: Cleanup
         if: always()
         run: |

--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -55,6 +55,8 @@ jobs:
           TELEGRAM_BACKUPS_THREAD_ID: ${{ secrets.TELEGRAM_BACKUPS_THREAD_ID }}
           TALLY_FORM_ID: ${{ secrets.TALLY_FORM_ID }}
           DEV_SSH_PUBLIC_KEY: ${{ secrets.DEV_SSH_PUBLIC_KEY }}
+          PROD_CF_API_TOKEN: ${{ secrets.PROD_CF_API_TOKEN }}
+          PROD_CF_ZONE_ID: ${{ secrets.PROD_CF_ZONE_ID }}
         shell: bash
         run: |
           # Validate required secrets are present
@@ -136,6 +138,10 @@ jobs:
             echo ""
             echo "# ─── Dev tunnel SSH ──────────────────────────────────────────────"
             echo "DEV_SSH_PUBLIC_KEY=${DEV_SSH_PUBLIC_KEY}"
+            echo ""
+            echo "# ─── Cloudflare Cache Purge ───────────────────────────────────────"
+            echo "PROD_CF_API_TOKEN=${PROD_CF_API_TOKEN}"
+            echo "PROD_CF_ZONE_ID=${PROD_CF_ZONE_ID}"
           } > secrets-plain.txt
 
       - name: Encrypt secrets file


### PR DESCRIPTION
## Summary

Automatically purges the Cloudflare CDN cache after every successful production deployment, ensuring users always receive the latest assets without needing to manually clear the cache.

## Changes

- Added `PROD_CF_API_TOKEN` and `PROD_CF_ZONE_ID` secrets to `sync-secrets.yml`
- Added **Purge Cloudflare cache** step in `deploy-production.yml` immediately after **Verify deployment**, using the Cloudflare Cache Purge API (`purge_everything`)

## Testing

- Secrets `PROD_CF_API_TOKEN` and `PROD_CF_ZONE_ID` are already set in GitHub repository secrets (added via `gh secret set` and verified with `pnpm sync-secrets`)
- Cache purge was manually tested and confirmed working (returned `{"success":true}`)
- On every future deploy the step will fire automatically after containers come up healthy

---

Generated with [Claude Code](https://claude.com/claude-code)