### PR TITLE
fix(deploy): use sudo swapon to fix PATH on GCP VM [GH-306]

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -350,7 +350,7 @@ jobs:
         run: |
           ssh "$GCP_HOST" bash -s << 'SWAP'
           set -e
-          if [ "$(swapon --show | wc -l)" -eq 0 ]; then
+          if [ "$(sudo swapon --show | wc -l)" -eq 0 ]; then
             echo "[SWAP] No swap active — creating 2 GB swapfile..."
             sudo fallocate -l 2G /swapfile
             sudo chmod 600 /swapfile
@@ -371,7 +371,7 @@ jobs:
           fi
           echo "[SWAP] Memory status:"
           free -h
-          swapon --show
+          sudo swapon --show
           SWAP
 
       - name: Compute app version


### PR DESCRIPTION
## Summary

`swapon` lives in `/sbin` which is not in the non-root SSH PATH.
Two lines changed: the active-swap check and the final `swapon --show` now both use `sudo`.

Previous deploy created swap successfully but failed at exit with code 127.

## Related Issue

Closes #306

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)