### PR TITLE
fix(security): run Docker containers as non-root user [GH-239]

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -15,7 +15,7 @@ SITE_PROD_IMAGE_NAME=candyshop-ci
 HOST_PORT=5050
 
 # ─── App origins ──────────────────────────────────────────────────
-APP_INTERNAL_ORIGIN=http://candyshop-ci:80
+APP_INTERNAL_ORIGIN=http://candyshop-ci:8080
 
 # ─── Supabase Docker (local, port 54321 — different from staging's 64321) ─────
 NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321

--- a/.env.prod
+++ b/.env.prod
@@ -13,7 +13,7 @@ SITE_PROD_IMAGE_NAME=candyshop-prod
 HOST_PORT=9090
 
 # ─── App origins ──────────────────────────────────────────────────
-APP_INTERNAL_ORIGIN=http://candyshop-prod:80
+APP_INTERNAL_ORIGIN=http://candyshop-prod:8080
 
 # ─── Supabase Cloud ───────────────────────────────────────────────
 NEXT_PUBLIC_SUPABASE_URL=https://olafyajipvsltohagiah.supabase.co

--- a/.env.staging
+++ b/.env.staging
@@ -13,7 +13,7 @@ SITE_PROD_IMAGE_NAME=candyshop-staging
 HOST_PORT=7542
 
 # ─── App origins ──────────────────────────────────────────────────
-APP_INTERNAL_ORIGIN=http://candyshop-staging:80
+APP_INTERNAL_ORIGIN=http://candyshop-staging:8080
 
 # ─── Supabase ─────────────────────────────────────────────────────
 NEXT_PUBLIC_SUPABASE_URL=https://supabase.ffxivbe.org

--- a/.kiro/specs/app-navigation-origins/design.md
+++ b/.kiro/specs/app-navigation-origins/design.md
@@ -206,12 +206,12 @@ No `isE2EMode` flag. No `E2E_PUBLIC_ORIGIN` reference. The script is environment
 
 ### 6. Env files (all four)
 
-| File           | `APP_PUBLIC_ORIGIN`               | `APP_INTERNAL_ORIGIN`         |
-| -------------- | --------------------------------- | ----------------------------- |
-| `.env.dev`     | `http://localhost:8088`           | `http://localhost:8088`       |
-| `.env.test`    | `http://localhost:8088`           | `http://localhost:8088`       |
-| `.env.staging` | `https://store.ffxivbe.org`       | `http://candyshop-staging:80` |
-| `.env.prod`    | `https://store.furrycolombia.com` | `http://candyshop-prod:80`    |
+| File           | `APP_PUBLIC_ORIGIN`               | `APP_INTERNAL_ORIGIN`           |
+| -------------- | --------------------------------- | ------------------------------- |
+| `.env.dev`     | `http://localhost:8088`           | `http://localhost:8088`         |
+| `.env.test`    | `http://localhost:8088`           | `http://localhost:8088`         |
+| `.env.staging` | `https://store.ffxivbe.org`       | `http://candyshop-staging:8080` |
+| `.env.prod`    | `https://store.furrycolombia.com` | `http://candyshop-prod:8080`    |
 
 Remove from all four: `SITE_PROD_PORT`, `SITE_PUBLIC_ORIGIN`, `E2E_PUBLIC_ORIGIN`.
 
@@ -230,7 +230,7 @@ With:
 
 ```
 APP_PUBLIC_ORIGIN=https://store.furrycolombia.com
-APP_INTERNAL_ORIGIN=http://candyshop-prod:80
+APP_INTERNAL_ORIGIN=http://candyshop-prod:8080
 ```
 
 ### 8. Documentation files

--- a/.kiro/specs/app-navigation-origins/requirements.md
+++ b/.kiro/specs/app-navigation-origins/requirements.md
@@ -20,7 +20,7 @@ The `E2E_PUBLIC_ORIGIN` dual-purpose pattern (navigation config + test-mode flag
 ## Glossary
 
 - **App_Navigation_Origins**: The feature described in this document — the two-variable model replacing the three legacy variables.
-- **APP_INTERNAL_ORIGIN**: New env var. The base URL used for Docker inter-service HTTP calls (e.g., `http://candyshop-prod:80`). Server-side only; never exposed to the browser.
+- **APP_INTERNAL_ORIGIN**: New env var. The base URL used for Docker inter-service HTTP calls (e.g., `http://candyshop-prod:808080`). Server-side only; never exposed to the browser.
 - **APP_PUBLIC_ORIGIN**: New env var. The browser-facing base URL of the deployed app (e.g., `https://store.furrycolombia.com`). Used by `appUrls.ts` and any code that builds canonical or nav-bar URLs.
 - **Env_File**: One of `.env.dev`, `.env.test`, `.env.staging`, `.env.prod` — the flat env files at the monorepo root loaded by `scripts/load-env.mjs`.
 - **Env_Linter**: `scripts/lint-envs.mjs`, enforces that all Env_Files have exactly the same set of keys.
@@ -93,8 +93,8 @@ The `E2E_PUBLIC_ORIGIN` dual-purpose pattern (navigation config + test-mode flag
 
 1. THE Env_File `.env.dev` SHALL set `APP_PUBLIC_ORIGIN` to `"http://localhost:8088"` and `APP_INTERNAL_ORIGIN` to `"http://localhost:8088"`, because in dev the public and internal origins are the same local address.
 2. THE Env_File `.env.test` SHALL set `APP_PUBLIC_ORIGIN` to `"http://localhost:8088"` and `APP_INTERNAL_ORIGIN` to `"http://localhost:8088"`.
-3. THE Env_File `.env.staging` SHALL set `APP_PUBLIC_ORIGIN` to `"https://store.ffxivbe.org"` and `APP_INTERNAL_ORIGIN` to `"http://candyshop-staging:80"`.
-4. THE Env_File `.env.prod` SHALL set `APP_PUBLIC_ORIGIN` to `"https://store.furrycolombia.com"` and `APP_INTERNAL_ORIGIN` to `"http://candyshop-prod:80"`.
+3. THE Env_File `.env.staging` SHALL set `APP_PUBLIC_ORIGIN` to `"https://store.ffxivbe.org"` and `APP_INTERNAL_ORIGIN` to `"http://candyshop-staging:8080"`.
+4. THE Env_File `.env.prod` SHALL set `APP_PUBLIC_ORIGIN` to `"https://store.furrycolombia.com"` and `APP_INTERNAL_ORIGIN` to `"http://candyshop-prod:8080"`.
 5. WHEN the Env_Linter runs, THE Env_Linter SHALL confirm that `APP_PUBLIC_ORIGIN` and `APP_INTERNAL_ORIGIN` are present in all four Env_Files and that no Env_File contains any Legacy_Var key.
 
 ---

--- a/.kiro/specs/app-navigation-origins/tasks.md
+++ b/.kiro/specs/app-navigation-origins/tasks.md
@@ -89,17 +89,17 @@ Replace the three legacy env vars (`SITE_PROD_PORT`, `SITE_PUBLIC_ORIGIN`, `E2E_
     - _Requirements: 3.1, 5.2_
 
   - [x] 7.3 Update `.env.staging`
-    - Add `APP_PUBLIC_ORIGIN=https://store.ffxivbe.org` and `APP_INTERNAL_ORIGIN=http://candyshop-staging:80`
+    - Add `APP_PUBLIC_ORIGIN=https://store.ffxivbe.org` and `APP_INTERNAL_ORIGIN=http://candyshop-staging:8080`
     - Remove `SITE_PROD_PORT`, `SITE_PUBLIC_ORIGIN`, `E2E_PUBLIC_ORIGIN`
     - _Requirements: 3.1, 5.3_
 
   - [x] 7.4 Update `.env.prod`
-    - Add `APP_PUBLIC_ORIGIN=https://store.furrycolombia.com` and `APP_INTERNAL_ORIGIN=http://candyshop-prod:80`
+    - Add `APP_PUBLIC_ORIGIN=https://store.furrycolombia.com` and `APP_INTERNAL_ORIGIN=http://candyshop-prod:8080`
     - Remove `SITE_PROD_PORT`, `SITE_PUBLIC_ORIGIN`, `E2E_PUBLIC_ORIGIN`
     - _Requirements: 3.1, 5.4_
 
 - [x] 8. Update `scripts/server/docker-prod.env.example`
-  - Replace `SITE_PROD_PORT` and `SITE_PUBLIC_ORIGIN` with `APP_PUBLIC_ORIGIN=https://store.furrycolombia.com` and `APP_INTERNAL_ORIGIN=http://candyshop-prod:80`
+  - Replace `SITE_PROD_PORT` and `SITE_PUBLIC_ORIGIN` with `APP_PUBLIC_ORIGIN=https://store.furrycolombia.com` and `APP_INTERNAL_ORIGIN=http://candyshop-prod:8080`
   - _Requirements: 7.1_
 
 - [x] 9. Update documentation files

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,9 +1,9 @@
 # =============================================================================
 # Candyshop — CI / local-dev image (all apps, built from source)
 # Builds all 7 apps in standalone mode, runs them behind nginx via supervisord.
-# Exposes port 80 (nginx) for E2E testing all routes.
+# Exposes port 8080 (nginx) for E2E testing all routes.
 # Build: docker build -f docker/ci/Dockerfile -t candyshop-ci .
-# Run:   docker run -p 8088:80 candyshop-ci
+# Run:   docker run -p 8088:8080 candyshop-ci
 # =============================================================================
 
 # ── Stage 1: install deps ─────────────────────────────────────────────────────
@@ -76,7 +76,8 @@ FROM node:22-alpine AS runner
 RUN apk add --no-cache nginx supervisor netcat-openbsd && \
     addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs && \
-    mkdir -p /var/log/nginx /var/log/supervisor /var/run/nginx /run/nginx
+    mkdir -p /var/log/nginx /var/log/supervisor /var/run/nginx /run/nginx && \
+    chown -R nextjs:nodejs /var/lib/nginx /var/log/nginx /var/log/supervisor /var/run/nginx /run/nginx
 
 # Copy standalone builds for each app
 COPY --from=builder /app/apps/store/.next/standalone    /app/store/
@@ -114,6 +115,9 @@ COPY docker/prod/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Copy the in-container health watcher
 COPY docker/watcher.mjs /app/watcher.mjs
 
-EXPOSE 80
+RUN chown -R nextjs:nodejs /app
 
+EXPOSE 8080
+
+USER nextjs
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -14,10 +14,10 @@ services:
     image: ${SITE_PROD_IMAGE_NAME}
     container_name: ${SITE_PROD_CONTAINER_NAME}
     ports:
-      - "${HOST_PORT}:80"
+      - "${HOST_PORT}:8080"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1/health"]
+      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1:8080/health"]
       interval: 15s
       timeout: 5s
       retries: 3

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -9,7 +9,8 @@ FROM node:22-alpine AS runner
 RUN apk add --no-cache nginx supervisor netcat-openbsd && \
     addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs && \
-    mkdir -p /var/log/nginx /var/log/supervisor /var/run/nginx /run/nginx
+    mkdir -p /var/log/nginx /var/log/supervisor /var/run/nginx /run/nginx && \
+    chown -R nextjs:nodejs /var/lib/nginx /var/log/nginx /var/log/supervisor /var/run/nginx /run/nginx
 
 # Standalone builds pre-built by CI (rsynced to server before this runs)
 COPY apps/store/.next/standalone      /app/store/
@@ -54,8 +55,10 @@ RUN rm -rf \
     /app/landing/apps/landing/node_modules \
     /app/payments/apps/payments/node_modules \
     /app/playground/apps/playground/node_modules \
-    /app/studio/apps/studio/node_modules
+    /app/studio/apps/studio/node_modules && \
+    chown -R nextjs:nodejs /app
 
-EXPOSE 80
+EXPOSE 8080
 
+USER nextjs
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/docker/prod/nginx.conf
+++ b/docker/prod/nginx.conf
@@ -1,4 +1,4 @@
-user nginx;
+user nextjs;
 worker_processes auto;
 pid /var/run/nginx/nginx.pid;
 error_log /var/log/nginx/error.log warn;
@@ -113,7 +113,7 @@ http {
     }
 
     server {
-        listen 80;
+        listen 8080;
         server_name _;
 
         # Store app - routes starting with /store

--- a/docker/prod/supervisord.conf
+++ b/docker/prod/supervisord.conf
@@ -1,11 +1,12 @@
 [supervisord]
 nodaemon=true
 logfile=/var/log/supervisor/supervisord.log
-pidfile=/var/run/supervisord.pid
-user=root
+pidfile=/tmp/supervisord.pid
+user=nextjs
 
 [program:nginx]
 command=/bin/sh -c 'until nc -z 127.0.0.1 5000 && nc -z 127.0.0.1 5001 && nc -z 127.0.0.1 5002 && nc -z 127.0.0.1 5004 && nc -z 127.0.0.1 5005 && nc -z 127.0.0.1 5006; do sleep 1; done && exec /usr/sbin/nginx -g "daemon off;"'
+user=nextjs
 autostart=true
 autorestart=true
 startretries=3

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -55,7 +55,7 @@ SITE_PROD_CONTAINER_NAME=candyshop-staging
 
 # ─── App origins ──────────────────────────────────────────────────
 HOST_PORT=3000   # host port for Docker container
-APP_INTERNAL_ORIGIN=http://candyshop-staging:80  # internal nginx address
+APP_INTERNAL_ORIGIN=http://candyshop-staging:8080  # internal nginx address
 
 # ─── Supabase ─────────────────────────────────────────────────────
 NEXT_PUBLIC_SUPABASE_URL=http://localhost:3030   # or https://... for cloud

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -150,7 +150,7 @@ The container runs Nginx + supervisord with 7 standalone Next.js servers inside.
 SITE_PROD_CONTAINER_NAME=candyshop-prod
 SITE_PROD_IMAGE_NAME=candyshop-prod
 HOST_PORT=9090
-APP_INTERNAL_ORIGIN=http://candyshop-prod:80
+APP_INTERNAL_ORIGIN=http://candyshop-prod:8080
 NEXT_PUBLIC_SUPABASE_URL=<supabase-url>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<supabase-anon-key>
 AUTH_PROVIDER_MODE=supabase
@@ -365,7 +365,7 @@ cat > ~/.env.prod << 'EOF'
 SITE_PROD_CONTAINER_NAME=candyshop-prod
 SITE_PROD_IMAGE_NAME=candyshop-prod
 HOST_PORT=9090
-APP_INTERNAL_ORIGIN=http://candyshop-prod:80
+APP_INTERNAL_ORIGIN=http://candyshop-prod:8080
 NEXT_PUBLIC_SUPABASE_URL=<supabase-url>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<supabase-anon-key>
 AUTH_PROVIDER_MODE=supabase

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -209,7 +209,7 @@ docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
 docker run -d \
   --name "$CONTAINER_NAME" \
   --restart unless-stopped \
-  -p "${HOST_PORT}:80" \
+  -p "${HOST_PORT}:8080" \
   -e "SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY:-}" \
   -e "TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}" \
   -e "TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-}" \

--- a/scripts/docker-health-check.sh
+++ b/scripts/docker-health-check.sh
@@ -86,7 +86,7 @@ echo "Using port $PORT for health check."
 # ── 3. Run container ──────────────────────────────────────────────────────────
 docker run -d \
   --name "$CONTAINER_NAME" \
-  -p "${PORT}:80" \
+  -p "${PORT}:8080" \
   "$IMAGE_NAME" > /dev/null
 
 # ── 4. Wait for /health endpoint (max 60s) ────────────────────────────────────

--- a/scripts/server/docker-prod.env.example
+++ b/scripts/server/docker-prod.env.example
@@ -5,7 +5,7 @@
 SITE_PROD_CONTAINER_NAME=candyshop-prod
 SITE_PROD_IMAGE_NAME=candyshop-prod
 HOST_PORT=9090
-APP_INTERNAL_ORIGIN=http://candyshop-prod:80
+APP_INTERNAL_ORIGIN=http://candyshop-prod:8080
 
 NEXT_PUBLIC_LANDING_URL=https://store.furrycolombia.com
 NEXT_PUBLIC_STORE_URL=https://store.furrycolombia.com/store


### PR DESCRIPTION
## Summary

Fixes the Aikido medium-severity finding: both Dockerfiles ran all processes as root. An attacker exploiting the application would immediately gain root access to the container filesystem.

The fix switches nginx from privileged port 80 to port 8080, configures supervisord and nginx to run as the `nextjs` user, and adds `USER nextjs` before `CMD` in both Dockerfiles.

## Related Issue

Closes #239

## Changes

- **`docker/prod/nginx.conf`** — `user nextjs;`, `listen 8080;`
- **`docker/prod/supervisord.conf`** — `user=nextjs` for supervisord and the nginx program; `pidfile=/tmp/supervisord.pid` (non-root writable)
- **`docker/ci/Dockerfile`** — chown `/var/lib/nginx`, log dirs, run dirs, and `/app` to `nextjs:nodejs`; `EXPOSE 8080`; `USER nextjs` before CMD
- **`docker/prod/Dockerfile`** — same chown + `EXPOSE 8080` + `USER nextjs` before CMD
- **`docker/compose.yml`** — port mapping and healthcheck updated to `:8080`
- **`scripts/deploy-production.sh`** — `-p "${HOST_PORT}:8080"`
- **`scripts/docker-health-check.sh`** — port updated to `:8080`
- **`.env.ci` / `.env.prod` / `.env.staging`** — `APP_INTERNAL_ORIGIN` updated to `:8080`
- **`scripts/server/docker-prod.env.example`** — `APP_INTERNAL_ORIGIN` updated
- **`docs/environment.md`**, **`docs/infrastructure.md`** — port updated in examples
- **`.kiro/specs/app-navigation-origins/`** — spec docs updated to reflect `:8080`

## Testing

- [ ] Build the CI image locally: `pnpm docker:build --env staging`
- [ ] Confirm container starts and nginx responds on `:8080`
- [ ] Confirm `docker exec <container> id` shows `nextjs`, not `root`
- [ ] CI E2E tests pass (uses `APP_INTERNAL_ORIGIN` to route inter-service calls)

---

Generated with [Claude Code](https://claude.com/claude-code)