### PR TITLE
fix(backup): suppress false-positive SAST finding in computeBackupHash [GH-258]

### DIFF
--- a/scripts/backup-prod.mjs
+++ b/scripts/backup-prod.mjs
@@ -430,7 +430,7 @@ function computeBackupHash(outDir) {
     const filePath = join(outDir, file); // nosemgrep: AIK_ts_generic_path_traversal
     assertPathInside(outDir, filePath);
     hash.update(file);
-    hash.update(readFileSync(filePath));
+    hash.update(readFileSync(filePath)); // nosemgrep: AIK_ts_generic_path_traversal
   }
   return hash.digest("hex");
 }


### PR DESCRIPTION
## Summary

Adds a `nosemgrep` suppression comment to silence a false-positive path traversal finding from the Aikido SAST scanner in `computeBackupHash`. No functional change.

## Related Issue

Closes #258

## Changes

- Add `// nosemgrep: AIK_ts_generic_path_traversal` to `readFileSync(filePath)` in `computeBackupHash`

## Why This Is Safe

The flagged call is already fully guarded:
1. `filePath = join(outDir, file)` — `outDir` is a controlled directory the script creates itself
2. `file` comes from `readdirSync(outDir).filter(f => f.endsWith('.json'))` — listing our own directory, not user input
3. `assertPathInside(outDir, filePath)` is called on the line immediately above, throwing if the path escapes

This matches the suppression pattern already used for 7+ other identical patterns in the same file.

---

Generated with [Claude Code](https://claude.com/claude-code)