### PR TITLE
fix(deploy): patch critical security issues in deploy script and nginx

### DIFF
--- a/docker/prod/nginx.conf
+++ b/docker/prod/nginx.conf
@@ -116,6 +116,15 @@ http {
         listen 8080;
         server_name _;
 
+        # Security headers — applied globally to all responses.
+        # Cloudflare sits in front and can override/augment these, but setting
+        # them here ensures they're present even in direct-to-VM scenarios.
+        add_header X-Content-Type-Options    "nosniff"          always;
+        add_header X-Frame-Options           "SAMEORIGIN"       always;
+        add_header X-XSS-Protection          "1; mode=block"    always;
+        add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy        "camera=(), microphone=(), geolocation=()" always;
+
         # Store app - routes starting with /store
         location /store {
             proxy_pass http://store_app;
@@ -219,10 +228,13 @@ http {
         }
 
         # Health check endpoint (exact match)
+        # Use default_type instead of add_header so the server-level security
+        # headers are inherited (nginx drops parent add_header when a location
+        # defines its own add_header directives).
         location = /health {
             access_log off;
+            default_type text/plain;
             return 200 'OK';
-            add_header Content-Type text/plain;
         }
     }
 }

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+set +x  # Never echo commands — prevents secrets leaking into CI log streams
 
 # =============================================================================
 # Production Deployment Script for hestia.local
@@ -106,9 +107,10 @@ DEPLOY_START=$(date +%s)
 _on_exit() {
   local code=$?
   echo $code >/tmp/deploy-candyshop.done
-  # Ensure ephemeral secrets file is removed on any exit path (early failure,
-  # success, or signal) — don't rely solely on the CI cleanup SSH step.
+  # Ensure all ephemeral secrets files are removed on any exit path (early
+  # failure, success, or signal) — don't rely solely on the CI cleanup step.
   rm -f "${ENV_FILE:-/tmp/.candyshop-build.env}" 2>/dev/null || true
+  rm -f "${_CONTAINER_ENV:-}" 2>/dev/null || true
   local dur
   dur="$(_dur $DEPLOY_START)"
   local commit="${DEPLOY_COMMIT:-unknown}"
@@ -219,6 +221,9 @@ if [ -n "${DOCKER_IMAGE:-}" ]; then
     docker tag "$DOCKER_IMAGE" "$DOCKER_IMAGE_LATEST" 2>/dev/null || true
   fi
   docker logout ghcr.io 2>/dev/null || true
+  # Scrub registry credentials from this process's environment; they must not
+  # be inherited by PM2-managed watcher/boot-notifier child processes.
+  unset GHCR_TOKEN GHCR_USERNAME
   log "Image pulled: $IMAGE_TAG (took $(_dur $_STEP_START))"
   notify_telegram "$(printf '🐳 <b>Image pulled</b> (%s)\n<code>%s</code>' "$(_dur $_STEP_START)" "$IMAGE_TAG")"
 else


### PR DESCRIPTION
## Summary

Security hardening for the GCP deploy pipeline, identified during code review of PR #288.

- **SEC-001** — Unset `GHCR_TOKEN` / `GHCR_USERNAME` from process environment immediately after `docker logout`. Prevents registry credentials leaking into PM2-managed child processes (watcher, boot-notifier).
- **SEC-002** — Add `set +x` at script top so Telegram bot token and other secrets can never appear in CI log streams even if xtrace is inadvertently enabled.
- **SEC-004** — Add `_CONTAINER_ENV` to the `_on_exit` trap. The temp container env file was previously only removed on the happy path; now it's cleaned up on any exit (early failure, signal, etc.).
- **SEC-008** — Add security response headers to nginx (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Permissions-Policy`). Health endpoint uses `default_type` instead of `add_header` to avoid the nginx parent-header-override gotcha.

## Pre-Release Checklist

- [x] All security fixes verified locally
- [x] nginx config validated (no semgrep warnings after add_header fix)
- [x] VM reset and SSH confirmed working (35.238.125.109:22 open)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)