### PR TITLE
fix(deploy): reorder Dockerfile layers and sync local :latest after pull

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -12,6 +12,14 @@ RUN apk add --no-cache nginx supervisor netcat-openbsd && \
     mkdir -p /var/log/nginx /var/log/supervisor /var/run/nginx /run/nginx && \
     chown -R nextjs:nodejs /var/lib/nginx /var/log/nginx /var/log/supervisor /var/run/nginx /run/nginx
 
+# Stable infrastructure config — placed BEFORE volatile app layers so these
+# layers keep identical hashes across deploys and are cache-hit by both CI
+# (--cache-from :latest) and the VM's local layer store.
+COPY docker/prod/nginx.conf           /etc/nginx/nginx.conf
+COPY docker/prod/supervisord.conf     /etc/supervisor/conf.d/supervisord.conf
+COPY docker/watcher.mjs               /app/watcher.mjs
+COPY docker/boot-reporter.mjs         /app/boot-reporter.mjs
+
 # Standalone builds pre-built by CI (rsynced to server before this runs)
 COPY apps/store/.next/standalone      /app/store/
 COPY apps/store/.next/static          /app/store/apps/store/.next/static
@@ -40,11 +48,6 @@ COPY apps/playground/public           /app/playground/apps/playground/public
 COPY apps/studio/.next/standalone     /app/studio/
 COPY apps/studio/.next/static         /app/studio/apps/studio/.next/static
 COPY apps/studio/public               /app/studio/apps/studio/public
-
-COPY docker/prod/nginx.conf           /etc/nginx/nginx.conf
-COPY docker/prod/supervisord.conf     /etc/supervisor/conf.d/supervisord.conf
-COPY docker/watcher.mjs               /app/watcher.mjs
-COPY docker/boot-reporter.mjs         /app/boot-reporter.mjs
 
 # pnpm workspace linking creates stub node_modules inside each app directory
 # (package.json only, no dist/) that shadow the complete packages at the

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -213,6 +213,11 @@ if [ -n "${DOCKER_IMAGE:-}" ]; then
   fi
   docker pull "$DOCKER_IMAGE" || err "Docker image pull failed"
   IMAGE_TAG="$DOCKER_IMAGE"
+  # Keep local :latest in sync so the next deploy's cache-warming pre-pull
+  # finds these layers already present and skips re-downloading them.
+  if [ -n "${DOCKER_IMAGE_LATEST:-}" ]; then
+    docker tag "$DOCKER_IMAGE" "$DOCKER_IMAGE_LATEST" 2>/dev/null || true
+  fi
   docker logout ghcr.io 2>/dev/null || true
   log "Image pulled: $IMAGE_TAG (took $(_dur $_STEP_START))"
   notify_telegram "$(printf '🐳 <b>Image pulled</b> (%s)\n<code>%s</code>' "$(_dur $_STEP_START)" "$IMAGE_TAG")"


### PR DESCRIPTION
## Summary

- **Dockerfile**: moves stable config layers (`nginx.conf`, `supervisord.conf`, `watcher.mjs`, `boot-reporter.mjs`) **before** the 7 volatile app `COPY` blocks. Docker layer hashes are derived from all parent layers, so config layers placed after app layers always get new hashes on every deploy — even when the config files are unchanged. With this order, those layers are cache-hit by both CI (`--cache-from :latest`) and the VM's local layer store.
- **deploy script**: after a successful `docker pull <sha-tag>`, tags the image as `:latest` locally so the cache-warming pre-pull on the *next* deploy finds those layers already present without re-downloading.

## Cloudflare cache

Purge-everything step in `deploy-gcp.yml` is untouched — it still runs after every successful deploy.

## Risk

Zero functional change — only layer ordering in the image and a local `docker tag` with a `|| true` guard. The running container, startup sequence, nginx config, and all app entrypoints are identical.

---

Generated with [Claude Code](https://claude.com/claude-code)