### PR TITLE
fix(backup): sanitize err.message before posting to Telegram [GH-260]

### DIFF
--- a/scripts/backup-prod.mjs
+++ b/scripts/backup-prod.mjs
@@ -721,11 +721,18 @@ try {
   const { TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, TELEGRAM_CRITICAL_THREAD_ID } = secrets;
   if (TELEGRAM_BOT_TOKEN && TELEGRAM_CHAT_ID && TELEGRAM_CRITICAL_THREAD_ID) {
     try {
+      // Sanitize before sending: strip bearer tokens and cap length so that
+      // raw API response bodies (which may include credentials or DB content)
+      // are never forwarded to Telegram.
+      const safeMsg = err.message
+        .replace(/Bearer\s+\S+/gi, "Bearer [REDACTED]")
+        .replace(/apikey[=:\s]+\S+/gi, "apikey=[REDACTED]")
+        .slice(0, 500);
       await sendTelegramMessage(
         TELEGRAM_BOT_TOKEN,
         TELEGRAM_CHAT_ID,
         TELEGRAM_CRITICAL_THREAD_ID,
-        `🚨 Prod backup FAILED\n\n${err.message}`,
+        `🚨 Prod backup FAILED\n\n${safeMsg}`,
       );
     } catch {
       // Swallow — don't mask the original error


### PR DESCRIPTION
## Summary

- Strip `Bearer <token>` and `apikey=<value>` patterns from the error message before posting to the critical Telegram channel
- Cap the message at 500 characters so full HTTP response bodies (504 HTML pages, Supabase JSON error payloads) cannot leak to Telegram

## Why

The critical notification was sending raw `err.message` which can include full API response bodies from Supabase — these may contain internal paths, partial credentials, or database error details. Identified during post-implementation SAST review.

## Test plan

- [ ] Trigger a backup failure (e.g. bad PAT) and confirm the Telegram message is capped and tokens are redacted
- [ ] Confirm normal backup flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)