### PR TITLE
fix(backup): exclude auto-updated timestamp columns from change-detection hash

### DIFF
--- a/scripts/backup-prod.mjs
+++ b/scripts/backup-prod.mjs
@@ -420,7 +420,16 @@ async function restoreTable(pat, serviceKey, table, rows) {
 
 // ─── Content hash ─────────────────────────────────────────────────────────────
 
-/** SHA-256 of all table JSON files in sorted order — captures any data change. */
+// Columns auto-managed by DB triggers that change on every user login or any row
+// touch.  Including them in the hash causes a false-positive upload every day even
+// when no real business data changed.  The backup ZIP still captures these columns
+// for restore purposes — they are only excluded from change detection.
+const HASH_EXCLUDED_COLS = new Set(["updated_at", "last_seen_at"]);
+
+/**
+ * SHA-256 of all table JSON files in sorted order — captures any data change,
+ * excluding system-managed timestamp columns that update on every user login.
+ */
 function computeBackupHash(outDir) {
   const hash = createHash("sha256");
   const files = readdirSync(outDir)
@@ -430,7 +439,13 @@ function computeBackupHash(outDir) {
     const filePath = join(outDir, file); // nosemgrep: AIK_ts_generic_path_traversal
     assertPathInside(outDir, filePath);
     hash.update(file);
-    hash.update(readFileSync(filePath)); // nosemgrep: AIK_ts_generic_path_traversal
+    const { table, rows } = JSON.parse(readFileSync(filePath, "utf-8")); // nosemgrep: AIK_ts_generic_path_traversal
+    const stableRows = rows.map((row) => {
+      const stable = { ...row };
+      for (const col of HASH_EXCLUDED_COLS) delete stable[col];
+      return stable;
+    });
+    hash.update(JSON.stringify({ table, rows: stableRows }));
   }
   return hash.digest("hex");
 }


### PR DESCRIPTION
## Summary

- `updated_at` and `last_seen_at` are auto-managed by DB triggers and refresh on every user login
- This caused the SHA-256 hash to differ on every daily run even when no real business data changed
- Result: Telegram backup uploaded every single day, regardless of whether anything actually changed

## Root Cause

`user_profiles.last_seen_at` is explicitly set to `now()` on every user login via an upsert trigger. Combined with the `trigger_set_updated_at` function that also updates `updated_at` when any row changes, these two columns cause the content hash to be different every day.

Multiple tables are affected: `user_profiles`, `products`, `product_templates`, `seller_payment_methods`, `seller_admins`.

## Fix

`computeBackupHash` now strips `updated_at` and `last_seen_at` before hashing. The backup ZIP **still captures all columns** for restore fidelity — only the change-detection comparison ignores these system-managed fields.

**Note:** The first run after this merge will upload once (the stored hash used the old computation method). Subsequent runs will correctly skip when no business data changed.

## Test plan

- [ ] Trigger manual backup workflow run → should upload (one-time hash reset)
- [ ] Trigger a second manual run immediately after → should detect **no changes** and skip upload