### PR TITLE
fix(ci): add --mkpath to GCP rsync to create missing app dirs [GH-264]

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -451,7 +451,7 @@ jobs:
         run: |
           for APP in store admin auth landing payments studio playground; do
             echo "Syncing .next for ${APP}..."
-            rsync -az --delete --exclude=cache \
+            rsync -az --delete --exclude=cache --mkpath \
               "apps/${APP}/.next/" \
               "${{ secrets.GCP_PROD_SERVER_USER }}@${{ secrets.GCP_PROD_SERVER_HOST }}:/home/furrycolombia/candyshop/apps/${APP}/.next/"
           done


### PR DESCRIPTION
## Summary

- Adds `--mkpath` flag to rsync in the `deploy-gcp` job so it creates the destination directory tree automatically on a fresh VM

## Related Issue

Closes #264

---
Generated with [Claude Code](https://claude.com/claude-code)