### PR TITLE
chore(release): v2026.05.10.4

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -2,6 +2,7 @@
 # Triggers automatically on push to main, or manually via workflow_dispatch.
 # Can also be called as a reusable workflow (workflow_call); in that mode
 # the build job is skipped (caller already built and uploaded artifacts).
+# Last reviewed: v2026.05.10.4 — deploy step ~3m, warm-up non-blocking.
 #
 # Manual usage: Actions tab → "Deploy GCP Production" → Run workflow.
 


### PR DESCRIPTION
## Test deploy #1

Minimal change — adds a comment to `deploy-gcp.yml` noting deploy timing post warm-up fix.

Purpose: validate the full GCP deploy pipeline end-to-end after the VM reset.