### PR TITLE
fix(deploy): handle non-empty DEPLOY_DIR on first clone [GH-264]

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -144,7 +144,12 @@ notify_telegram "$(printf '🚀 <b>Deploy started</b>  •  <code>%s</code>\nBra
 _STEP_START=$(date +%s)
 if [ ! -d "$DEPLOY_DIR/.git" ]; then
   log "First deploy — cloning repository..."
-  git clone --branch "$BRANCH" --depth 1 "$REPO_URL" "$DEPLOY_DIR"
+  # DEPLOY_DIR may already exist (rsync creates app dirs before this script runs).
+  # git clone refuses non-empty dirs, so clone to a temp dir then merge in.
+  _CLONE_TMP=$(mktemp -d)
+  git clone --branch "$BRANCH" --depth 1 "$REPO_URL" "$_CLONE_TMP"
+  cp -a "$_CLONE_TMP/." "$DEPLOY_DIR/"
+  rm -rf "$_CLONE_TMP"
 else
   log "Pulling latest from $BRANCH..."
   cd "$DEPLOY_DIR"


### PR DESCRIPTION
## Summary

- rsync creates `candyshop/apps/` before `deploy-production.sh` runs, so `git clone` fails on a fresh VM with "destination path already exists and is not an empty directory"
- Fix: clone to a temp dir and `cp -a` merge it in, preserving any rsynced artifacts

This is self-healing — works on first deploy, reprovisioned VMs, or any future clean state.

Closes #264