### PR TITLE
fix(security): prevent template injection in sandbox-release workflow [GH-242]

### DIFF
--- a/.github/workflows/sandbox-release.yml
+++ b/.github/workflows/sandbox-release.yml
@@ -73,6 +73,8 @@ jobs:
           git log --oneline -1 "$COMMIT"
 
       - name: Update staging branch
+        env:
+          RESOLVED_COMMIT: ${{ steps.resolve.outputs.commit }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -81,21 +83,23 @@ jobs:
           if git rev-parse origin/staging >/dev/null 2>&1; then
             echo "Staging branch exists, updating..."
             git checkout staging
-            git reset --hard ${{ steps.resolve.outputs.commit }}
+            git reset --hard "$RESOLVED_COMMIT"
           else
             echo "Creating staging branch..."
-            git checkout -b staging ${{ steps.resolve.outputs.commit }}
+            git checkout -b staging "$RESOLVED_COMMIT"
           fi
 
           git push origin staging --force-with-lease
 
       - name: Summary
+        env:
+          RESOLVED_COMMIT: ${{ steps.resolve.outputs.commit }}
         run: |
           echo "## Sandbox Release Complete" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **Commit** | \`${{ steps.resolve.outputs.commit }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Commit** | \`${RESOLVED_COMMIT}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Checks** | Passed |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "The staging branch has been updated. The deploy workflow will automatically build and deploy the POC version." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Fixes the remaining GitHub Actions template injection finding from the Aikido security scan. The other findings reported in #242 were already resolved in prior commits on `develop` (PR #238 — path traversal in receipt storage + SQL injection in backup scripts, and preceding workflow hardening PRs).

This PR addresses the one genuine remaining injection vector: `sandbox-release.yml` used `${{ steps.resolve.outputs.commit }}` directly inside `run:` shell blocks, where the expression is expanded before the shell interprets it — a classic taint chain.

## Related Issue

Closes #242

## Changes

- **`.github/workflows/sandbox-release.yml`** — Move `${{ steps.resolve.outputs.commit }}` to `env: RESOLVED_COMMIT:` on both the `Update staging branch` step and the `Summary` step. Shell now references `$RESOLVED_COMMIT` instead of the direct template expression, eliminating the injection vector.

## Prior Fixes Already in `develop` (covered by this issue)

| Finding | File | Fixed In |
|---|---|---|
| Template injection | `pr-freshness.yml` | Previous commit on develop |
| Template injection | `sync-secrets.yml` | Previous commit on develop |
| Path traversal | `receiptStorage.ts`, `userReceiptQueries.ts` | PR #238 |
| SQL injection | `scripts/backup-prod.mjs` | PR #238 |
| `ci.yml` expressions | `ci.yml` | No fix needed — all values are trusted (booleans, SHA, repo slug) |

## Testing

- All 59 active E2E tests pass on this branch (`/e2e-eval dev headless`): 41 auth + 18 admin, 0 failures.
- 2 skipped tests are OAuth flows (Discord/Google) that always skip in dev — expected.

---

Generated with [Claude Code](https://claude.com/claude-code)