### PR TITLE
chore(backup): lower AVIF compression quality to 30 for smaller backups

### DIFF
--- a/scripts/backup-prod.mjs
+++ b/scripts/backup-prod.mjs
@@ -218,7 +218,7 @@ async function compressImagesToAvif(storageDir) {
     return;
   }
 
-  console.log(`  Compressing ${imageFiles.length} image(s) to AVIF (quality 85)...`);
+  console.log(`  Compressing ${imageFiles.length} image(s) to AVIF (quality 30)...`);
   let compressed = 0;
   let skipped = 0;
   let savedBytes = 0;
@@ -229,7 +229,7 @@ async function compressImagesToAvif(storageDir) {
     process.stdout.write(`\r  [${i + 1}/${imageFiles.length}] ${basename(filePath).slice(0, 50)}...`);
     try {
       const input = readFileSync(filePath); // nosemgrep: AIK_ts_generic_path_traversal
-      const buf = await sharp(input).avif({ quality: 85 }).toBuffer();
+      const buf = await sharp(input).avif({ quality: 30 }).toBuffer();
       if (buf.length < originalSize) {
         writeFileSync(filePath, buf);
         savedBytes += originalSize - buf.length;


### PR DESCRIPTION
## Summary

- Lower AVIF image compression quality from 85 → 30 in the production backup script
- AVIF quality 85 was near-lossless, producing backup files heavier than the previous WebP output
- Quality 30 yields significantly smaller files while keeping receipt/bill text fully legible

## Changes

- `scripts/backup-prod.mjs`: `.avif({ quality: 85 })` → `.avif({ quality: 30 })` and updated log message

## Testing

Run backup and compare compressed image sizes against previous run.

---

Generated with [Claude Code](https://claude.com/claude-code)