### PR TITLE
chore(release): v2026.05.10.6 [GH-291]

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -23,10 +23,27 @@ set +x  # Never echo commands — prevents secrets leaking into CI log streams
 if [ -z "${DEPLOY_DETACHED:-}" ]; then
   DEPLOY_LOG=/tmp/deploy-candyshop.log
   DEPLOY_DONE=/tmp/deploy-candyshop.done
+  DEPLOY_PIDFILE=/tmp/deploy-candyshop.pid
+
+  # Kill any previous deploy still running on this server.
+  # GHA job timeouts leave detached nohup processes running; on the e2-micro
+  # that starves every CPU cycle, making the new deploy hang immediately.
+  if [ -f "$DEPLOY_PIDFILE" ]; then
+    PREV_PID=$(cat "$DEPLOY_PIDFILE" 2>/dev/null || true)
+    if [ -n "$PREV_PID" ] && kill -0 "$PREV_PID" 2>/dev/null; then
+      echo "[DEPLOY] Stopping previous deploy (PID $PREV_PID) to free CPU..."
+      pkill -KILL -P "$PREV_PID" 2>/dev/null || true
+      kill -KILL "$PREV_PID" 2>/dev/null || true
+      sleep 2
+    fi
+    rm -f "$DEPLOY_PIDFILE"
+  fi
+
   rm -f "$DEPLOY_LOG" "$DEPLOY_DONE"
 
   DEPLOY_DETACHED=1 nohup bash "$0" "$@" >"$DEPLOY_LOG" 2>&1 &
   BG_PID=$!
+  echo "$BG_PID" > "$DEPLOY_PIDFILE"
 
   # Stream log back — keeps the SSH/WebSocket alive AND surfaces build output.
   # GNU tail exits automatically when the watched PID exits (Linux coreutils).
@@ -107,6 +124,7 @@ DEPLOY_START=$(date +%s)
 _on_exit() {
   local code=$?
   echo $code >/tmp/deploy-candyshop.done
+  rm -f /tmp/deploy-candyshop.pid 2>/dev/null || true
   # Ensure all ephemeral secrets files are removed on any exit path (early
   # failure, success, or signal) — don't rely solely on the CI cleanup step.
   rm -f "${ENV_FILE:-/tmp/.candyshop-build.env}" 2>/dev/null || true
@@ -151,7 +169,7 @@ echo "[DEPLOY] Loading NVM from $NVM_DIR"
 echo "[DEPLOY] Activating Node 22"
 nvm use 22 || err "Node 22 not available via nvm — run: nvm install 22"
 
-log "Node $(node --version) | PM2 $(pm2 --version)"
+log "Node $(node --version)"
 notify_telegram "$(printf '🚀 <b>Deploy started</b>  •  <code>%s</code>\nBranch: <code>%s</code>' "$_safe_hostname" "$BRANCH")"
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Kill any lingering detached deploy process before starting a new one (PID-file mechanism)
- Remove `pm2 --version` cold-start from deploy log (saves CPU on constrained VM)

## Root Cause Fixed

GHA `timeout-minutes: 20` kills the CI job but leaves the `nohup`-spawned deploy process running on the e2-micro VM. On the next deploy attempt, that zombie process consumes all CPU, causing the new deploy script to stall immediately at startup — triggering yet another timeout in a cascading loop.

## Test plan

- [ ] Deploy to GCP job completes within 25 minutes
- [ ] No lingering zombie processes from previous timed-out deploys