### PR TITLE
fix(deploy): guard boot-notifier pm2 start as non-critical [GH-264]

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -288,7 +288,7 @@ WATCHER_NGINX_PORT=$HOST_PORT pm2 start "$DEPLOY_DIR/docker/watcher.mjs" \
 
 pm2 delete candyshop-boot-notifier 2>/dev/null || true
 WATCHER_NGINX_PORT=$HOST_PORT SERVER_HOSTNAME=$HOSTNAME pm2 start "$DEPLOY_DIR/scripts/server/boot-notifier.mjs" \
-  --name candyshop-boot-notifier
+  --name candyshop-boot-notifier || warn "boot-notifier failed to start (non-critical)"
 
 # Persist both processes across reboots
 pm2 save


### PR DESCRIPTION
## Summary

- Guard `pm2 start candyshop-boot-notifier` with `|| warn` so a notification-only process cannot abort the deploy under `set -euo pipefail`.

## Context

The boot-notifier is a Telegram progress reporter — non-critical infrastructure. The watcher is left unguarded because a failed watcher is a meaningful error worth surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)