### PR TITLE
feat(deploy): add GCP deploy job via direct SSH [GH-264]

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -291,14 +291,17 @@ jobs:
             'cat > /tmp/deploy-production.sh && chmod +x /tmp/deploy-production.sh'
 
       - name: Start deployment
+        env:
+          DEPLOY_REPO_URL: https://github.com/${{ github.repository }}.git
+          DEPLOY_BRANCH: ${{ github.ref_name }}
         run: |
           # Fire-and-forget: start the deploy in background and disconnect immediately.
           # The Cloudflare Access proxy drops long-lived SSH WebSockets mid-build,
           # so we never keep a connection open for more than a few seconds.
           ssh ${{ secrets.PROD_SERVER_HOST }} "
             rm -f /tmp/deploy-candyshop.done /tmp/deploy-candyshop.log
-            REPO_URL='https://github.com/${{ github.repository }}.git' \
-            BRANCH='${{ github.ref_name }}' \
+            REPO_URL='${DEPLOY_REPO_URL}' \
+            BRANCH='${DEPLOY_BRANCH}' \
             ENV_FILE='/tmp/.candyshop-build.env' \
             DEPLOY_DETACHED=1 \
             nohup bash /tmp/deploy-production.sh > /tmp/deploy-candyshop.log 2>&1 &
@@ -349,16 +352,176 @@ jobs:
           rm -f ~/.ssh/deploy_key
 
   # ============================================
+  # Deploy to GCP production VM via direct SSH
+  # No cloudflared — connects directly to 35.238.125.109
+  # ============================================
+  deploy-gcp:
+    name: Deploy to GCP
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: build
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.GCP_PROD_SERVER_SSH_KEY }}" | tr -d '\r' > ~/.ssh/gcp_deploy_key
+          chmod 600 ~/.ssh/gcp_deploy_key
+          cat >> ~/.ssh/config << EOF
+          Host ${{ secrets.GCP_PROD_SERVER_HOST }}
+            HostName ${{ secrets.GCP_PROD_SERVER_HOST }}
+            User ${{ secrets.GCP_PROD_SERVER_USER }}
+            IdentityFile ~/.ssh/gcp_deploy_key
+            StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
+          EOF
+
+      - name: Compute app version
+        id: app_version
+        run: |
+          VERSION=$(git log -1 --pretty=%s | grep -oP 'v\d{4}\.\d{2}\.\d{2}\.\d+' || true)
+          if [ -z "$VERSION" ]; then
+            VERSION="${GITHUB_SHA:0:7}"
+          fi
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "App version: $VERSION"
+
+      - name: Write ephemeral env file on GCP server
+        env:
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_THREAD_ID: ${{ secrets.TELEGRAM_THREAD_ID }}
+          TELEGRAM_CRITICAL_THREAD_ID: ${{ secrets.TELEGRAM_CRITICAL_THREAD_ID }}
+        run: |
+          {
+            printf 'SUPABASE_SERVICE_ROLE_KEY=%s\n'     "$SUPABASE_SERVICE_ROLE_KEY"
+            printf 'TELEGRAM_BOT_TOKEN=%s\n'            "$TELEGRAM_BOT_TOKEN"
+            printf 'TELEGRAM_CHAT_ID=%s\n'              "$TELEGRAM_CHAT_ID"
+            printf 'TELEGRAM_THREAD_ID=%s\n'            "$TELEGRAM_THREAD_ID"
+            printf 'TELEGRAM_CRITICAL_THREAD_ID=%s\n'  "$TELEGRAM_CRITICAL_THREAD_ID"
+            printf 'NEXT_PUBLIC_APP_VERSION=%s\n'       "${{ steps.app_version.outputs.value }}"
+          } | ssh ${{ secrets.GCP_PROD_SERVER_HOST }} 'cat > /tmp/.candyshop-build.env'
+
+      - name: Download store build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-store
+          path: apps/store/.next/
+
+      - name: Download admin build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-admin
+          path: apps/admin/.next/
+
+      - name: Download auth build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-auth
+          path: apps/auth/.next/
+
+      - name: Download landing build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-landing
+          path: apps/landing/.next/
+
+      - name: Download payments build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-payments
+          path: apps/payments/.next/
+
+      - name: Download studio build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-studio
+          path: apps/studio/.next/
+
+      - name: Download playground build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-playground
+          path: apps/playground/.next/
+
+      - name: Sync build artifacts to GCP server
+        run: |
+          ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+            'mkdir -p /opt/candyshop/apps/{store,admin,auth,landing,payments,studio,playground}'
+          for APP in store admin auth landing payments studio playground; do
+            echo "Syncing .next for ${APP}..."
+            rsync -az --delete --exclude=cache \
+              "apps/${APP}/.next/" \
+              "${{ secrets.GCP_PROD_SERVER_HOST }}:/opt/candyshop/apps/${APP}/.next/"
+          done
+
+      - name: Copy deploy script to GCP server
+        run: |
+          cat scripts/deploy-production.sh | ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+            'cat > /tmp/deploy-production.sh && chmod +x /tmp/deploy-production.sh'
+
+      - name: Start deployment
+        env:
+          DEPLOY_REPO_URL: https://github.com/${{ github.repository }}.git
+          DEPLOY_BRANCH: ${{ github.ref_name }}
+        run: |
+          ssh ${{ secrets.GCP_PROD_SERVER_HOST }} "
+            rm -f /tmp/deploy-candyshop.done /tmp/deploy-candyshop.log
+            REPO_URL='${DEPLOY_REPO_URL}' \
+            BRANCH='${DEPLOY_BRANCH}' \
+            ENV_FILE='/tmp/.candyshop-build.env' \
+            DEPLOY_DIR='/opt/candyshop' \
+            DEPLOY_DETACHED=1 \
+            nohup bash /tmp/deploy-production.sh > /tmp/deploy-candyshop.log 2>&1 &
+            disown
+          "
+          echo "Deploy process started on GCP server — polling for result..."
+
+      - name: Wait for deployment
+        run: |
+          for i in $(seq 1 60); do
+            sleep 15
+            echo "--- log tail [poll $i/60] ---"
+            ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+              "tail -25 /tmp/deploy-candyshop.log 2>/dev/null" || true
+            RESULT=$(ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+              "cat /tmp/deploy-candyshop.done 2>/dev/null || echo pending" || echo pending)
+            if [ "$RESULT" != "pending" ]; then
+              echo "Deploy finished with exit code: $RESULT"
+              [ "$RESULT" = "0" ] && exit 0 || exit 1
+            fi
+          done
+          echo "Timed out after 15 minutes waiting for deployment"
+          exit 1
+
+      - name: Verify deployment
+        run: |
+          ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+            'docker ps --filter name=candyshop-prod --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || true'
+
+      - name: Cleanup
+        if: always()
+        run: |
+          ssh ${{ secrets.GCP_PROD_SERVER_HOST }} \
+            'rm -f /tmp/.candyshop-build.env /tmp/deploy-production.sh' 2>/dev/null || true
+          rm -f ~/.ssh/gcp_deploy_key
+
+  # ============================================
   # Alert Telegram when any deploy job fails
   # ============================================
   notify-failure:
     name: Notify Deploy Failure
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    needs: [build, deploy]
+    needs: [build, deploy, deploy-gcp]
     # always() lets this job run even when upstream jobs are skipped due to failure;
     # the explicit result checks ensure we only fire on actual failures, not cancellations.
-    if: ${{ always() && (needs.build.result == 'failure' || needs.deploy.result == 'failure') }}
+    if: ${{ always() && (needs.build.result == 'failure' || needs.deploy.result == 'failure' || needs['deploy-gcp'].result == 'failure') }}
     steps:
       - name: Send Telegram alert
         env:

--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -66,6 +66,11 @@ jobs:
           PROD_CF_ZONE_ID: ${{ secrets.PROD_CF_ZONE_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          GCP_PROD_SERVER_HOST: ${{ secrets.GCP_PROD_SERVER_HOST }}
+          GCP_PROD_SERVER_USER: ${{ secrets.GCP_PROD_SERVER_USER }}
+          GCP_PROD_SERVER_SSH_PUBLIC_KEY: ${{ secrets.GCP_PROD_SERVER_SSH_PUBLIC_KEY }}
+          GCP_PROD_SERVER_SSH_KEY: ${{ secrets.GCP_PROD_SERVER_SSH_KEY }}
+          GCP_PROD_SERVER_SSH_KEY_B64: ${{ secrets.GCP_PROD_SERVER_SSH_KEY_B64 }}
         shell: bash
         run: |
           # Validate required secrets are present
@@ -165,6 +170,13 @@ jobs:
             echo "SENTRY_ORG=furry-colombia"
             echo "SENTRY_PROJECT=candyshop"
             echo "SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}"
+            echo ""
+            echo "# ─── Production GCP VM (furrycolombia-candyshop) ─────────────────"
+            echo "# To restore key file: echo \$GCP_PROD_SERVER_SSH_KEY_B64 | base64 -d > ~/.ssh/candyshop_gcp && chmod 600 ~/.ssh/candyshop_gcp"
+            echo "GCP_PROD_SERVER_HOST=${GCP_PROD_SERVER_HOST}"
+            echo "GCP_PROD_SERVER_USER=${GCP_PROD_SERVER_USER}"
+            echo "GCP_PROD_SERVER_SSH_PUBLIC_KEY=${GCP_PROD_SERVER_SSH_PUBLIC_KEY}"
+            echo "GCP_PROD_SERVER_SSH_KEY_B64=${GCP_PROD_SERVER_SSH_KEY_B64}"
           } > secrets-plain.txt
 
       - name: Encrypt secrets file

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -114,7 +114,7 @@ _on_exit() {
 trap _on_exit EXIT
 # ─────────────────────────────────────────────────────────────────────────────
 
-DEPLOY_DIR="/home/furrycolombia/candyshop"
+DEPLOY_DIR="${DEPLOY_DIR:-/home/furrycolombia/candyshop}"
 REPO_URL="${REPO_URL:-}"
 BRANCH="${BRANCH:-main}"
 CONTAINER_NAME="${SITE_PROD_CONTAINER_NAME:-candyshop-prod}"


### PR DESCRIPTION
## Summary

- Add `deploy-gcp` CI job that deploys to the GCP VM (`35.238.125.109`) over plain SSH — no cloudflared proxy needed since the VM has a static public IP
- Fix CWE-78 injection in the existing `deploy` job's "Start deployment" step (`github.repository` / `github.ref_name` now routed through `env:` vars)
- `notify-failure` now watches both `deploy` and `deploy-gcp` results
- `deploy-production.sh`: `DEPLOY_DIR` is now env-var overridable (defaults to `/home/furrycolombia/candyshop` so local prod behavior is unchanged; GCP job overrides to `/opt/candyshop`)
- `sync-secrets.yml`: expose `GCP_PROD_SERVER_*` secrets so they are included in local `.secrets` syncs

## Related Issue

Closes #264

## Changes

- `.github/workflows/deploy-production.yml`: new `deploy-gcp` job with SSH setup, artifact downloads, rsync, detached deploy script execution, polling wait, and cleanup
- `.github/workflows/deploy-production.yml`: `deploy` job injection fix
- `.github/workflows/deploy-production.yml`: `notify-failure` updated to include `deploy-gcp`
- `.github/workflows/sync-secrets.yml`: GCP secrets added to env block and written output
- `scripts/deploy-production.sh`: line 117 `DEPLOY_DIR` made env-overridable

## Testing

- [ ] Trigger a deploy to GCP by merging to `main` (or manually via workflow dispatch once wired)
- [ ] Confirm local prod deploy (`PROD_SERVER_HOST`) is unaffected
- [ ] Verify `notify-failure` fires when either deploy job fails

---

Generated with [Claude Code](https://claude.com/claude-code)