### PR TITLE
chore(release): v2026.05.08.2 [GH-264]

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -360,21 +360,29 @@ jobs:
     timeout-minutes: 25
     needs: build
     environment: production
+    env:
+      DEPLOY_HOST: ${{ secrets.GCP_PROD_SERVER_HOST }}
+      DEPLOY_USER: ${{ secrets.GCP_PROD_SERVER_USER }}
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup SSH key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.GCP_PROD_SERVER_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.GCP_PROD_SERVER_KNOWN_HOSTS }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.GCP_PROD_SERVER_SSH_KEY }}" | tr -d '\r' > ~/.ssh/deploy_key
+          printf '%s\n' "$SSH_PRIVATE_KEY" | tr -d '\r' > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "$KNOWN_HOSTS" >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
           cat >> ~/.ssh/config << EOF
-          Host ${{ secrets.GCP_PROD_SERVER_HOST }}
-            HostName ${{ secrets.GCP_PROD_SERVER_HOST }}
-            User ${{ secrets.GCP_PROD_SERVER_USER }}
+          Host $DEPLOY_HOST
+            HostName $DEPLOY_HOST
+            User $DEPLOY_USER
             IdentityFile ~/.ssh/deploy_key
-            StrictHostKeyChecking no
+            StrictHostKeyChecking yes
             ServerAliveInterval 30
             ServerAliveCountMax 20
           EOF
@@ -395,6 +403,7 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           TELEGRAM_THREAD_ID: ${{ secrets.TELEGRAM_THREAD_ID }}
           TELEGRAM_CRITICAL_THREAD_ID: ${{ secrets.TELEGRAM_CRITICAL_THREAD_ID }}
+          APP_VERSION: ${{ steps.app_version.outputs.value }}
         run: |
           {
             printf 'SUPABASE_SERVICE_ROLE_KEY=%s\n'      "$SUPABASE_SERVICE_ROLE_KEY"
@@ -402,8 +411,8 @@ jobs:
             printf 'TELEGRAM_CHAT_ID=%s\n'               "$TELEGRAM_CHAT_ID"
             printf 'TELEGRAM_THREAD_ID=%s\n'             "$TELEGRAM_THREAD_ID"
             printf 'TELEGRAM_CRITICAL_THREAD_ID=%s\n'   "$TELEGRAM_CRITICAL_THREAD_ID"
-            printf 'NEXT_PUBLIC_APP_VERSION=%s\n'        "${{ steps.app_version.outputs.value }}"
-          } | ssh ${{ secrets.GCP_PROD_SERVER_HOST }} 'cat > /tmp/.candyshop-build.env'
+            printf 'NEXT_PUBLIC_APP_VERSION=%s\n'        "$APP_VERSION"
+          } | ssh "$DEPLOY_HOST" 'umask 077; cat > /tmp/.candyshop-build.env'
 
       - name: Download build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -453,20 +462,20 @@ jobs:
             echo "Syncing .next for ${APP}..."
             rsync -az --delete --exclude=cache --mkpath \
               "apps/${APP}/.next/" \
-              "${{ secrets.GCP_PROD_SERVER_USER }}@${{ secrets.GCP_PROD_SERVER_HOST }}:/home/furrycolombia/candyshop/apps/${APP}/.next/"
+              "${DEPLOY_USER}@${DEPLOY_HOST}:/home/furrycolombia/candyshop/apps/${APP}/.next/"
           done
 
       - name: Copy deploy script to server
         run: |
-          cat scripts/deploy-production.sh | ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
-            'cat > /tmp/deploy-production.sh && chmod +x /tmp/deploy-production.sh'
+          ssh "$DEPLOY_HOST" 'umask 077; cat > /tmp/deploy-production.sh && chmod +x /tmp/deploy-production.sh' \
+            < scripts/deploy-production.sh
 
       - name: Start deployment
         env:
           GH_REPOSITORY: ${{ github.repository }}
           GH_REF_NAME: ${{ github.ref_name }}
         run: |
-          ssh ${{ secrets.GCP_PROD_SERVER_HOST }} "
+          ssh "$DEPLOY_HOST" "
             rm -f /tmp/deploy-candyshop.done /tmp/deploy-candyshop.log
             REPO_URL='https://github.com/${GH_REPOSITORY}.git' \
             BRANCH='${GH_REF_NAME}' \
@@ -482,9 +491,9 @@ jobs:
           for i in $(seq 1 60); do
             sleep 15
             echo "--- log tail [poll $i/60] ---"
-            ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+            ssh "$DEPLOY_HOST" \
               "tail -25 /tmp/deploy-candyshop.log 2>/dev/null" || true
-            RESULT=$(ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+            RESULT=$(ssh "$DEPLOY_HOST" \
               "cat /tmp/deploy-candyshop.done 2>/dev/null || echo pending" || echo pending)
             if [ "$RESULT" != "pending" ]; then
               echo "Deploy finished with exit code: $RESULT"
@@ -497,7 +506,7 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+          ssh "$DEPLOY_HOST" \
             'rm -f /tmp/.candyshop-build.env /tmp/deploy-production.sh' 2>/dev/null || true
           rm -f ~/.ssh/deploy_key
 

--- a/docker/boot-reporter.mjs
+++ b/docker/boot-reporter.mjs
@@ -18,13 +18,21 @@
 import { createConnection } from 'net';
 import { readFileSync }     from 'fs';
 
-const BOOT_MSG_ID        = parseInt(process.env.TELEGRAM_BOOT_MSG_ID || '0') || 0;
+function htmlEscape(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function asPositiveInt(v) {
+  const n = parseInt(v, 10);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+const BOOT_MSG_ID        = asPositiveInt(process.env.TELEGRAM_BOOT_MSG_ID || '') ?? 0;
 const BOT_TOKEN          = process.env.TELEGRAM_BOT_TOKEN || '';
 const CHAT_ID            = process.env.TELEGRAM_CHAT_ID || '';
 const CRITICAL_THREAD_ID = process.env.TELEGRAM_CRITICAL_THREAD_ID
                         || process.env.TELEGRAM_THREAD_ID || '';
-const SERVER_HOSTNAME    = (process.env.SERVER_HOSTNAME || '')
-  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const SERVER_HOSTNAME    = htmlEscape(process.env.SERVER_HOSTNAME || '');
 
 if (!BOOT_MSG_ID) process.exit(0);
 
@@ -69,7 +77,8 @@ async function tgCritical(text) {
   if (!BOT_TOKEN || !CHAT_ID) return;
   try {
     const body = { chat_id: CHAT_ID, text, parse_mode: 'HTML' };
-    if (CRITICAL_THREAD_ID) body.message_thread_id = parseInt(CRITICAL_THREAD_ID);
+    const tid = asPositiveInt(CRITICAL_THREAD_ID);
+    if (tid) body.message_thread_id = tid;
     await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -172,10 +172,13 @@ rm -f "$DEPLOY_DIR/.secrets"
 ENV_FILE="${ENV_FILE:-/tmp/.candyshop-build.env}"
 if [ -f "$ENV_FILE" ]; then
   log "Loading runtime env from $ENV_FILE"
-  set -o allexport
-  # shellcheck source=/dev/null
-  source "$ENV_FILE"
-  set +o allexport
+  while IFS= read -r _line || [ -n "$_line" ]; do
+    [[ -z "$_line" || "$_line" == \#* ]] && continue
+    _key="${_line%%=*}"
+    _val="${_line#*=}"
+    [[ "$_key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    export "$_key=$_val"
+  done < "$ENV_FILE"
 else
   warn "No env file found at $ENV_FILE — container may lack runtime secrets"
 fi
@@ -215,9 +218,16 @@ _BOOT_MSG_ID=""
 if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
   _boot_now=$(python3 -c "from datetime import datetime,timezone; print(datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC'))" 2>/dev/null || true)
   _BOOT_RESP=$(python3 -c "
-import json, urllib.request
+import json, os, sys, urllib.request
+hostname  = sys.argv[1]
+boot_now  = sys.argv[2]
+chat_id   = os.environ.get('TELEGRAM_CHAT_ID', '')
+thread    = os.environ.get('TELEGRAM_THREAD_ID', '')
+bot_token = os.environ.get('TELEGRAM_BOT_TOKEN', '')
+if not (chat_id and bot_token):
+    raise SystemExit(0)
 text = (
-  '\U0001f504 <b>Container Boot</b>  •  <code>$_safe_hostname</code>  •  $_boot_now\n\n'
+  '\U0001f504 <b>Container Boot</b>  •  <code>' + hostname + '</code>  •  ' + boot_now + '\n\n'
   'Progress: 0/7  ░░░░░░░░░░░░░░░░  0%\n\n'
   '  ⏳ auth         ...\n'
   '  ⏳ store        ...\n'
@@ -229,13 +239,12 @@ text = (
   '  ⏳ nginx        waiting for all apps...\n\n'
   'Elapsed: 0s'
 )
-payload = {'chat_id': '${TELEGRAM_CHAT_ID}', 'text': text, 'parse_mode': 'HTML'}
-thread = '${TELEGRAM_THREAD_ID:-}'
+payload = {'chat_id': chat_id, 'text': text, 'parse_mode': 'HTML'}
 if thread:
     payload['message_thread_id'] = int(thread)
 data = json.dumps(payload).encode()
 req = urllib.request.Request(
-    'https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage',
+    'https://api.telegram.org/bot' + bot_token + '/sendMessage',
     data=data, headers={'Content-Type': 'application/json'}, method='POST')
 try:
     with urllib.request.urlopen(req, timeout=10) as r:
@@ -244,7 +253,7 @@ try:
             print(resp['result']['message_id'])
 except Exception:
     pass
-" 2>/dev/null || true)
+" "$_safe_hostname" "${_boot_now:-}" 2>/dev/null || true)
   _BOOT_MSG_ID="${_BOOT_RESP:-}"
 fi
 
@@ -253,13 +262,16 @@ docker run -d \
   --name "$CONTAINER_NAME" \
   --restart unless-stopped \
   -p "${HOST_PORT}:8080" \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --pids-limit=1024 \
   -e "SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY:-}" \
   -e "TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}" \
   -e "TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-}" \
   -e "TELEGRAM_THREAD_ID=${TELEGRAM_THREAD_ID:-}" \
   -e "TELEGRAM_CRITICAL_THREAD_ID=${TELEGRAM_CRITICAL_THREAD_ID:-}" \
   -e "TELEGRAM_BOOT_MSG_ID=${_BOOT_MSG_ID:-}" \
-  -e "SERVER_HOSTNAME=${HOSTNAME}" \
+  -e "SERVER_HOSTNAME=${_safe_hostname}" \
   "$IMAGE_TAG" \
   || err "Docker container start failed"
 
@@ -287,7 +299,7 @@ WATCHER_NGINX_PORT=$HOST_PORT pm2 start "$DEPLOY_DIR/docker/watcher.mjs" \
   --name candyshop-watcher
 
 pm2 delete candyshop-boot-notifier 2>/dev/null || true
-WATCHER_NGINX_PORT=$HOST_PORT SERVER_HOSTNAME=$HOSTNAME pm2 start "$DEPLOY_DIR/scripts/server/boot-notifier.mjs" \
+WATCHER_NGINX_PORT=$HOST_PORT SERVER_HOSTNAME=$_safe_hostname pm2 start "$DEPLOY_DIR/scripts/server/boot-notifier.mjs" \
   --name candyshop-boot-notifier || warn "boot-notifier failed to start (non-critical)"
 
 # Persist both processes across reboots

--- a/scripts/server/boot-notifier.mjs
+++ b/scripts/server/boot-notifier.mjs
@@ -15,12 +15,20 @@ import { readFileSync } from 'fs';
 import { hostname   } from 'os';
 
 const NGINX_PORT         = process.env.WATCHER_NGINX_PORT || '9090';
-const SERVER_HOSTNAME    = (process.env.SERVER_HOSTNAME || hostname())
-  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const SERVER_HOSTNAME    = htmlEscape(process.env.SERVER_HOSTNAME || hostname());
 const BOT_TOKEN          = process.env.TELEGRAM_BOT_TOKEN || '';
 const CHAT_ID            = process.env.TELEGRAM_CHAT_ID || '';
 const THREAD_ID          = process.env.TELEGRAM_THREAD_ID || '';
 const CRITICAL_THREAD_ID = process.env.TELEGRAM_CRITICAL_THREAD_ID || THREAD_ID;
+
+function htmlEscape(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function asPositiveInt(v) {
+  const n = parseInt(v, 10);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
 
 const APPS = [
   { name: 'auth',       path: '/auth/health' },
@@ -41,7 +49,8 @@ async function tgPost(text, threadId) {
   if (!BOT_TOKEN || !CHAT_ID) return null;
   try {
     const body = { chat_id: CHAT_ID, text, parse_mode: 'HTML' };
-    if (threadId) body.message_thread_id = parseInt(threadId);
+    const tid = asPositiveInt(threadId);
+    if (tid) body.message_thread_id = tid;
     const res = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

Security hardening of the boot-progress notification pipeline introduced in GH-264. Six classes of vulnerabilities were identified and remediated across 4 files.

## Related Issue

Closes #264

## Security Fixes

### 🔴 CRITICAL — Python heredoc injection
Shell variables (`$TELEGRAM_CHAT_ID`, `$TELEGRAM_BOT_TOKEN`, etc.) were interpolated directly into a Python `-c "..."` string, allowing arbitrary code execution if a secret contained `'`, newlines, or shell metacharacters. **Fix:** secrets now reach Python via `os.environ.get()`, safe values via `sys.argv`.

### 🔴 CRITICAL — Unsafe `source` of untrusted env file
`source "$ENV_FILE"` executed the env file as bash, allowing any shell command embedded in the file to run as the deploy user. **Fix:** replaced with a `while IFS= read -r` loop that only exports lines matching `^[A-Za-z_][A-Za-z0-9_]*=` (key allowlist).

### 🔴 HIGH — `${{ secrets.* }}` template injection in GitHub Actions `run:`
Secrets interpolated directly into `run:` shell text can be extracted via log manipulation. **Fix:** all secrets moved to `env:` blocks at job and step level; shell references use `$VAR` syntax.

### 🔴 HIGH — `StrictHostKeyChecking no` (MITM risk)
Disabled SSH host verification on every deploy, allowing a man-in-the-middle attack. **Fix:** `StrictHostKeyChecking yes` with pinned `known_hosts` populated from a new `GCP_PROD_SERVER_KNOWN_HOSTS` repository secret.

> **⚠️ Action required before merging:** Add `GCP_PROD_SERVER_KNOWN_HOSTS` to GitHub repository secrets. Generate the value with: `ssh-keyscan -H $GCP_PROD_SERVER_HOST`

### 🟠 HIGH — No Docker capability limits
Container ran without `--cap-drop`, allowing privilege escalation inside a compromised container. **Fix:** added `--cap-drop=ALL --security-opt=no-new-privileges --pids-limit=1024`.

### 🟡 MEDIUM — Weak `parseInt` and unescaped HTML in Telegram messages
`parseInt()` without radix 10 and NaN validation caused silent Telegram API failures on malformed env values. Ad-hoc `.replace()` chains for HTML escaping were incomplete. **Fix:** `asPositiveInt()` helper with `Number.isInteger()` + `> 0` guard; `htmlEscape()` helper covering `&`, `<`, `>`.

## Changes

- `.github/workflows/deploy-production.yml` — secrets via `env:` blocks, pinned `known_hosts`, `StrictHostKeyChecking yes`, `umask 077` on env file write
- `scripts/deploy-production.sh` — safe env loader, Python injection fix, Docker hardening flags, sanitized hostname propagation
- `docker/boot-reporter.mjs` — `asPositiveInt()` + `htmlEscape()` helpers
- `scripts/server/boot-notifier.mjs` — `asPositiveInt()` + `htmlEscape()` helpers

## Testing

1. Add `GCP_PROD_SERVER_KNOWN_HOSTS` secret to repository settings
2. Trigger a deploy and verify the boot-progress Telegram message appears and updates correctly
3. Verify container starts successfully with the new `--cap-drop` flags
4. Verify env file is created `chmod 600` on the server (`ls -la /tmp/.candyshop-build.env`)

---

Generated with [Claude Code](https://claude.com/claude-code)