### PR TITLE
chore(backup): switch image compression from WebP to AVIF

### DIFF
--- a/scripts/backup-prod.mjs
+++ b/scripts/backup-prod.mjs
@@ -200,7 +200,7 @@ function* walkDir(dir) {
   }
 }
 
-async function compressImagesToWebP(storageDir) {
+async function compressImagesToAvif(storageDir) {
   let sharp;
   try {
     sharp = (await import("sharp")).default;
@@ -218,7 +218,7 @@ async function compressImagesToWebP(storageDir) {
     return;
   }
 
-  console.log(`  Compressing ${imageFiles.length} image(s) to WebP (quality 85)...`);
+  console.log(`  Compressing ${imageFiles.length} image(s) to AVIF (quality 85)...`);
   let compressed = 0;
   let skipped = 0;
   let savedBytes = 0;
@@ -229,7 +229,7 @@ async function compressImagesToWebP(storageDir) {
     process.stdout.write(`\r  [${i + 1}/${imageFiles.length}] ${basename(filePath).slice(0, 50)}...`);
     try {
       const input = readFileSync(filePath); // nosemgrep: AIK_ts_generic_path_traversal
-      const buf = await sharp(input).webp({ quality: 85 }).toBuffer();
+      const buf = await sharp(input).avif({ quality: 85 }).toBuffer();
       if (buf.length < originalSize) {
         writeFileSync(filePath, buf);
         savedBytes += originalSize - buf.length;
@@ -498,9 +498,9 @@ async function backup(pat, serviceKey) {
   }
   if (objects.length > 0) console.log(`\r  ✅ ${objects.length} files downloaded            `);
 
-  // ── Compress images to WebP ──
+  // ── Compress images to AVIF ──
   console.log("\n── Image compression ─────────────────────────");
-  await compressImagesToWebP(storageDir);
+  await compressImagesToAvif(storageDir);
 
   // ── Manifest ──
   writeFileSync(resolve(outDir, "manifest.json"), JSON.stringify(manifest, null, 2));


### PR DESCRIPTION
## Summary

- Replace WebP encoding with AVIF in the production backup script (`scripts/backup-prod.mjs`)
- Files on disk retain their original names — only the encoded bytes change
- AVIF typically achieves better compression ratios than WebP at equivalent quality settings

## Changes

- `compressImagesToWebP` → `compressImagesToAvif`
- `.webp({ quality: 85 })` → `.avif({ quality: 85 })`
- Updated log messages and inline comment to reflect AVIF

## Testing

- Script is exercised on the next scheduled backup run
- No functional change to backup/restore logic — only the image encoding format differs

---

Generated with [Claude Code](https://claude.com/claude-code)