### PR TITLE
fix(deploy): GCP VM swap memory + verbose deploy poll logs [GH-306]

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -448,35 +448,43 @@ jobs:
       - name: Wait for deployment
         run: |
           ssh_errors=0
-          echo "Waiting for deploy script to complete on GCP (up to 15 min)..."
-          for i in $(seq 1 30); do
+          echo "Polling GCP deploy script every 20s (up to 15 min)..."
+          for i in $(seq 1 45); do
             sleep 20
-            if OUTPUT=$(ssh "$GCP_HOST" \
-              'printf "__DONE__:"; cat /tmp/deploy-candyshop.done 2>/dev/null || printf "pending"; printf "\n__LOG__:"; tail -1 /tmp/deploy-candyshop.log 2>/dev/null' \
+            elapsed=$(( i * 20 ))
+
+            if RAW=$(ssh "$GCP_HOST" \
+              'printf "DONE:%s\n" "$(cat /tmp/deploy-candyshop.done 2>/dev/null || echo pending)"
+               echo "---LOG---"
+               tail -5 /tmp/deploy-candyshop.log 2>/dev/null || echo "(no log yet)"
+               echo "---END---"' \
               2>&1); then
               ssh_errors=0
             else
               ssh_errors=$((ssh_errors + 1))
-              echo "SSH error ($ssh_errors/5): $OUTPUT"
+              echo "[${elapsed}s] SSH error ($ssh_errors/5):"
+              echo "$RAW"
               if [ "$ssh_errors" -ge 5 ]; then
                 echo "5 consecutive SSH failures — aborting"
                 exit 1
               fi
               continue
             fi
-            RESULT=$(printf '%s' "$OUTPUT" | grep -o '__DONE__:.*' | sed 's/__DONE__://')
+
+            RESULT=$(printf '%s' "$RAW" | grep '^DONE:' | sed 's/^DONE://')
+            LOG=$(printf '%s' "$RAW" | awk '/^---LOG---/{f=1;next} /^---END---/{f=0} f{print}')
+
+            echo "── [${elapsed}s | poll ${i}/45] ──────────────────────────"
+            printf '%s\n' "${LOG:-(no output yet)}"
+
             if [ -n "$RESULT" ] && [ "$RESULT" != "pending" ]; then
-              echo "Deploy finished with exit code: $RESULT"
+              echo "──────────────────────────────────────────────────"
+              echo "Deploy finished — exit code: $RESULT"
               [ "$RESULT" = "0" ] && exit 0 || exit 1
             fi
-            # Print a status line once per minute (every 3 polls × 20s = 60s)
-            if [ $(( i % 3 )) -eq 0 ]; then
-              elapsed=$(( i * 20 ))
-              LAST_LOG=$(printf '%s' "$OUTPUT" | grep '__LOG__:' | sed 's/__LOG__://' | xargs)
-              echo "Still deploying — ${elapsed}s elapsed | ${LAST_LOG:-…}"
-            fi
           done
-          echo "Timed out after 10 minutes — dumping last 50 lines of deploy log:"
+
+          echo "Timed out after 15 min — dumping last 50 lines of deploy log:"
           ssh "$GCP_HOST" 'tail -50 /tmp/deploy-candyshop.log 2>/dev/null || true' || true
           exit 1
 

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -310,6 +310,34 @@ jobs:
             exit 1
           fi
 
+      - name: Ensure swap is configured on GCP VM
+        run: |
+          ssh "$GCP_HOST" bash -s << 'SWAP'
+          set -e
+          if [ "$(swapon --show | wc -l)" -eq 0 ]; then
+            echo "[SWAP] No swap active — creating 2 GB swapfile..."
+            sudo fallocate -l 2G /swapfile
+            sudo chmod 600 /swapfile
+            sudo mkswap /swapfile
+            sudo swapon /swapfile
+            grep -q '/swapfile' /etc/fstab \
+              || echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab > /dev/null
+            echo "[SWAP] Swap created and activated."
+          else
+            echo "[SWAP] Swap already active — skipping."
+          fi
+          cur=$(cat /proc/sys/vm/swappiness 2>/dev/null || echo 60)
+          if [ "$cur" -ne 10 ]; then
+            sudo sysctl -w vm.swappiness=10 > /dev/null
+            grep -q 'vm.swappiness' /etc/sysctl.conf 2>/dev/null \
+              || echo 'vm.swappiness=10' | sudo tee -a /etc/sysctl.conf > /dev/null
+            echo "[SWAP] vm.swappiness set to 10."
+          fi
+          echo "[SWAP] Memory status:"
+          free -h
+          swapon --show
+          SWAP
+
       - name: Compute app version
         id: app_version
         run: |


### PR DESCRIPTION
## Summary

Two deploy-workflow improvements combined into one hotfix:

**Swap memory (GH-306)**
- Adds idempotent "Ensure swap is configured on GCP VM" step — runs every deploy
- Creates a 2 GB swapfile on first run; skips if swap already active
- Sets `vm.swappiness=10` so the kernel strongly prefers RAM before touching swap
- Persists via `/etc/fstab` + `/etc/sysctl.conf` — survives reboots and VM rebuilds
- Prints `free -h` + `swapon --show` so every deploy log shows memory status

**Verbose poll logs (GH-304)**
- "Wait for deployment" now polls every 20 s and prints last 5 log lines each iteration (was 1 line / 60 s)
- Adds `── [Xs | poll N/45] ──` separator per iteration for easy CI log scanning
- Uses `awk` to extract log section between `---LOG---` / `---END---` sentinels
- Extends timeout to 15 min (45 × 20 s) and fixes the timeout message

## Related Issues

Closes #306
Closes #304

## Why targeting main

The e2-micro (1 GB RAM) is the only GCP free-tier option — without swap the VM OOM-kills processes during deploys. Both fixes are production-critical.

## Test plan

- [ ] Trigger a production deploy — confirm `[SWAP]` lines appear in the "Ensure swap" step
- [ ] On a fresh VM rebuild, confirm `/swapfile` shows in `swapon --show`
- [ ] On subsequent deploys, confirm "Swap already active — skipping" is printed
- [ ] Confirm "Wait for deployment" prints 5 log lines every 20 s during a deploy

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)