### PR TITLE
chore(release): v2026.05.08.2 [GH-264]

### DIFF
--- a/docker/boot-reporter.mjs
+++ b/docker/boot-reporter.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * boot-reporter.mjs — In-container one-shot Telegram progress reporter.
+ *
+ * Managed by supervisord with autorestart=false and startretries=0.
+ * Runs exactly once per container start; exits 0 on success, 1 on timeout.
+ *
+ * Uptime gate: /proc/uptime is shared with the host kernel (same Linux kernel).
+ * - uptime < 120s → fresh OS boot → host boot-notifier.mjs owns the progress
+ *   message → this script exits 0 immediately to avoid double-editing.
+ * - uptime >= 120s → deploy restart → TELEGRAM_BOOT_MSG_ID was set by
+ *   deploy-production.sh → this script edits that message as ports open.
+ *
+ * If TELEGRAM_BOOT_MSG_ID is absent (old container, manual docker run, etc.)
+ * → exits 0 silently.
+ */
+
+import { createConnection } from 'net';
+import { readFileSync }     from 'fs';
+
+const BOOT_MSG_ID        = parseInt(process.env.TELEGRAM_BOOT_MSG_ID || '0') || 0;
+const BOT_TOKEN          = process.env.TELEGRAM_BOT_TOKEN || '';
+const CHAT_ID            = process.env.TELEGRAM_CHAT_ID || '';
+const CRITICAL_THREAD_ID = process.env.TELEGRAM_CRITICAL_THREAD_ID
+                        || process.env.TELEGRAM_THREAD_ID || '';
+
+if (!BOOT_MSG_ID) process.exit(0);
+
+try {
+  const uptime = parseFloat(readFileSync('/proc/uptime', 'utf8').split(' ')[0]);
+  if (uptime < 120) process.exit(0);
+} catch {}
+
+const APPS = [
+  { name: 'auth',       port: 5000 },
+  { name: 'store',      port: 5001 },
+  { name: 'admin',      port: 5002 },
+  { name: 'playground', port: 5003 },
+  { name: 'landing',    port: 5004 },
+  { name: 'payments',   port: 5005 },
+  { name: 'studio',     port: 5006 },
+];
+const NGINX_PORT = 8080;
+
+function checkPort(port) {
+  return new Promise(resolve => {
+    const s = createConnection({ port, host: '127.0.0.1', timeout: 2_000 });
+    s.on('connect', () => { s.destroy(); resolve(true); });
+    s.on('error',   () => resolve(false));
+    s.on('timeout', () => { s.destroy(); resolve(false); });
+  });
+}
+
+async function tgEdit(text) {
+  if (!BOT_TOKEN || !CHAT_ID || !BOOT_MSG_ID) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/editMessageText`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: CHAT_ID, message_id: BOOT_MSG_ID, text, parse_mode: 'HTML' }),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {}
+}
+
+async function tgCritical(text) {
+  if (!BOT_TOKEN || !CHAT_ID) return;
+  try {
+    const body = { chat_id: CHAT_ID, text, parse_mode: 'HTML' };
+    if (CRITICAL_THREAD_ID) body.message_thread_id = parseInt(CRITICAL_THREAD_ID);
+    await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {}
+}
+
+function progressBar(ready, total) {
+  const n = Math.round((ready / total) * 16);
+  return '█'.repeat(n) + '░'.repeat(16 - n);
+}
+
+function fmtElapsed(startTime) {
+  const s = Math.round((Date.now() - startTime) / 1000);
+  return s >= 60 ? `${Math.floor(s / 60)}m ${s % 60}s` : `${s}s`;
+}
+
+function formatProgress(appStatus, startTime) {
+  const ready   = appStatus.filter(a => a.readyAt !== null).length;
+  const total   = appStatus.length;
+  const pct     = Math.round((ready / total) * 100);
+  const dateStr = new Date().toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
+
+  const rows = appStatus.map(a => {
+    if (a.readyAt !== null) {
+      const s = Math.round((a.readyAt - startTime) / 1000);
+      return `  ✅ ${a.name.padEnd(12)}${s}s`;
+    }
+    return `  ⏳ ${a.name.padEnd(12)}...`;
+  });
+  rows.push(`  ⏳ ${'nginx'.padEnd(12)}waiting for all apps...`);
+
+  return [
+    `🔄 <b>Container Boot</b> — ${dateStr}`, '',
+    `Progress: ${ready}/${total}  ${progressBar(ready, total)}  ${pct}%`, '',
+    ...rows, '',
+    `Elapsed: ${fmtElapsed(startTime)}`,
+  ].join('\n');
+}
+
+async function main() {
+  const startTime = Date.now();
+  const appStatus = APPS.map(a => ({ ...a, readyAt: null }));
+  const deadline  = startTime + 120_000;
+
+  while (Date.now() < deadline) {
+    for (const app of appStatus) {
+      if (app.readyAt === null && await checkPort(app.port)) {
+        app.readyAt = Date.now();
+      }
+    }
+
+    if (appStatus.every(a => a.readyAt !== null)) {
+      const nginxOk = await checkPort(NGINX_PORT);
+      const dur = fmtElapsed(startTime);
+      await tgEdit(nginxOk
+        ? `✅ <b>All ${APPS.length} apps ready</b> — Boot in ${dur}\n   nginx up — traffic restored`
+        : `✅ <b>All ${APPS.length} apps ready</b> — Boot in ${dur}\n   ⚠️ nginx not yet up`
+      );
+      process.exit(0);
+    }
+
+    await tgEdit(formatProgress(appStatus, startTime));
+    await new Promise(r => setTimeout(r, 3_000));
+  }
+
+  const failed = appStatus.filter(a => a.readyAt === null).map(a => a.name).join(', ');
+  await tgCritical(
+    `❌ <b>${failed} failed to start after 120s</b>\n   Check: <code>docker logs candyshop-prod</code>`
+  );
+  process.exit(1);
+}
+
+main().catch(err => { console.error('[boot-reporter]', err.message); process.exit(1); });

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -44,6 +44,7 @@ COPY apps/studio/public               /app/studio/apps/studio/public
 COPY docker/prod/nginx.conf           /etc/nginx/nginx.conf
 COPY docker/prod/supervisord.conf     /etc/supervisor/conf.d/supervisord.conf
 COPY docker/watcher.mjs               /app/watcher.mjs
+COPY docker/boot-reporter.mjs         /app/boot-reporter.mjs
 
 # pnpm workspace linking creates stub node_modules inside each app directory
 # (package.json only, no dist/) that shadow the complete packages at the

--- a/docker/prod/supervisord.conf
+++ b/docker/prod/supervisord.conf
@@ -135,3 +135,17 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:boot-reporter]
+command=node /app/boot-reporter.mjs
+directory=/app
+user=nextjs
+autostart=true
+autorestart=false
+startretries=0
+startsecs=0
+exitcodes=0,1
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docs/superpowers/plans/2026-05-08-boot-progress-notifications.md
+++ b/docs/superpowers/plans/2026-05-08-boot-progress-notifications.md
@@ -1,0 +1,551 @@
+# Boot Progress Notifications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Send live-updating Telegram progress messages during container boot (deploy path) and OS server reboot (PM2 path), with new critical messages only for failures.
+
+**Architecture:** Two separate scripts handle OS reboot (host PM2 `boot-notifier.mjs`) and deploy-time boot (in-container supervisord `boot-reporter.mjs`). A `/proc/uptime` gate (shared kernel) prevents both from running simultaneously. The host creates the initial Telegram progress message, passes `TELEGRAM_BOOT_MSG_ID` to the container via `docker run -e`, and the container edits it as ports open.
+
+**Tech Stack:** Node.js ESM (fetch, net, fs — built-ins only), bash, supervisord, PM2
+
+---
+
+## Files
+
+| File                               | Change                                              |
+| ---------------------------------- | --------------------------------------------------- |
+| `scripts/server/boot-notifier.mjs` | CREATE — host-side OS boot detection + progress     |
+| `docker/boot-reporter.mjs`         | CREATE — in-container deploy boot progress          |
+| `docker/prod/supervisord.conf`     | MODIFY — add `[program:boot-reporter]`              |
+| `docker/prod/Dockerfile`           | MODIFY — COPY boot-reporter.mjs                     |
+| `scripts/deploy-production.sh`     | MODIFY — create message, pass MSG_ID, replace sleep |
+
+---
+
+### Task 1: `scripts/server/boot-notifier.mjs`
+
+**Files:**
+
+- Create: `scripts/server/boot-notifier.mjs`
+
+- [ ] **Step 1: Write the file**
+
+```javascript
+#!/usr/bin/env node
+/**
+ * boot-notifier.mjs — Host-side PM2 process for OS reboot detection.
+ * Sends a live-updating Telegram progress message when uptime < 120s.
+ * Goes idle (100s loop) when uptime >= 120s (deploy restart — container handles it).
+ */
+
+import { readFileSync } from "fs";
+
+const NGINX_PORT = process.env.WATCHER_NGINX_PORT || "9090";
+const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || "";
+const CHAT_ID = process.env.TELEGRAM_CHAT_ID || "";
+const THREAD_ID = process.env.TELEGRAM_THREAD_ID || "";
+const CRITICAL_THREAD_ID = process.env.TELEGRAM_CRITICAL_THREAD_ID || THREAD_ID;
+
+const APPS = [
+  { name: "auth", path: "/auth/health" },
+  { name: "store", path: "/store/health" },
+  { name: "admin", path: "/admin/health" },
+  { name: "playground", path: "/playground/health" },
+  { name: "landing", path: "/en" },
+  { name: "payments", path: "/payments/health" },
+  { name: "studio", path: "/studio/health" },
+];
+
+function readUptime() {
+  try {
+    return parseFloat(readFileSync("/proc/uptime", "utf8").split(" ")[0]);
+  } catch {
+    return 9999;
+  }
+}
+
+async function tgPost(text, threadId) {
+  if (!BOT_TOKEN || !CHAT_ID) return null;
+  try {
+    const body = { chat_id: CHAT_ID, text, parse_mode: "HTML" };
+    if (threadId) body.message_thread_id = parseInt(threadId);
+    const res = await fetch(
+      `https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+    const d = await res.json();
+    return d.ok ? d.result.message_id : null;
+  } catch {
+    return null;
+  }
+}
+
+async function tgEdit(msgId, text) {
+  if (!BOT_TOKEN || !CHAT_ID || !msgId) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/editMessageText`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: CHAT_ID,
+        message_id: msgId,
+        text,
+        parse_mode: "HTML",
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {}
+}
+
+async function checkHealth(path) {
+  try {
+    const res = await fetch(`http://127.0.0.1:${NGINX_PORT}${path}`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+function bar(ready, total) {
+  const n = Math.round((ready / total) * 16);
+  return "█".repeat(n) + "░".repeat(16 - n);
+}
+
+function elapsed(startTime) {
+  const s = Math.round((Date.now() - startTime) / 1000);
+  return s >= 60 ? `${Math.floor(s / 60)}m ${s % 60}s` : `${s}s`;
+}
+
+function formatProgress(appStatus, startTime, label) {
+  const ready = appStatus.filter((a) => a.readyAt !== null).length;
+  const total = appStatus.length;
+  const pct = Math.round((ready / total) * 100);
+  const dateStr =
+    new Date().toISOString().replace("T", " ").slice(0, 16) + " UTC";
+
+  const rows = appStatus.map((a) => {
+    if (a.readyAt !== null) {
+      const s = Math.round((a.readyAt - startTime) / 1000);
+      return `  ✅ ${a.name.padEnd(12)}${s}s`;
+    }
+    return `  ⏳ ${a.name.padEnd(12)}...`;
+  });
+  rows.push(`  ⏳ ${"nginx".padEnd(12)}waiting for all apps...`);
+
+  return [
+    `🔄 <b>${label}</b> — ${dateStr}`,
+    "",
+    `Progress: ${ready}/${total}  ${bar(ready, total)}  ${pct}%`,
+    "",
+    ...rows,
+    "",
+    `Elapsed: ${elapsed(startTime)}`,
+  ].join("\n");
+}
+
+async function runBootSequence(label) {
+  const startTime = Date.now();
+  const appStatus = APPS.map((a) => ({ ...a, readyAt: null }));
+
+  const msgId = await tgPost(
+    formatProgress(appStatus, startTime, label),
+    THREAD_ID,
+  );
+
+  const deadline = startTime + 180_000;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 5_000));
+
+    for (const app of appStatus) {
+      if (app.readyAt === null && (await checkHealth(app.path))) {
+        app.readyAt = Date.now();
+      }
+    }
+
+    if (appStatus.every((a) => a.readyAt !== null)) {
+      const dur = elapsed(startTime);
+      await tgEdit(
+        msgId,
+        `✅ <b>All ${APPS.length} apps ready</b> — Boot in ${dur}\n   nginx up — traffic restored`,
+      );
+      return;
+    }
+
+    await tgEdit(msgId, formatProgress(appStatus, startTime, label));
+  }
+
+  const failed = appStatus
+    .filter((a) => a.readyAt === null)
+    .map((a) => a.name)
+    .join(", ");
+  await tgPost(
+    `❌ <b>${failed} failed to start after 180s</b>\n   Check: <code>docker logs candyshop-prod</code>`,
+    CRITICAL_THREAD_ID,
+  );
+}
+
+async function main() {
+  if (readUptime() >= 120) {
+    while (true) await new Promise((r) => setTimeout(r, 100_000));
+  }
+  await runBootSequence("Server Boot");
+  while (true) await new Promise((r) => setTimeout(r, 100_000));
+}
+
+main().catch((err) => {
+  console.error("[boot-notifier]", err.message);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/server/boot-notifier.mjs
+git commit -m "feat(infra): add boot-notifier host-side PM2 process [GH-264]"
+```
+
+---
+
+### Task 2: `docker/boot-reporter.mjs`
+
+**Files:**
+
+- Create: `docker/boot-reporter.mjs`
+
+- [ ] **Step 1: Write the file**
+
+```javascript
+#!/usr/bin/env node
+/**
+ * boot-reporter.mjs — In-container one-shot progress reporter.
+ * Managed by supervisord (autorestart=false, startretries=0).
+ *
+ * Uptime gate: /proc/uptime is shared with the host kernel.
+ * If uptime < 120s → OS boot → host boot-notifier.mjs handles it → exit 0.
+ * If TELEGRAM_BOOT_MSG_ID is unset → non-deploy start → exit 0.
+ */
+
+import { createConnection } from "net";
+import { readFileSync } from "fs";
+
+const BOOT_MSG_ID = parseInt(process.env.TELEGRAM_BOOT_MSG_ID || "0") || 0;
+const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || "";
+const CHAT_ID = process.env.TELEGRAM_CHAT_ID || "";
+const CRITICAL_THREAD_ID =
+  process.env.TELEGRAM_CRITICAL_THREAD_ID ||
+  process.env.TELEGRAM_THREAD_ID ||
+  "";
+
+if (!BOOT_MSG_ID) process.exit(0);
+
+try {
+  const uptime = parseFloat(readFileSync("/proc/uptime", "utf8").split(" ")[0]);
+  if (uptime < 120) process.exit(0);
+} catch {}
+
+const APPS = [
+  { name: "auth", port: 5000 },
+  { name: "store", port: 5001 },
+  { name: "admin", port: 5002 },
+  { name: "playground", port: 5003 },
+  { name: "landing", port: 5004 },
+  { name: "payments", port: 5005 },
+  { name: "studio", port: 5006 },
+];
+const NGINX_PORT = 8080;
+
+function checkPort(port) {
+  return new Promise((resolve) => {
+    const s = createConnection({ port, host: "127.0.0.1", timeout: 2_000 });
+    s.on("connect", () => {
+      s.destroy();
+      resolve(true);
+    });
+    s.on("error", () => resolve(false));
+    s.on("timeout", () => {
+      s.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function tgEdit(text) {
+  if (!BOT_TOKEN || !CHAT_ID || !BOOT_MSG_ID) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/editMessageText`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: CHAT_ID,
+        message_id: BOOT_MSG_ID,
+        text,
+        parse_mode: "HTML",
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {}
+}
+
+async function tgCritical(text) {
+  if (!BOT_TOKEN || !CHAT_ID) return;
+  try {
+    const body = { chat_id: CHAT_ID, text, parse_mode: "HTML" };
+    if (CRITICAL_THREAD_ID)
+      body.message_thread_id = parseInt(CRITICAL_THREAD_ID);
+    await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {}
+}
+
+function bar(ready, total) {
+  const n = Math.round((ready / total) * 16);
+  return "█".repeat(n) + "░".repeat(16 - n);
+}
+
+function elapsed(startTime) {
+  const s = Math.round((Date.now() - startTime) / 1000);
+  return s >= 60 ? `${Math.floor(s / 60)}m ${s % 60}s` : `${s}s`;
+}
+
+function formatProgress(appStatus, startTime) {
+  const ready = appStatus.filter((a) => a.readyAt !== null).length;
+  const total = appStatus.length;
+  const pct = Math.round((ready / total) * 100);
+  const dateStr =
+    new Date().toISOString().replace("T", " ").slice(0, 16) + " UTC";
+
+  const rows = appStatus.map((a) => {
+    if (a.readyAt !== null) {
+      const s = Math.round((a.readyAt - startTime) / 1000);
+      return `  ✅ ${a.name.padEnd(12)}${s}s`;
+    }
+    return `  ⏳ ${a.name.padEnd(12)}...`;
+  });
+  rows.push(`  ⏳ ${"nginx".padEnd(12)}waiting for all apps...`);
+
+  return [
+    `🔄 <b>Container Boot</b> — ${dateStr}`,
+    "",
+    `Progress: ${ready}/${total}  ${bar(ready, total)}  ${pct}%`,
+    "",
+    ...rows,
+    "",
+    `Elapsed: ${elapsed(startTime)}`,
+  ].join("\n");
+}
+
+async function main() {
+  const startTime = Date.now();
+  const appStatus = APPS.map((a) => ({ ...a, readyAt: null }));
+
+  const deadline = startTime + 120_000;
+
+  while (Date.now() < deadline) {
+    for (const app of appStatus) {
+      if (app.readyAt === null && (await checkPort(app.port))) {
+        app.readyAt = Date.now();
+      }
+    }
+
+    if (appStatus.every((a) => a.readyAt !== null)) {
+      const nginxOk = await checkPort(NGINX_PORT);
+      const dur = elapsed(startTime);
+      await tgEdit(
+        nginxOk
+          ? `✅ <b>All ${APPS.length} apps ready</b> — Boot in ${dur}\n   nginx up — traffic restored`
+          : `✅ <b>All ${APPS.length} apps ready</b> — Boot in ${dur}\n   ⚠️ nginx not yet up`,
+      );
+      process.exit(0);
+    }
+
+    await tgEdit(formatProgress(appStatus, startTime));
+    await new Promise((r) => setTimeout(r, 3_000));
+  }
+
+  const failed = appStatus
+    .filter((a) => a.readyAt === null)
+    .map((a) => a.name)
+    .join(", ");
+  await tgCritical(
+    `❌ <b>${failed} failed to start after 120s</b>\n   Check: <code>docker logs candyshop-prod</code>`,
+  );
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("[boot-reporter]", err.message);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docker/boot-reporter.mjs
+git commit -m "feat(infra): add boot-reporter in-container one-shot progress reporter [GH-264]"
+```
+
+---
+
+### Task 3: `docker/prod/supervisord.conf` + `Dockerfile`
+
+**Files:**
+
+- Modify: `docker/prod/supervisord.conf`
+- Modify: `docker/prod/Dockerfile`
+
+- [ ] **Step 1: Add `[program:boot-reporter]` to supervisord.conf**
+
+After the `[program:watcher]` stanza, append:
+
+```ini
+[program:boot-reporter]
+command=node /app/boot-reporter.mjs
+directory=/app
+user=nextjs
+autostart=true
+autorestart=false
+startretries=0
+startsecs=0
+exitcodes=0,1
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+```
+
+- [ ] **Step 2: Add COPY to Dockerfile**
+
+After `COPY docker/watcher.mjs /app/watcher.mjs`, add:
+
+```dockerfile
+COPY docker/boot-reporter.mjs               /app/boot-reporter.mjs
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/prod/supervisord.conf docker/prod/Dockerfile
+git commit -m "feat(infra): wire boot-reporter into supervisord and Dockerfile [GH-264]"
+```
+
+---
+
+### Task 4: `scripts/deploy-production.sh`
+
+**Files:**
+
+- Modify: `scripts/deploy-production.sh`
+
+- [ ] **Step 1: Create initial progress message before docker rm**
+
+Add before the `docker rm -f` line:
+
+```bash
+# Create boot progress message; container edits it via TELEGRAM_BOOT_MSG_ID
+_BOOT_MSG_ID=""
+if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+  _boot_now=$(python3 -c "from datetime import datetime,timezone; print(datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC'))" 2>/dev/null || true)
+  _BOOT_RESP=$(python3 -c "
+import json, urllib.request
+text = (
+  '🔄 <b>Container Boot</b> — $_boot_now\n\n'
+  'Progress: 0/7  ░░░░░░░░░░░░░░░░  0%\n\n'
+  '  ⏳ auth         ...\n'
+  '  ⏳ store        ...\n'
+  '  ⏳ admin        ...\n'
+  '  ⏳ playground   ...\n'
+  '  ⏳ landing      ...\n'
+  '  ⏳ payments     ...\n'
+  '  ⏳ studio       ...\n'
+  '  ⏳ nginx        waiting for all apps...\n\n'
+  'Elapsed: 0s'
+)
+payload = {'chat_id': '${TELEGRAM_CHAT_ID}', 'text': text, 'parse_mode': 'HTML'}
+thread = '${TELEGRAM_THREAD_ID:-}'
+if thread:
+    payload['message_thread_id'] = int(thread)
+data = json.dumps(payload).encode()
+req = urllib.request.Request(
+    'https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage',
+    data=data, headers={'Content-Type': 'application/json'}, method='POST')
+try:
+    with urllib.request.urlopen(req, timeout=10) as r:
+        resp = json.loads(r.read())
+        if resp.get('ok'):
+            print(resp['result']['message_id'])
+except Exception:
+    pass
+" 2>/dev/null || true)
+  _BOOT_MSG_ID="${_BOOT_RESP:-}"
+fi
+```
+
+- [ ] **Step 2: Add TELEGRAM_BOOT_MSG_ID to docker run**
+
+Add `-e "TELEGRAM_BOOT_MSG_ID=${_BOOT_MSG_ID:-}" \` after the existing `-e` flags.
+
+- [ ] **Step 3: Remove redundant "Container restarted" notification**
+
+Delete the `notify_telegram "$(printf '🔄 <b>Container restarted</b>..."` line — the progress message covers this.
+
+- [ ] **Step 4: Add boot-notifier PM2 start before pm2 save**
+
+After `pm2 start candyshop-watcher` and before `pm2 save`:
+
+```bash
+pm2 delete candyshop-boot-notifier 2>/dev/null || true
+WATCHER_NGINX_PORT=$HOST_PORT pm2 start "$DEPLOY_DIR/scripts/server/boot-notifier.mjs" \
+  --name candyshop-boot-notifier
+```
+
+- [ ] **Step 5: Move APPS definition before sleep 60 and replace sleep with poll loop**
+
+Move `APPS=(...)` before `sleep 60`, then replace `sleep 60` with:
+
+```bash
+log "Waiting for container health endpoints..."
+_POLL_START=$(date +%s)
+while [ $(( $(date +%s) - _POLL_START )) -lt 120 ]; do
+  _HEALTHY_COUNT=0
+  for APP_ENTRY in "${APPS[@]}"; do
+    APP_HEALTH="${APP_ENTRY#*:}"
+    curl -sf --max-time 5 "http://localhost:${HOST_PORT}${APP_HEALTH}" >/dev/null 2>&1 && \
+      _HEALTHY_COUNT=$(( _HEALTHY_COUNT + 1 ))
+  done
+  [ "$_HEALTHY_COUNT" -eq "${#APPS[@]}" ] && break
+  sleep 5
+done
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/deploy-production.sh
+git commit -m "feat(infra): integrate boot progress into deploy script [GH-264]"
+```
+
+---
+
+## Testing
+
+Manual verification only (infra-only change):
+
+1. Trigger a deploy and observe Telegram messages updating in real time.
+2. Verify the progress message starts at 0/7 and advances as apps come up.
+3. Verify the final message shows "All 7 apps ready — nginx up".
+4. OS reboot: `sudo reboot`, observe separate boot notification sequence from host.
+
+No automated tests required — no application code touched.

--- a/docs/superpowers/specs/2026-05-08-boot-progress-notifications-design.md
+++ b/docs/superpowers/specs/2026-05-08-boot-progress-notifications-design.md
@@ -1,0 +1,284 @@
+# Boot Progress Notifications — Design Spec
+
+**Issue:** GH-264
+**Date:** 2026-05-08
+**Status:** Approved
+
+## Problem
+
+During the v2026.05.08.1 deployment the store returned 502 Bad Gateway while the container
+was still booting. There was no visibility into which apps were up, which were still starting,
+or how long to expect. Operators had no signal except to wait and refresh.
+
+---
+
+## Goals
+
+1. Send a live-updating Telegram progress message during container boot (deploy path).
+2. Send a live-updating Telegram progress message during OS server reboot (host PM2 path).
+3. New critical messages only for failures — not for every stage (hybrid approach).
+4. Full unattended delivery: no manual steps required after merging to main.
+
+---
+
+## Architecture
+
+Two boot paths are handled independently to avoid overlap and stale-message edits.
+
+```
+OS Reboot
+  systemd → PM2 → boot-notifier.mjs (host)
+                    │
+                    ├── creates Telegram progress message
+                    └── polls health endpoints every 5s, edits message live
+
+Deploy (docker run)
+  deploy-production.sh
+    ├── creates Telegram progress message → captures message_id
+    ├── passes TELEGRAM_BOOT_MSG_ID=<id> to docker run
+    └── replaces sleep 60 with active poll loop
+
+  container (supervisord)
+    └── boot-reporter.mjs [program:boot-reporter]
+          ├── checks TELEGRAM_BOOT_MSG_ID + /proc/uptime
+          ├── if uptime < 120s → OS boot → skip (host handles it)
+          └── else → deploy boot → polls each port every 3s, edits message
+```
+
+### Key invariant: uptime gate
+
+`/proc/uptime` is shared between host and container (same kernel). If the container's
+uptime reading is < 120 seconds, the server just rebooted — the host `boot-notifier.mjs`
+is already managing the progress message. `boot-reporter.mjs` exits immediately to avoid
+double-editing.
+
+If uptime ≥ 120 seconds, it is a deploy restart. `TELEGRAM_BOOT_MSG_ID` is fresh and
+`boot-reporter.mjs` owns the message edits.
+
+---
+
+## Telegram Message Format
+
+### Live-edited progress message
+
+```
+🔄 Container Boot — 2026-05-08 03:45 UTC
+
+Progress: 4/7  ████████████░░░░  57%
+
+  ✅ auth         8s
+  ✅ store        12s
+  ✅ payments     15s
+  ✅ admin        18s
+  ⏳ landing      ...
+  ⏳ studio       ...
+  ⏳ playground   ...
+  ⏳ nginx        waiting for all apps...
+
+Elapsed: 21s
+```
+
+### Final edit (all healthy)
+
+```
+✅ All 7 apps ready — Boot in 1m 34s
+   nginx up — traffic restored
+```
+
+### Failure (new critical message, not an edit)
+
+```
+❌ studio failed to start after 120s
+   Check: docker logs candyshop-prod
+```
+
+Progress bar uses Unicode block characters: `█` (filled) and `░` (empty), 16 chars wide.
+
+---
+
+## Files
+
+| File                               | Change   | Responsibility                                         |
+| ---------------------------------- | -------- | ------------------------------------------------------ |
+| `scripts/server/boot-notifier.mjs` | NEW      | OS reboot detection + host-side progress               |
+| `docker/boot-reporter.mjs`         | NEW      | In-container per-port progress signaling               |
+| `docker/prod/supervisord.conf`     | MODIFIED | Add `[program:boot-reporter]`                          |
+| `docker/prod/Dockerfile`           | MODIFIED | `COPY docker/boot-reporter.mjs /app/boot-reporter.mjs` |
+| `scripts/deploy-production.sh`     | MODIFIED | Create message, pass MSG_ID, replace sleep             |
+
+---
+
+## Component Specs
+
+### 1. `scripts/server/boot-notifier.mjs`
+
+**Runtime:** Node.js, managed by PM2 on the host.
+**Started by:** `pm2 start` in deploy-production.sh (same as watcher), persisted by `pm2 save`.
+**Telegram credentials:** inherited from PM2 environment (set during deploy, persisted by `pm2 save`).
+
+**Behavior on startup:**
+
+1. Read `/proc/uptime`. If uptime ≥ 120s → not a fresh boot → idle loop, no notification.
+2. If uptime < 120s → OS boot detected.
+3. Send initial Telegram progress message → store `message_id`.
+4. Poll loop (every 5s, max 180s):
+   - For each of the 7 apps: `fetch http://127.0.0.1:${NGINX_PORT}/<health-path>` with 5s timeout.
+   - Track first-seen timestamps per app.
+   - Edit Telegram message with updated progress bar and per-app status.
+5. When all 7 apps healthy: final edit "✅ All 7 apps ready", stop polling.
+6. If any app not healthy after 180s: new critical message listing failed apps, stop polling.
+7. Enter idle loop (100s interval no-op) so PM2 doesn't restart it as a crash.
+
+**Environment variables required (same as watcher):**
+
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_CHAT_ID`
+- `TELEGRAM_THREAD_ID`
+- `TELEGRAM_CRITICAL_THREAD_ID`
+- `WATCHER_NGINX_PORT` (same as watcher, set by deploy-production.sh)
+
+**deploy-production.sh additions:**
+
+```bash
+pm2 delete candyshop-boot-notifier 2>/dev/null || true
+WATCHER_NGINX_PORT=$HOST_PORT pm2 start "$DEPLOY_DIR/scripts/server/boot-notifier.mjs" \
+  --name candyshop-boot-notifier
+pm2 save
+```
+
+### 2. `docker/boot-reporter.mjs`
+
+**Runtime:** Node.js, inside container, managed by supervisord.
+**Started by:** supervisord as `[program:boot-reporter]` with `autorestart=false`.
+**Telegram credentials:** passed via `docker run -e` (already done for TOKEN, CHAT_ID, THREAD_ID).
+**New env var:** `TELEGRAM_BOOT_MSG_ID` — the Telegram message ID to edit.
+
+**Behavior:**
+
+1. Read `TELEGRAM_BOOT_MSG_ID`. If not set → exit 0 (no-op, old container or non-deploy start).
+2. Read `/proc/uptime`. If < 120s → OS boot → exit 0 (host handles it).
+3. Record `startTime = Date.now()`.
+4. Poll loop (every 3s, max 120s):
+   - For each of the 7 apps: check if port is listening using Node.js `net.createConnection`.
+   - Track first-seen timestamps per app.
+   - Call `editMessageText` on `TELEGRAM_BOOT_MSG_ID` with updated progress bar.
+5. When all 7 ports open: final edit including nginx port (8080) check, then exit 0.
+6. If any port not open after 120s: send new critical message, exit 1.
+
+**Ports checked:**
+
+- auth: 5000, store: 5001, admin: 5002, playground: 5003, landing: 5004, payments: 5005, studio: 5006, nginx: 8080
+
+**supervisord entry:**
+
+```ini
+[program:boot-reporter]
+command=node /app/boot-reporter.mjs
+directory=/app
+user=nextjs
+autostart=true
+autorestart=false
+startretries=0
+startsecs=0
+exitcodes=0,1
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+```
+
+`autorestart=false` and `startretries=0`: this is a one-shot script, not a daemon.
+
+### 3. `scripts/deploy-production.sh` changes
+
+**Before `docker rm -f` / `docker run`:**
+
+```bash
+# Create boot progress message; capture message_id for container to edit
+_BOOT_MSG_ID=$(python3 -c "..." send initial message, parse response.result.message_id)
+```
+
+**In `docker run`:**
+
+```bash
+docker run -d \
+  ...existing -e flags...
+  -e "TELEGRAM_BOOT_MSG_ID=${_BOOT_MSG_ID:-}" \
+  "$IMAGE_TAG"
+```
+
+**Replace `sleep 60`:**
+
+```bash
+# Poll health endpoints instead of blind sleep (max 120s)
+log "Waiting for container health endpoints..."
+_POLL_START=$(date +%s)
+_ALL_HEALTHY=0
+while [ $(( $(date +%s) - _POLL_START )) -lt 120 ]; do
+  _HEALTHY_COUNT=0
+  for APP_ENTRY in "${APPS[@]}"; do
+    APP_HEALTH="${APP_ENTRY#*:}"
+    curl -sf --max-time 5 "http://localhost:${HOST_PORT}${APP_HEALTH}" >/dev/null 2>&1 && \
+      _HEALTHY_COUNT=$(( _HEALTHY_COUNT + 1 ))
+  done
+  if [ "$_HEALTHY_COUNT" -eq "${#APPS[@]}" ]; then
+    _ALL_HEALTHY=1
+    break
+  fi
+  sleep 5
+done
+```
+
+The existing phase-1 liveness check and phase-2 JIT warm-up remain unchanged after this loop.
+
+---
+
+## Prerequisites
+
+### PM2 startup (one-time server setup)
+
+`boot-notifier.mjs` relies on PM2 being configured as a systemd service so it restarts on
+OS reboot. Check and configure if needed:
+
+```bash
+# On the server — check
+systemctl status pm2-furrycolombia
+
+# If NOT configured, run once:
+pm2 startup   # generates and prints a systemd command
+# Then run the printed command as root
+```
+
+This is a manual prerequisite that must be verified before the feature can work for OS reboots.
+The implementation plan includes a verification step in the deploy script that warns via
+Telegram if PM2 startup is not active.
+
+---
+
+## Error Handling
+
+| Scenario                                    | Behavior                                                                         |
+| ------------------------------------------- | -------------------------------------------------------------------------------- |
+| `TELEGRAM_BOT_TOKEN` missing                | All notifiers silently skip Telegram calls (no crash)                            |
+| `editMessageText` fails (throttle, network) | Log warning, continue polling — next edit attempt in 3–5s                        |
+| App never comes up (deploy, 120s)           | New critical Telegram message; deploy script still runs health check and reports |
+| App never comes up (OS boot, 180s)          | New critical Telegram message; boot-notifier goes idle                           |
+| `TELEGRAM_BOOT_MSG_ID` not set              | boot-reporter exits 0 silently                                                   |
+| uptime < 120s in container                  | boot-reporter exits 0, host handles it                                           |
+
+---
+
+## Testing
+
+- Manual: trigger a deploy and observe Telegram messages updating in real time.
+- Manual: SSH into server, `sudo reboot`, observe OS boot notification sequence.
+- No automated tests required for this infra-only change (no application code touched).
+
+---
+
+## Non-goals
+
+- No changes to application code or API routes.
+- No changes to the Docker health endpoints (`/health`).
+- No changes to `docker/watcher.mjs` (existing health watcher remains unchanged).
+- `boot-notifier.mjs` does not replace `watcher.mjs` — they serve different purposes.

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -205,6 +205,45 @@ notify_telegram "$(printf '🐳 <b>Image built</b> (%s)\n<code>%s</code>' "$(_du
 # =============================================================================
 log "Restarting container '$CONTAINER_NAME'..."
 _STEP_START=$(date +%s)
+
+# Create boot progress message; container edits it live via TELEGRAM_BOOT_MSG_ID
+_BOOT_MSG_ID=""
+if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+  _boot_now=$(python3 -c "from datetime import datetime,timezone; print(datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC'))" 2>/dev/null || true)
+  _BOOT_RESP=$(python3 -c "
+import json, urllib.request
+text = (
+  '\U0001f504 <b>Container Boot</b> — $_boot_now\n\n'
+  'Progress: 0/7  ░░░░░░░░░░░░░░░░  0%\n\n'
+  '  ⏳ auth         ...\n'
+  '  ⏳ store        ...\n'
+  '  ⏳ admin        ...\n'
+  '  ⏳ playground   ...\n'
+  '  ⏳ landing      ...\n'
+  '  ⏳ payments     ...\n'
+  '  ⏳ studio       ...\n'
+  '  ⏳ nginx        waiting for all apps...\n\n'
+  'Elapsed: 0s'
+)
+payload = {'chat_id': '${TELEGRAM_CHAT_ID}', 'text': text, 'parse_mode': 'HTML'}
+thread = '${TELEGRAM_THREAD_ID:-}'
+if thread:
+    payload['message_thread_id'] = int(thread)
+data = json.dumps(payload).encode()
+req = urllib.request.Request(
+    'https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage',
+    data=data, headers={'Content-Type': 'application/json'}, method='POST')
+try:
+    with urllib.request.urlopen(req, timeout=10) as r:
+        resp = json.loads(r.read())
+        if resp.get('ok'):
+            print(resp['result']['message_id'])
+except Exception:
+    pass
+" 2>/dev/null || true)
+  _BOOT_MSG_ID="${_BOOT_RESP:-}"
+fi
+
 docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
 docker run -d \
   --name "$CONTAINER_NAME" \
@@ -215,6 +254,7 @@ docker run -d \
   -e "TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-}" \
   -e "TELEGRAM_THREAD_ID=${TELEGRAM_THREAD_ID:-}" \
   -e "TELEGRAM_CRITICAL_THREAD_ID=${TELEGRAM_CRITICAL_THREAD_ID:-}" \
+  -e "TELEGRAM_BOOT_MSG_ID=${_BOOT_MSG_ID:-}" \
   "$IMAGE_TAG" \
   || err "Docker container start failed"
 
@@ -226,8 +266,6 @@ docker images --format '{{.Repository}}:{{.Tag}}' \
   | sort -r \
   | tail -n +3 \
   | xargs -r docker rmi 2>/dev/null || true
-
-notify_telegram "$(printf '🔄 <b>Container restarted</b> (%s)' "$(_dur $_STEP_START)")"
 
 # Clean up env file — secrets must not persist on disk
 rm -f "$ENV_FILE"
@@ -243,7 +281,11 @@ pm2 delete candyshop-watcher 2>/dev/null || true
 WATCHER_NGINX_PORT=$HOST_PORT pm2 start "$DEPLOY_DIR/docker/watcher.mjs" \
   --name candyshop-watcher
 
-# Persist watcher across reboots
+pm2 delete candyshop-boot-notifier 2>/dev/null || true
+WATCHER_NGINX_PORT=$HOST_PORT pm2 start "$DEPLOY_DIR/scripts/server/boot-notifier.mjs" \
+  --name candyshop-boot-notifier
+
+# Persist both processes across reboots
 pm2 save
 
 # =============================================================================
@@ -252,9 +294,6 @@ pm2 save
 # compilation penalty on every route. We hit each app's key localized pages
 # 3 times so V8 JIT-compiles the hot paths before real traffic arrives.
 # =============================================================================
-log "Waiting for container to be ready..."
-sleep 60
-
 APPS=(
   "store:/store/health"
   "auth:/auth/health"
@@ -264,6 +303,19 @@ APPS=(
   "payments:/payments/health"
   "studio:/studio/health"
 )
+
+log "Waiting for container health endpoints..."
+_POLL_START=$(date +%s)
+while [ $(( $(date +%s) - _POLL_START )) -lt 120 ]; do
+  _HEALTHY_COUNT=0
+  for APP_ENTRY in "${APPS[@]}"; do
+    APP_HEALTH="${APP_ENTRY#*:}"
+    curl -sf --max-time 5 "http://localhost:${HOST_PORT}${APP_HEALTH}" >/dev/null 2>&1 && \
+      _HEALTHY_COUNT=$(( _HEALTHY_COUNT + 1 ))
+  done
+  [ "$_HEALTHY_COUNT" -eq "${#APPS[@]}" ] && break
+  sleep 5
+done
 
 # --- phase 1: liveness check ---
 FAILED=0

--- a/scripts/server/boot-notifier.mjs
+++ b/scripts/server/boot-notifier.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * boot-notifier.mjs — Host-side PM2 process for OS reboot detection.
+ *
+ * Sends a live-updating Telegram progress message when the server reboots.
+ * Uses /proc/uptime to distinguish OS boot (< 120s) from a deploy restart
+ * (>= 120s). On deploy restarts, the container's boot-reporter.mjs handles
+ * Telegram updates; this script simply idles to avoid double-editing.
+ *
+ * Managed by PM2. Added to pm2 save so it restores on OS boot automatically.
+ * Environment: inherited from PM2 (WATCHER_NGINX_PORT set by deploy-production.sh).
+ */
+
+import { readFileSync } from 'fs';
+
+const NGINX_PORT         = process.env.WATCHER_NGINX_PORT || '9090';
+const BOT_TOKEN          = process.env.TELEGRAM_BOT_TOKEN || '';
+const CHAT_ID            = process.env.TELEGRAM_CHAT_ID || '';
+const THREAD_ID          = process.env.TELEGRAM_THREAD_ID || '';
+const CRITICAL_THREAD_ID = process.env.TELEGRAM_CRITICAL_THREAD_ID || THREAD_ID;
+
+const APPS = [
+  { name: 'auth',       path: '/auth/health' },
+  { name: 'store',      path: '/store/health' },
+  { name: 'admin',      path: '/admin/health' },
+  { name: 'playground', path: '/playground/health' },
+  { name: 'landing',    path: '/en' },
+  { name: 'payments',   path: '/payments/health' },
+  { name: 'studio',     path: '/studio/health' },
+];
+
+function readUptime() {
+  try { return parseFloat(readFileSync('/proc/uptime', 'utf8').split(' ')[0]); }
+  catch { return 9999; }
+}
+
+async function tgPost(text, threadId) {
+  if (!BOT_TOKEN || !CHAT_ID) return null;
+  try {
+    const body = { chat_id: CHAT_ID, text, parse_mode: 'HTML' };
+    if (threadId) body.message_thread_id = parseInt(threadId);
+    const res = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+    const d = await res.json();
+    return d.ok ? d.result.message_id : null;
+  } catch { return null; }
+}
+
+async function tgEdit(msgId, text) {
+  if (!BOT_TOKEN || !CHAT_ID || !msgId) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/editMessageText`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: CHAT_ID, message_id: msgId, text, parse_mode: 'HTML' }),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {}
+}
+
+async function checkHealth(path) {
+  try {
+    const res = await fetch(`http://127.0.0.1:${NGINX_PORT}${path}`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    return res.ok;
+  } catch { return false; }
+}
+
+function progressBar(ready, total) {
+  const n = Math.round((ready / total) * 16);
+  return '█'.repeat(n) + '░'.repeat(16 - n);
+}
+
+function fmtElapsed(startTime) {
+  const s = Math.round((Date.now() - startTime) / 1000);
+  return s >= 60 ? `${Math.floor(s / 60)}m ${s % 60}s` : `${s}s`;
+}
+
+function formatProgress(appStatus, startTime, label) {
+  const ready   = appStatus.filter(a => a.readyAt !== null).length;
+  const total   = appStatus.length;
+  const pct     = Math.round((ready / total) * 100);
+  const dateStr = new Date().toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
+
+  const rows = appStatus.map(a => {
+    if (a.readyAt !== null) {
+      const s = Math.round((a.readyAt - startTime) / 1000);
+      return `  ✅ ${a.name.padEnd(12)}${s}s`;
+    }
+    return `  ⏳ ${a.name.padEnd(12)}...`;
+  });
+  rows.push(`  ⏳ ${'nginx'.padEnd(12)}waiting for all apps...`);
+
+  return [
+    `🔄 <b>${label}</b> — ${dateStr}`, '',
+    `Progress: ${ready}/${total}  ${progressBar(ready, total)}  ${pct}%`, '',
+    ...rows, '',
+    `Elapsed: ${fmtElapsed(startTime)}`,
+  ].join('\n');
+}
+
+async function runBootSequence(label) {
+  const startTime  = Date.now();
+  const appStatus  = APPS.map(a => ({ ...a, readyAt: null }));
+  const msgId      = await tgPost(formatProgress(appStatus, startTime, label), THREAD_ID);
+  const deadline   = startTime + 180_000;
+
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 5_000));
+
+    for (const app of appStatus) {
+      if (app.readyAt === null && await checkHealth(app.path)) {
+        app.readyAt = Date.now();
+      }
+    }
+
+    if (appStatus.every(a => a.readyAt !== null)) {
+      const dur = fmtElapsed(startTime);
+      await tgEdit(msgId,
+        `✅ <b>All ${APPS.length} apps ready</b> — Boot in ${dur}\n   nginx up — traffic restored`
+      );
+      return;
+    }
+
+    await tgEdit(msgId, formatProgress(appStatus, startTime, label));
+  }
+
+  const failed = appStatus.filter(a => a.readyAt === null).map(a => a.name).join(', ');
+  await tgPost(
+    `❌ <b>${failed} failed to start after 180s</b>\n   Check: <code>docker logs candyshop-prod</code>`,
+    CRITICAL_THREAD_ID
+  );
+}
+
+async function main() {
+  if (readUptime() >= 120) {
+    // Deploy restart — container's boot-reporter.mjs handles Telegram updates.
+    // Idle so PM2 doesn't restart this as a crash.
+    while (true) await new Promise(r => setTimeout(r, 100_000));
+  }
+  await runBootSequence('Server Boot');
+  while (true) await new Promise(r => setTimeout(r, 100_000));
+}
+
+main().catch(err => { console.error('[boot-notifier]', err.message); process.exit(1); });


### PR DESCRIPTION
## Release v2026.05.08.2

### Changes

- **feat(infra): boot progress notifications via Telegram [GH-264]**
  - In-container `boot-reporter.mjs`: live-edits a Telegram message as each app port (5000–5006) comes up during deploys
  - Host-side `boot-notifier.mjs`: PM2 process that detects OS reboots via `/proc/uptime`, sends initial progress message, polls 7 health endpoints every 5s up to 180s
  - `deploy-production.sh`: creates initial Telegram message before `docker run`, passes `TELEGRAM_BOOT_MSG_ID` to container, replaces blind `sleep 60` with active health-poll loop
  - Supervisord and Dockerfile updated to include the new `boot-reporter` one-shot program

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)