### PR TITLE
chore(infra): add app warmer and fix RAM alert threshold [GH-311]

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -531,6 +531,19 @@ jobs:
             'docker ps --filter name=candyshop-prod --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || true' \
             || echo "Verify skipped (SSH timed out) — deploy confirmed by wait loop above"
 
+      - name: Warm up apps
+        run: |
+          # Hit one representative route per app immediately after deploy so the
+          # first real user never sees a cold-start. The in-container warmer.sh
+          # keeps them warm from here on (every 12 min via supervisord).
+          # Uses the nginx proxy port (9090) — same path the tunnel serves.
+          APPS="/auth/en /store/en /admin/en /playground/en /en /payments/en /studio/en"
+          for path in $APPS; do
+            status=$(ssh "$GCP_HOST" \
+              "curl -s -o /dev/null -w '%{http_code}' --max-time 15 http://localhost:9090${path} 2>/dev/null || echo ERR")
+            echo "  localhost:9090${path} → HTTP ${status}"
+          done
+
       - name: Purge Cloudflare cache
         env:
           CF_API_TOKEN: ${{ secrets.PROD_CF_API_TOKEN }}

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -6,7 +6,7 @@
 # =============================================================================
 FROM node:22-alpine AS runner
 
-RUN apk add --no-cache nginx supervisor netcat-openbsd && \
+RUN apk add --no-cache nginx supervisor netcat-openbsd curl && \
     addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs && \
     mkdir -p /var/log/nginx /var/log/supervisor /var/run/nginx /run/nginx && \
@@ -19,6 +19,7 @@ COPY docker/prod/nginx.conf           /etc/nginx/nginx.conf
 COPY docker/prod/supervisord.conf     /etc/supervisor/conf.d/supervisord.conf
 COPY docker/watcher.mjs               /app/watcher.mjs
 COPY docker/boot-reporter.mjs         /app/boot-reporter.mjs
+COPY docker/warmer.sh                 /app/warmer.sh
 
 # Standalone builds pre-built by CI (rsynced to server before this runs)
 COPY apps/store/.next/standalone      /app/store/
@@ -60,7 +61,8 @@ RUN rm -rf \
     /app/payments/apps/payments/node_modules \
     /app/playground/apps/playground/node_modules \
     /app/studio/apps/studio/node_modules && \
-    chown -R nextjs:nodejs /app
+    chown -R nextjs:nodejs /app && \
+    chmod +x /app/warmer.sh
 
 EXPOSE 8080
 

--- a/docker/prod/supervisord.conf
+++ b/docker/prod/supervisord.conf
@@ -136,6 +136,20 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
+[program:warmer]
+command=/bin/sh /app/warmer.sh
+directory=/app
+user=nextjs
+autostart=true
+autorestart=true
+startretries=5
+startsecs=0
+stopwaitsecs=5
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
 [program:boot-reporter]
 command=node /app/boot-reporter.mjs
 directory=/app

--- a/docker/warmer.sh
+++ b/docker/warmer.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Warm-up loop — hits every Next.js app to prevent cold starts on the e2-micro.
+# Runs as a supervisord program inside the prod container.
+# Fires immediately on startup (after apps are ready), then every 12 minutes.
+
+set -eu
+
+INTERVAL=720  # 12 minutes
+
+# port:path pairs — one representative route per app
+APPS="
+5000:/auth/en
+5001:/store/en
+5002:/admin/en
+5003:/playground/en
+5004:/en
+5005:/payments/en
+5006:/studio/en
+"
+
+log() { printf '[WARMER] %s %s\n' "$(date -u '+%H:%M:%S')" "$*"; }
+
+# Wait until every app's TCP port accepts connections
+log "Waiting for all apps to be ready..."
+for entry in $APPS; do
+  port="${entry%%:*}"
+  until nc -z 127.0.0.1 "$port" 2>/dev/null; do sleep 2; done
+  log "  port ${port} ready"
+done
+log "All apps ready — starting warm-up loop (every ${INTERVAL}s)."
+
+warm() {
+  for entry in $APPS; do
+    port="${entry%%:*}"
+    path="${entry#*:}"
+    url="http://127.0.0.1:${port}${path}"
+    status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url" 2>/dev/null || echo "ERR")
+    log "  :${port}${path} → HTTP ${status}"
+  done
+}
+
+while true; do
+  log "--- warm-up start ---"
+  warm
+  log "--- warm-up done. next in ${INTERVAL}s ---"
+  sleep "$INTERVAL"
+done

--- a/docker/watcher.mjs
+++ b/docker/watcher.mjs
@@ -32,8 +32,7 @@ const STARTUP_GRACE_MS = 90_000; // wait before first check so apps can boot
 const REPEAT_ALERT_MS = 2 * 60 * 60 * 1_000;
 
 // System resource thresholds
-const RAM_CRITICAL_MB = 200;
-const RAM_WARN_MB     = 400;
+const RAM_CRITICAL_PCT  = 2;   // alert only when free RAM drops below 2% of total
 const DISK_CRITICAL_PCT = 90;
 const DISK_WARN_PCT     = 80;
 
@@ -168,15 +167,26 @@ async function maybeAlert(key, isNew, text) {
 
 // ── System health checks ──────────────────────────────────────────────────────
 
-function readRamFreeBytes() {
+/** Returns { freeMB, totalMB } from /proc/meminfo, or null if unavailable. */
+function readRamInfo() {
   try {
     const meminfo = readFileSync("/proc/meminfo", "utf8");
-    // MemAvailable is the best indicator of free+reclaimable RAM
-    const match = meminfo.match(/^MemAvailable:\s+(\d+)\s+kB/m);
-    if (match) return Number(match[1]) * 1024;
-    // Fallback: MemFree
-    const fallback = meminfo.match(/^MemFree:\s+(\d+)\s+kB/m);
-    if (fallback) return Number(fallback[1]) * 1024;
+    const total = meminfo.match(/^MemTotal:\s+(\d+)\s+kB/m);
+    const avail = meminfo.match(/^MemAvailable:\s+(\d+)\s+kB/m);
+    if (total && avail) {
+      return {
+        totalMB: Number(total[1]) / 1024,
+        freeMB:  Number(avail[1]) / 1024,
+      };
+    }
+    // Fallback: MemFree (less accurate — doesn't include reclaimable cache)
+    const free = meminfo.match(/^MemFree:\s+(\d+)\s+kB/m);
+    if (total && free) {
+      return {
+        totalMB: Number(total[1]) / 1024,
+        freeMB:  Number(free[1]) / 1024,
+      };
+    }
   } catch {
     // not Linux or no /proc — ignore
   }
@@ -229,26 +239,22 @@ function isTunnelRunning() {
 
 async function checkSystem() {
   // ── RAM ──
-  const ramBytes = readRamFreeBytes();
-  if (ramBytes !== null) {
-    const ramMB = ramBytes / (1024 * 1024);
+  const ramInfo = readRamInfo();
+  if (ramInfo !== null) {
+    const { freeMB, totalMB } = ramInfo;
+    const freePct = (freeMB / totalMB) * 100;
     const prev = sysState.ram;
-    let next;
-    if (ramMB < RAM_CRITICAL_MB) next = "critical";
-    else if (ramMB < RAM_WARN_MB) next = "warning";
-    else next = "ok";
+    const next = freePct < RAM_CRITICAL_PCT ? "critical" : "ok";
 
-    if (next !== "ok") {
-      const icon = next === "critical" ? "🔴" : "🟡";
-      const severity = next === "critical" ? "CRITICAL" : "warning";
-      const msg = `${icon} <b>RAM ${severity}</b>\nAvailable: <code>${ramMB.toFixed(0)} MB</code>  •  <code>${CONTAINER_NAME}</code>`;
-      await maybeAlert("ram", prev === "ok" || prev === "unknown", msg);
-      console.error(`[watcher] RAM ${next}: ${ramMB.toFixed(0)} MB available`);
-    } else if (prev === "warning" || prev === "critical") {
-      await sendTelegram(`✅ <b>RAM recovered</b>\nAvailable: <code>${ramMB.toFixed(0)} MB</code>  •  <code>${CONTAINER_NAME}</code>`);
-      console.log(`[watcher] RAM recovered: ${ramMB.toFixed(0)} MB`);
+    if (next === "critical") {
+      const msg = `🔴 <b>RAM CRITICAL</b>\nAvailable: <code>${freeMB.toFixed(0)} MB</code> (<code>${freePct.toFixed(1)}%</code> of <code>${totalMB.toFixed(0)} MB</code>)  •  <code>${CONTAINER_NAME}</code>`;
+      await maybeAlert("ram", prev !== "critical", msg);
+      console.error(`[watcher] RAM critical: ${freeMB.toFixed(0)} MB (${freePct.toFixed(1)}%) of ${totalMB.toFixed(0)} MB`);
+    } else if (prev === "critical") {
+      await sendTelegram(`✅ <b>RAM recovered</b>\nAvailable: <code>${freeMB.toFixed(0)} MB</code> (<code>${freePct.toFixed(1)}%</code>)  •  <code>${CONTAINER_NAME}</code>`);
+      console.log(`[watcher] RAM recovered: ${freeMB.toFixed(0)} MB (${freePct.toFixed(1)}%)`);
     } else {
-      console.log(`[watcher] RAM ok: ${ramMB.toFixed(0)} MB`);
+      console.log(`[watcher] RAM ok: ${freeMB.toFixed(0)} MB (${freePct.toFixed(1)}% of ${totalMB.toFixed(0)} MB)`);
     }
     sysState.ram = next;
   }


### PR DESCRIPTION
## Summary

- Add a supervisord-managed `warmer.sh` that keeps all 7 Next.js apps warm inside the Docker container, preventing cold starts on the GCP e2-micro VM
- Add a one-shot post-deploy warm step to `deploy-gcp.yml` for immediate warmup after each new deploy
- Replace fixed-MB RAM thresholds in `watcher.mjs` with a 2% percentage-based threshold to stop alert spam on the 1 GB VM

## Related Issue

Closes #311

## Changes

- `docker/warmer.sh` — new supervisord program; waits for all 7 app ports, then loops every 12 min hitting one route per app via internal ports
- `docker/prod/supervisord.conf` — add `[program:warmer]`
- `docker/prod/Dockerfile` — add `curl` to apk (needed by warmer), COPY + chmod warmer.sh
- `.github/workflows/deploy-gcp.yml` — post-deploy step: SSH into VM and curl all 7 routes through nginx immediately after container starts
- `docker/watcher.mjs` — replace `RAM_CRITICAL_MB=200` / `RAM_WARN_MB=400` with `RAM_CRITICAL_PCT=2` (reads `MemTotal` + `MemAvailable` from `/proc/meminfo`); removes warning tier; notification now shows MB + % + total

## Testing

- Warmer logs will appear in `docker logs` under `[WARMER]` prefix
- RAM alert will now only fire when free RAM < ~20 MB on the 1 GB VM (instead of < 200 MB)

---

Generated with [Claude Code](https://claude.com/claude-code)