### PR TITLE
chore(ci): send Telegram alert when backup workflow fails

### DIFF
--- a/.github/workflows/backup-scheduled.yml
+++ b/.github/workflows/backup-scheduled.yml
@@ -82,3 +82,58 @@ jobs:
         with:
           path: .backup-hash
           key: backup-hash-${{ github.run_id }}
+
+      - name: Notify Telegram on failure
+        if: failure()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_THREAD_ID: ${{ secrets.TELEGRAM_BACKUPS_THREAD_ID }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SERVER_HOSTNAME: "github.com/${{ github.repository }}"
+        run: |
+          python3 - <<'EOF'
+          import html, json, os, urllib.error, urllib.request
+
+          token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+          chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
+          if not token or not chat_id:
+              raise SystemExit("Missing required secret: TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID")
+
+          source = os.environ.get("SERVER_HOSTNAME", "github-actions")
+          run_url = os.environ.get("RUN_URL", "")
+          text = (
+              "❌ <b>Backup Failed</b>\n\n"
+              f"The scheduled production backup did not complete successfully.\n\n"
+              f"🔗 {html.escape(run_url)}\n\n"
+              f"\U0001F4CD {source}"
+          )
+
+          payload = {
+              "chat_id": chat_id,
+              "text": text,
+              "parse_mode": "HTML",
+          }
+          thread_id = os.environ.get("TELEGRAM_THREAD_ID", "").strip()
+          if thread_id:
+              try:
+                  payload["message_thread_id"] = int(thread_id)
+              except ValueError:
+                  print(f"Warning: invalid TELEGRAM_THREAD_ID={thread_id!r}, sending without thread")
+
+          data = json.dumps(payload).encode()
+          req = urllib.request.Request(
+              f"https://api.telegram.org/bot{token}/sendMessage",
+              data=data,
+              headers={"Content-Type": "application/json"},
+          )
+          try:
+              with urllib.request.urlopen(req, timeout=10) as resp:
+                  print(f"Notification sent: {resp.read().decode()}")
+          except urllib.error.HTTPError as e:
+              print(f"Telegram API error {e.code}: {e.read().decode('utf-8', errors='replace')}")
+              raise
+          except urllib.error.URLError as e:
+              print(f"Network error reaching Telegram: {e.reason}")
+              raise
+          EOF


### PR DESCRIPTION
## Summary

- Adds a `Notify Telegram on failure` step to `backup-scheduled.yml` that fires whenever any preceding step in the job fails
- Posts to `TELEGRAM_BACKUPS_THREAD_ID` (thread 6 — same thread where successful backup messages appear)
- Message includes the run URL so you can jump directly to the failing logs
- Source footer (`📍 github.com/repo`) matches the style used in all other Telegram notifications in this repo

## Changes

- `.github/workflows/backup-scheduled.yml` — new `if: failure()` step at the end of the `backup` job using the same Python3 + urllib pattern as `notify-bug-issue.yml`

## Testing

Trigger the workflow manually via `gh workflow run backup-scheduled.yml --ref <branch>` with a deliberately broken step to verify the alert fires and lands in the correct Telegram thread.

---

Generated with [Claude Code](https://claude.com/claude-code)