### PR TITLE
fix(deploy): remove path filter so every push to main triggers deploy

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -11,13 +11,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "apps/**"
-      - "packages/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "docker/**"
-      - "scripts/**"
   workflow_call: {}
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

Removes the `paths` filter from the `push: main` trigger in `deploy-gcp.yml`.

Previously, a release that only touched files like `.github/workflows/**` would not trigger the deploy workflow because those paths were not in the filter. Now any push to `main` — regardless of which files changed — triggers the GCP deploy automatically.

## Changes

- Removed `paths` block from the `on.push` trigger in `deploy-gcp.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)