### PR TITLE
chore(release): v2026.05.08.2 [GH-264]

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -291,14 +291,17 @@ jobs:
             'cat > /tmp/deploy-production.sh && chmod +x /tmp/deploy-production.sh'
 
       - name: Start deployment
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_REF_NAME: ${{ github.ref_name }}
         run: |
           # Fire-and-forget: start the deploy in background and disconnect immediately.
           # The Cloudflare Access proxy drops long-lived SSH WebSockets mid-build,
           # so we never keep a connection open for more than a few seconds.
           ssh ${{ secrets.PROD_SERVER_HOST }} "
             rm -f /tmp/deploy-candyshop.done /tmp/deploy-candyshop.log
-            REPO_URL='https://github.com/${{ github.repository }}.git' \
-            BRANCH='${{ github.ref_name }}' \
+            REPO_URL='https://github.com/${GH_REPOSITORY}.git' \
+            BRANCH='${GH_REF_NAME}' \
             ENV_FILE='/tmp/.candyshop-build.env' \
             DEPLOY_DETACHED=1 \
             nohup bash /tmp/deploy-production.sh > /tmp/deploy-candyshop.log 2>&1 &
@@ -349,13 +352,163 @@ jobs:
           rm -f ~/.ssh/deploy_key
 
   # ============================================
+  # Deploy to GCP cloud server via SSH
+  # ============================================
+  deploy-gcp:
+    name: Deploy to GCP
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: build
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.GCP_PROD_SERVER_SSH_KEY }}" | tr -d '\r' > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          cat >> ~/.ssh/config << EOF
+          Host ${{ secrets.GCP_PROD_SERVER_HOST }}
+            HostName ${{ secrets.GCP_PROD_SERVER_HOST }}
+            User ${{ secrets.GCP_PROD_SERVER_USER }}
+            IdentityFile ~/.ssh/deploy_key
+            StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
+          EOF
+
+      - name: Compute app version
+        id: app_version
+        run: |
+          VERSION=$(git log -1 --pretty=%s | grep -oP 'v\d{4}\.\d{2}\.\d{2}\.\d+' || true)
+          if [ -z "$VERSION" ]; then
+            VERSION="${GITHUB_SHA:0:7}"
+          fi
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Write ephemeral env file on server
+        env:
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_THREAD_ID: ${{ secrets.TELEGRAM_THREAD_ID }}
+          TELEGRAM_CRITICAL_THREAD_ID: ${{ secrets.TELEGRAM_CRITICAL_THREAD_ID }}
+        run: |
+          {
+            printf 'SUPABASE_SERVICE_ROLE_KEY=%s\n'      "$SUPABASE_SERVICE_ROLE_KEY"
+            printf 'TELEGRAM_BOT_TOKEN=%s\n'             "$TELEGRAM_BOT_TOKEN"
+            printf 'TELEGRAM_CHAT_ID=%s\n'               "$TELEGRAM_CHAT_ID"
+            printf 'TELEGRAM_THREAD_ID=%s\n'             "$TELEGRAM_THREAD_ID"
+            printf 'TELEGRAM_CRITICAL_THREAD_ID=%s\n'   "$TELEGRAM_CRITICAL_THREAD_ID"
+            printf 'NEXT_PUBLIC_APP_VERSION=%s\n'        "${{ steps.app_version.outputs.value }}"
+          } | ssh ${{ secrets.GCP_PROD_SERVER_HOST }} 'cat > /tmp/.candyshop-build.env'
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-store
+          path: apps/store/.next/
+
+      - name: Download admin build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-admin
+          path: apps/admin/.next/
+
+      - name: Download auth build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-auth
+          path: apps/auth/.next/
+
+      - name: Download landing build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-landing
+          path: apps/landing/.next/
+
+      - name: Download payments build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-payments
+          path: apps/payments/.next/
+
+      - name: Download studio build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-studio
+          path: apps/studio/.next/
+
+      - name: Download playground build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-playground
+          path: apps/playground/.next/
+
+      - name: Sync build artifacts to server
+        run: |
+          for APP in store admin auth landing payments studio playground; do
+            echo "Syncing .next for ${APP}..."
+            rsync -az --delete --exclude=cache \
+              "apps/${APP}/.next/" \
+              "${{ secrets.GCP_PROD_SERVER_USER }}@${{ secrets.GCP_PROD_SERVER_HOST }}:/home/furrycolombia/candyshop/apps/${APP}/.next/"
+          done
+
+      - name: Copy deploy script to server
+        run: |
+          cat scripts/deploy-production.sh | ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+            'cat > /tmp/deploy-production.sh && chmod +x /tmp/deploy-production.sh'
+
+      - name: Start deployment
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_REF_NAME: ${{ github.ref_name }}
+        run: |
+          ssh ${{ secrets.GCP_PROD_SERVER_HOST }} "
+            rm -f /tmp/deploy-candyshop.done /tmp/deploy-candyshop.log
+            REPO_URL='https://github.com/${GH_REPOSITORY}.git' \
+            BRANCH='${GH_REF_NAME}' \
+            ENV_FILE='/tmp/.candyshop-build.env' \
+            DEPLOY_DETACHED=1 \
+            nohup bash /tmp/deploy-production.sh > /tmp/deploy-candyshop.log 2>&1 &
+            disown
+          "
+          echo "Deploy process started on GCP server — polling for result..."
+
+      - name: Wait for deployment
+        run: |
+          for i in $(seq 1 60); do
+            sleep 15
+            echo "--- log tail [poll $i/60] ---"
+            ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+              "tail -25 /tmp/deploy-candyshop.log 2>/dev/null" || true
+            RESULT=$(ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+              "cat /tmp/deploy-candyshop.done 2>/dev/null || echo pending" || echo pending)
+            if [ "$RESULT" != "pending" ]; then
+              echo "Deploy finished with exit code: $RESULT"
+              [ "$RESULT" = "0" ] && exit 0 || exit 1
+            fi
+          done
+          echo "Timed out after 15 minutes"
+          exit 1
+
+      - name: Cleanup
+        if: always()
+        run: |
+          ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+            'rm -f /tmp/.candyshop-build.env /tmp/deploy-production.sh' 2>/dev/null || true
+          rm -f ~/.ssh/deploy_key
+
+  # ============================================
   # Alert Telegram when any deploy job fails
   # ============================================
   notify-failure:
     name: Notify Deploy Failure
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    needs: [build, deploy]
+    needs: [build, deploy, deploy-gcp]
     # always() lets this job run even when upstream jobs are skipped due to failure;
     # the explicit result checks ensure we only fire on actual failures, not cancellations.
     if: ${{ always() && (needs.build.result == 'failure' || needs.deploy.result == 'failure') }}

--- a/docker/boot-reporter.mjs
+++ b/docker/boot-reporter.mjs
@@ -23,6 +23,8 @@ const BOT_TOKEN          = process.env.TELEGRAM_BOT_TOKEN || '';
 const CHAT_ID            = process.env.TELEGRAM_CHAT_ID || '';
 const CRITICAL_THREAD_ID = process.env.TELEGRAM_CRITICAL_THREAD_ID
                         || process.env.TELEGRAM_THREAD_ID || '';
+const SERVER_HOSTNAME    = (process.env.SERVER_HOSTNAME || '')
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 if (!BOOT_MSG_ID) process.exit(0);
 
@@ -103,7 +105,7 @@ function formatProgress(appStatus, startTime) {
   rows.push(`  ⏳ ${'nginx'.padEnd(12)}waiting for all apps...`);
 
   return [
-    `🔄 <b>Container Boot</b> — ${dateStr}`, '',
+    `🔄 <b>Container Boot</b>${SERVER_HOSTNAME ? `  •  <code>${SERVER_HOSTNAME}</code>` : ''}  •  ${dateStr}`, '',
     `Progress: ${ready}/${total}  ${progressBar(ready, total)}  ${pct}%`, '',
     ...rows, '',
     `Elapsed: ${fmtElapsed(startTime)}`,
@@ -125,9 +127,10 @@ async function main() {
     if (appStatus.every(a => a.readyAt !== null)) {
       const nginxOk = await checkPort(NGINX_PORT);
       const dur = fmtElapsed(startTime);
+      const host = SERVER_HOSTNAME ? `  •  <code>${SERVER_HOSTNAME}</code>` : '';
       await tgEdit(nginxOk
-        ? `✅ <b>All ${APPS.length} apps ready</b> — Boot in ${dur}\n   nginx up — traffic restored`
-        : `✅ <b>All ${APPS.length} apps ready</b> — Boot in ${dur}\n   ⚠️ nginx not yet up`
+        ? `✅ <b>All ${APPS.length} apps ready</b>${host}  •  Boot in ${dur}\n   nginx up — traffic restored`
+        : `✅ <b>All ${APPS.length} apps ready</b>${host}  •  Boot in ${dur}\n   ⚠️ nginx not yet up`
       );
       process.exit(0);
     }
@@ -137,8 +140,9 @@ async function main() {
   }
 
   const failed = appStatus.filter(a => a.readyAt === null).map(a => a.name).join(', ');
+  const host = SERVER_HOSTNAME ? `  •  <code>${SERVER_HOSTNAME}</code>` : '';
   await tgCritical(
-    `❌ <b>${failed} failed to start after 120s</b>\n   Check: <code>docker logs candyshop-prod</code>`
+    `❌ <b>${failed} failed to start after 120s</b>${host}\n   Check: <code>docker logs candyshop-prod</code>`
   );
   process.exit(1);
 }

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -53,6 +53,9 @@ if [ -f "$_tg_env" ]; then
   TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-$(grep '^TELEGRAM_CHAT_ID=' "$_tg_env" | cut -d= -f2- 2>/dev/null || true)}"
   TELEGRAM_THREAD_ID="${TELEGRAM_THREAD_ID:-$(grep '^TELEGRAM_THREAD_ID=' "$_tg_env" | cut -d= -f2- 2>/dev/null || true)}"
 fi
+# Sanitize hostname once: only RFC-1123-valid chars so it can't break the Python
+# string literal or inject HTML into Telegram messages.
+_safe_hostname=$(printf '%s' "$HOSTNAME" | tr -dc '[:alnum:]._-')
 
 _telegram_send() {
   local thread_id="$1" text="$2"
@@ -101,11 +104,11 @@ _on_exit() {
   dur="$(_dur $DEPLOY_START)"
   local commit="${DEPLOY_COMMIT:-unknown}"
   if [ "$code" -eq 0 ]; then
-    notify_telegram "$(printf '✅ <b>Deploy complete</b>\nBranch: <code>%s</code>\nCommit: <code>%s</code>\nTotal: %s' \
-      "$BRANCH" "$commit" "$dur")"
+    notify_telegram "$(printf '✅ <b>Deploy complete</b>  •  <code>%s</code>\nBranch: <code>%s</code>\nCommit: <code>%s</code>\nTotal: %s' \
+      "$_safe_hostname" "$BRANCH" "$commit" "$dur")"
   else
-    notify_telegram_critical "$(printf '❌ <b>Deploy FAILED</b> (exit %s)\nBranch: <code>%s</code>\nCommit: <code>%s</code>\nTotal: %s' \
-      "$code" "$BRANCH" "$commit" "$dur")"
+    notify_telegram_critical "$(printf '❌ <b>Deploy FAILED</b> (exit %s)  •  <code>%s</code>\nBranch: <code>%s</code>\nCommit: <code>%s</code>\nTotal: %s' \
+      "$code" "$_safe_hostname" "$BRANCH" "$commit" "$dur")"
   fi
 }
 trap _on_exit EXIT
@@ -133,7 +136,7 @@ export NVM_DIR="$HOME/.nvm"
 nvm use 22 --silent || err "Node 22 not available via nvm"
 
 log "Node $(node --version) | PM2 $(pm2 --version)"
-notify_telegram "$(printf '🚀 <b>Deploy started</b>\nBranch: <code>%s</code>' "$BRANCH")"
+notify_telegram "$(printf '🚀 <b>Deploy started</b>  •  <code>%s</code>\nBranch: <code>%s</code>' "$_safe_hostname" "$BRANCH")"
 
 # =============================================================================
 # Clone or pull
@@ -213,7 +216,7 @@ if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
   _BOOT_RESP=$(python3 -c "
 import json, urllib.request
 text = (
-  '\U0001f504 <b>Container Boot</b> — $_boot_now\n\n'
+  '\U0001f504 <b>Container Boot</b>  •  <code>$_safe_hostname</code>  •  $_boot_now\n\n'
   'Progress: 0/7  ░░░░░░░░░░░░░░░░  0%\n\n'
   '  ⏳ auth         ...\n'
   '  ⏳ store        ...\n'
@@ -255,6 +258,7 @@ docker run -d \
   -e "TELEGRAM_THREAD_ID=${TELEGRAM_THREAD_ID:-}" \
   -e "TELEGRAM_CRITICAL_THREAD_ID=${TELEGRAM_CRITICAL_THREAD_ID:-}" \
   -e "TELEGRAM_BOOT_MSG_ID=${_BOOT_MSG_ID:-}" \
+  -e "SERVER_HOSTNAME=${HOSTNAME}" \
   "$IMAGE_TAG" \
   || err "Docker container start failed"
 
@@ -282,7 +286,7 @@ WATCHER_NGINX_PORT=$HOST_PORT pm2 start "$DEPLOY_DIR/docker/watcher.mjs" \
   --name candyshop-watcher
 
 pm2 delete candyshop-boot-notifier 2>/dev/null || true
-WATCHER_NGINX_PORT=$HOST_PORT pm2 start "$DEPLOY_DIR/scripts/server/boot-notifier.mjs" \
+WATCHER_NGINX_PORT=$HOST_PORT SERVER_HOSTNAME=$HOSTNAME pm2 start "$DEPLOY_DIR/scripts/server/boot-notifier.mjs" \
   --name candyshop-boot-notifier
 
 # Persist both processes across reboots
@@ -334,7 +338,7 @@ for APP_ENTRY in "${APPS[@]}"; do
 done
 
 if [ "$FAILED" -gt 0 ]; then
-  notify_telegram_critical "$(printf '⚠️ <b>Health check: %d/%d apps not responding</b>\nDeploy complete with warnings.\n<i>Check: docker logs %s</i>' "$FAILED" "${#APPS[@]}" "$CONTAINER_NAME")"
+  notify_telegram_critical "$(printf '⚠️ <b>Health check: %d/%d apps not responding</b>  •  <code>%s</code>\nDeploy complete with warnings.\n<i>Check: docker logs %s</i>' "$FAILED" "${#APPS[@]}" "$_safe_hostname" "$CONTAINER_NAME")"
   warn "$FAILED app(s) not responding. Skipping warm-up."
   log "Deployment complete (with warnings)."
   exit 0

--- a/scripts/server/boot-notifier.mjs
+++ b/scripts/server/boot-notifier.mjs
@@ -12,8 +12,11 @@
  */
 
 import { readFileSync } from 'fs';
+import { hostname   } from 'os';
 
 const NGINX_PORT         = process.env.WATCHER_NGINX_PORT || '9090';
+const SERVER_HOSTNAME    = (process.env.SERVER_HOSTNAME || hostname())
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 const BOT_TOKEN          = process.env.TELEGRAM_BOT_TOKEN || '';
 const CHAT_ID            = process.env.TELEGRAM_CHAT_ID || '';
 const THREAD_ID          = process.env.TELEGRAM_THREAD_ID || '';
@@ -97,7 +100,7 @@ function formatProgress(appStatus, startTime, label) {
   rows.push(`  ⏳ ${'nginx'.padEnd(12)}waiting for all apps...`);
 
   return [
-    `🔄 <b>${label}</b> — ${dateStr}`, '',
+    `🔄 <b>${label}</b>  •  <code>${SERVER_HOSTNAME}</code>  •  ${dateStr}`, '',
     `Progress: ${ready}/${total}  ${progressBar(ready, total)}  ${pct}%`, '',
     ...rows, '',
     `Elapsed: ${fmtElapsed(startTime)}`,
@@ -122,7 +125,7 @@ async function runBootSequence(label) {
     if (appStatus.every(a => a.readyAt !== null)) {
       const dur = fmtElapsed(startTime);
       await tgEdit(msgId,
-        `✅ <b>All ${APPS.length} apps ready</b> — Boot in ${dur}\n   nginx up — traffic restored`
+        `✅ <b>All ${APPS.length} apps ready</b>  •  <code>${SERVER_HOSTNAME}</code>  •  Boot in ${dur}\n   nginx up — traffic restored`
       );
       return;
     }
@@ -132,7 +135,7 @@ async function runBootSequence(label) {
 
   const failed = appStatus.filter(a => a.readyAt === null).map(a => a.name).join(', ');
   await tgPost(
-    `❌ <b>${failed} failed to start after 180s</b>\n   Check: <code>docker logs candyshop-prod</code>`,
+    `❌ <b>${failed} failed to start after 180s</b>  •  <code>${SERVER_HOSTNAME}</code>\n   Check: <code>docker logs candyshop-prod</code>`,
     CRITICAL_THREAD_ID
   );
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add boot progress notifications via Telegram — reports each app's startup status after container boot
- Add parallel GCP production deployment job — deploys to GCP e2-micro VM alongside the home server, enabling live traffic migration via DNS cutover

## Changes

- `docker/boot-reporter.mjs` — new boot reporter that polls supervisord and posts per-app status to Telegram
- `scripts/server/boot-notifier.mjs` — PM2-managed notifier process on the host
- `docker/prod/supervisord.conf` — adds `boot-reporter` program
- `docker/prod/Dockerfile` — copies boot-reporter into image
- `scripts/deploy-production.sh` — starts boot-notifier via PM2 after container swap
- `.github/workflows/deploy-production.yml` — adds `deploy-gcp` job (parallel to `deploy`); fixes CWE-78 by moving `github.repository` and `github.ref_name` to `env:` blocks

## Test plan

- [ ] Merge and confirm CI build passes
- [ ] Verify `deploy` job (home server) completes successfully
- [ ] Verify `deploy-gcp` job (GCP VM) completes successfully
- [ ] SSH into GCP and confirm `docker ps` shows `candyshop-prod` running
- [ ] Check Telegram for boot progress notification from GCP
- [ ] Reserve static IP for GCP VM in GCP Console
- [ ] Flip `store.furrycolombia.com` DNS A record to GCP IP in Cloudflare

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
EOF
)