### PR TITLE
feat(products): show seller card on product detail page [GH-319]

### DIFF
--- a/.ai-context/task-outputs/GH-319/00-task-overview.md
+++ b/.ai-context/task-outputs/GH-319/00-task-overview.md
@@ -2,14 +2,14 @@
 
 ## Issue Details
 
-| Field        | Value                                                                                 |
-|--------------|---------------------------------------------------------------------------------------|
-| **Issue**    | [#319](https://github.com/furrycolombia-sys/candyshop/issues/319)                    |
-| **Title**    | feat(store): show seller/creator info on product pages                                |
-| **Type**     | feat                                                                                  |
-| **Labels**   | enhancement                                                                           |
-| **Assignee** | —                                                                                     |
-| **Created**  | 2026-05-14                                                                            |
+| Field        | Value                                                             |
+| ------------ | ----------------------------------------------------------------- |
+| **Issue**    | [#319](https://github.com/furrycolombia-sys/candyshop/issues/319) |
+| **Title**    | feat(store): show seller/creator info on product pages            |
+| **Type**     | feat                                                              |
+| **Labels**   | enhancement                                                       |
+| **Assignee** | —                                                                 |
+| **Created**  | 2026-05-14                                                        |
 
 ## Description
 
@@ -19,14 +19,14 @@ Product pages in the store don't show who created/sells the item. We should disp
 
 The infrastructure is already in place but not wired up to the UI:
 
-| What | Status |
-|------|--------|
-| `user_profiles` table (`display_name`, `display_avatar_url`, `avatar_url`) | ✅ exists |
-| `products.seller_id` FK to `auth.users` | ✅ exists |
-| `useSellerProfiles()` hook in store | ✅ exists (used in cart only) |
-| Public read-only profile page at `auth/[locale]/profile/[id]` | ✅ exists |
-| Seller info on product detail page | ❌ missing |
-| Seller info on product cards | ❌ missing |
+| What                                                                       | Status                        |
+| -------------------------------------------------------------------------- | ----------------------------- |
+| `user_profiles` table (`display_name`, `display_avatar_url`, `avatar_url`) | ✅ exists                     |
+| `products.seller_id` FK to `auth.users`                                    | ✅ exists                     |
+| `useSellerProfiles()` hook in store                                        | ✅ exists (used in cart only) |
+| Public read-only profile page at `auth/[locale]/profile/[id]`              | ✅ exists                     |
+| Seller info on product detail page                                         | ❌ missing                    |
+| Seller info on product cards                                               | ❌ missing                    |
 
 ## Acceptance Criteria
 

--- a/.ai-context/task-outputs/GH-319/00-task-overview.md
+++ b/.ai-context/task-outputs/GH-319/00-task-overview.md
@@ -1,0 +1,60 @@
+# Task Overview: GH-319
+
+## Issue Details
+
+| Field        | Value                                                                                 |
+|--------------|---------------------------------------------------------------------------------------|
+| **Issue**    | [#319](https://github.com/furrycolombia-sys/candyshop/issues/319)                    |
+| **Title**    | feat(store): show seller/creator info on product pages                                |
+| **Type**     | feat                                                                                  |
+| **Labels**   | enhancement                                                                           |
+| **Assignee** | —                                                                                     |
+| **Created**  | 2026-05-14                                                                            |
+
+## Description
+
+Product pages in the store don't show who created/sells the item. We should display the seller's avatar, display name, and a link to their read-only profile on the product detail page.
+
+## Current State
+
+The infrastructure is already in place but not wired up to the UI:
+
+| What | Status |
+|------|--------|
+| `user_profiles` table (`display_name`, `display_avatar_url`, `avatar_url`) | ✅ exists |
+| `products.seller_id` FK to `auth.users` | ✅ exists |
+| `useSellerProfiles()` hook in store | ✅ exists (used in cart only) |
+| Public read-only profile page at `auth/[locale]/profile/[id]` | ✅ exists |
+| Seller info on product detail page | ❌ missing |
+| Seller info on product cards | ❌ missing |
+
+## Acceptance Criteria
+
+- [ ] Product detail page shows a **seller card** with:
+  - Avatar (`display_avatar_url` → fallback `avatar_url` → initials placeholder)
+  - Display name (`display_name` → fallback to email prefix)
+  - Link to their public profile at `auth/[locale]/profile/[seller_id]`
+- [ ] The seller card is **read-only** — no edit affordances for buyers
+- [ ] Loading and empty states handled gracefully (`seller_id` may be null on legacy products)
+- [ ] Seller info is **not** shown if `seller_id` is null
+- [ ] Unit tests for the new component
+
+## Out of Scope
+
+- Seller-specific product listing page (browse all products by a seller)
+- Seller badges or ratings
+- Contact seller functionality
+
+## Technical Notes
+
+- Reuse the existing `useSellerProfiles()` hook (`apps/store/src/features/cart/application/hooks/useSellerProfiles.ts`) or extract it to a more shared location if needed
+- `user_profiles` has public RLS read access — no auth required to fetch seller info
+- The profile link should point to the auth app URL (`NEXT_PUBLIC_AUTH_URL/[locale]/profile/[id]`)
+
+## Dependencies
+
+- None
+
+## Missing Information
+
+- None — requirements are clear

--- a/.ai-context/task-outputs/GH-319/01-setup.md
+++ b/.ai-context/task-outputs/GH-319/01-setup.md
@@ -2,12 +2,12 @@
 
 ## Branch Information
 
-| Field         | Value                                          |
-|---------------|------------------------------------------------|
+| Field         | Value                                           |
+| ------------- | ----------------------------------------------- |
 | **Branch**    | `feat/GH-319_Show-Seller-Info-On-Product-Pages` |
-| **Source**    | `develop`                                      |
-| **PR Target** | `develop`                                      |
-| **Created**   | 2026-05-14                                     |
+| **Source**    | `develop`                                       |
+| **PR Target** | `develop`                                       |
+| **Created**   | 2026-05-14                                      |
 
 ## Git Status
 

--- a/.ai-context/task-outputs/GH-319/01-setup.md
+++ b/.ai-context/task-outputs/GH-319/01-setup.md
@@ -1,0 +1,26 @@
+# Setup: GH-319
+
+## Branch Information
+
+| Field         | Value                                          |
+|---------------|------------------------------------------------|
+| **Branch**    | `feat/GH-319_Show-Seller-Info-On-Product-Pages` |
+| **Source**    | `develop`                                      |
+| **PR Target** | `develop`                                      |
+| **Created**   | 2026-05-14                                     |
+
+## Git Status
+
+Clean — branched from develop at `53212f3` (0 ahead/behind at branch time).
+
+## Quick Links
+
+- [GitHub Issue](https://github.com/furrycolombia-sys/candyshop/issues/319)
+- [Task Artifacts](./)
+
+## Next Steps
+
+1. Review `02-analysis.md`
+2. Create implementation plan → `03-implementation-plan.md`
+3. Implement with TDD → `04-implementation-log.md`
+4. Submit PR → `/submit-pr` (targets `develop`)

--- a/.ai-context/task-outputs/GH-319/02-analysis.md
+++ b/.ai-context/task-outputs/GH-319/02-analysis.md
@@ -1,0 +1,128 @@
+# Analysis: GH-319
+
+## Branch Context
+
+| Field         | Value                                          |
+|---------------|------------------------------------------------|
+| **Branch**    | `feat/GH-319_Show-Seller-Info-On-Product-Pages` |
+| **Type**      | `feat`                                         |
+| **Source**    | `develop`                                      |
+| **PR Target** | `develop`                                      |
+
+---
+
+## Relevant Files
+
+| File | Purpose | Action Needed |
+|------|---------|---------------|
+| `apps/store/src/features/products/presentation/pages/ProductDetailPage.tsx` | Product detail page — lines 77-79 are where seller card slots in | Modify: add `<SellerCard>` after `<ProductSections>` |
+| `apps/store/src/features/cart/application/hooks/useSellerProfiles.ts` | Fetches `Record<sellerId, displayName>` for a list of IDs | Reference only — create a new product-scoped hook instead (it only returns display name, not avatar) |
+| `apps/store/src/features/products/domain/` | Product domain types | Reference: `seller_id: string \| null` on `Product` |
+| `packages/ui/src/components/avatar.tsx` | `<Avatar>` + `<AvatarImage>` + `<AvatarFallback>` | Use as-is |
+| `packages/shared/src/config/appUrls.ts` | `appUrls.auth` — resolved from env | Use `appUrls.auth` for profile link |
+| `apps/store/src/shared/infrastructure/i18n/messages/en.json` | Translation keys — namespace `products.detail` | Add: `viewProfile` key (existing `seller` key covers the title) |
+| `apps/store/src/shared/infrastructure/i18n/messages/es.json` | Spanish translations | Add: matching `viewProfile` key |
+| `apps/store/src/features/products/presentation/components/ProductDetail/HeroSection.test.tsx` | Reference test pattern | Follow for new component tests |
+
+---
+
+## Existing Patterns
+
+### useSellerProfiles (cart feature)
+
+**Location:** `apps/store/src/features/cart/application/hooks/useSellerProfiles.ts`
+
+- Takes `string[]` (array of seller IDs), returns `Record<sellerId, displayName>` via React Query
+- Queries `user_profiles` selecting `id, display_name, email`
+- Fallback: `display_name ?? email.split("@")[0]`
+- staleTime: 60s, disabled when no IDs
+
+**Gap:** Only fetches `display_name` — does **not** fetch `display_avatar_url` or `avatar_url`. A new hook is needed.
+
+### Avatar Component
+
+**Location:** `packages/ui/src/components/avatar.tsx`
+
+Composite API: `<Avatar>` + `<AvatarImage src={...} />` + `<AvatarFallback>{initials}</AvatarFallback>`
+
+### appUrls
+
+**Location:** `packages/shared/src/config/appUrls.ts`
+
+`appUrls.auth` resolves to the auth app base URL. Profile link pattern:
+```typescript
+`${appUrls.auth}/${locale}/profile/${sellerId}`
+```
+
+### i18n Namespace
+
+**Location:** `apps/store/src/shared/infrastructure/i18n/messages/en.json` — namespace `products.detail`
+
+Existing relevant keys:
+- `"seller": "About the Seller"` — use as section title
+- Add: `"viewProfile": "View profile"`
+
+### Test Pattern
+
+**Reference:** `HeroSection.test.tsx`
+- `vi.mock()` all external hooks
+- `vi.mock("shared", ...)` with `tid` returning `{ "data-testid": id }`
+- `vi.mock("next-intl", ...)` returning key strings
+- Factory function `makeProduct(overrides)` for test data
+- Assertions via `data-testid`
+
+---
+
+## Requirements Analysis
+
+| Requirement | Existing Support | Gap / Action |
+|-------------|-----------------|--------------|
+| Fetch seller display name | `useSellerProfiles()` ✅ | Must also fetch `display_avatar_url` + `avatar_url` — extend or new hook |
+| Fetch seller avatar URL | Nothing in store ❌ | New hook queries both name + avatar fields |
+| Render avatar with fallback | `<Avatar>` in ui package ✅ | None |
+| Link to public profile | `appUrls.auth` ✅ | Compose URL with locale + seller_id |
+| Hide when seller_id is null | Pattern in cart ✅ | Guard in `ProductDetailPage` |
+| i18n section title | `products.detail.seller` ✅ | None |
+| i18n "View profile" label | Missing ❌ | Add key to en.json + es.json |
+| Unit tests | Pattern established ✅ | Create `SellerCard.test.tsx` |
+
+---
+
+## Technical Considerations
+
+- **Hook placement:** Create `useSellerInfo(sellerId: string | null)` in `apps/store/src/features/products/application/hooks/`. It wraps a Supabase query for a single seller, returning `{ displayName, avatarUrl }`. Keep it in the products feature — no need to share with cart yet.
+- **Avatar fallback:** Use first letter of display name (uppercased) as the `<AvatarFallback>` initials.
+- **Profile URL:** Must include locale from `useLocale()` — the auth app uses `/[locale]/profile/[id]`.
+- **Null guard:** `ProductDetailPage` already receives the full `product` object. Check `product.seller_id` before rendering `<SellerCard>`.
+- **No breaking changes** — purely additive UI change.
+
+---
+
+## Implementation Summary
+
+### Files to Create
+
+| File | Description |
+|------|-------------|
+| `apps/store/src/features/products/application/hooks/useSellerInfo.ts` | New hook: queries `user_profiles` for a single seller, returns `displayName` + `avatarUrl` |
+| `apps/store/src/features/products/presentation/components/SellerCard/SellerCard.tsx` | New component: avatar, name, profile link |
+| `apps/store/src/features/products/presentation/components/SellerCard/SellerCard.test.tsx` | Unit tests |
+| `apps/store/src/features/products/presentation/components/SellerCard/index.ts` | Barrel export |
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `apps/store/src/features/products/presentation/pages/ProductDetailPage.tsx` | Add `<SellerCard sellerId={product.seller_id} />` after `<ProductSections>` |
+| `apps/store/src/shared/infrastructure/i18n/messages/en.json` | Add `products.detail.viewProfile` |
+| `apps/store/src/shared/infrastructure/i18n/messages/es.json` | Add `products.detail.viewProfile` (Spanish) |
+
+### Key Insights
+
+1. The `useSellerProfiles` cart hook won't work as-is — it takes an array and doesn't return avatar URLs. A dedicated single-seller hook is cleaner for the product detail use case.
+2. All required infrastructure (Avatar component, appUrls, i18n namespace) exists — this is a pure presentation-layer gap.
+3. The slot in `ProductDetailPage` is obvious: after `<ProductSections product={product} />` on line 77, before `<MobileBarWithCart>`.
+
+## Questions / Blockers
+
+- None

--- a/.ai-context/task-outputs/GH-319/02-analysis.md
+++ b/.ai-context/task-outputs/GH-319/02-analysis.md
@@ -2,27 +2,27 @@
 
 ## Branch Context
 
-| Field         | Value                                          |
-|---------------|------------------------------------------------|
+| Field         | Value                                           |
+| ------------- | ----------------------------------------------- |
 | **Branch**    | `feat/GH-319_Show-Seller-Info-On-Product-Pages` |
-| **Type**      | `feat`                                         |
-| **Source**    | `develop`                                      |
-| **PR Target** | `develop`                                      |
+| **Type**      | `feat`                                          |
+| **Source**    | `develop`                                       |
+| **PR Target** | `develop`                                       |
 
 ---
 
 ## Relevant Files
 
-| File | Purpose | Action Needed |
-|------|---------|---------------|
-| `apps/store/src/features/products/presentation/pages/ProductDetailPage.tsx` | Product detail page — lines 77-79 are where seller card slots in | Modify: add `<SellerCard>` after `<ProductSections>` |
-| `apps/store/src/features/cart/application/hooks/useSellerProfiles.ts` | Fetches `Record<sellerId, displayName>` for a list of IDs | Reference only — create a new product-scoped hook instead (it only returns display name, not avatar) |
-| `apps/store/src/features/products/domain/` | Product domain types | Reference: `seller_id: string \| null` on `Product` |
-| `packages/ui/src/components/avatar.tsx` | `<Avatar>` + `<AvatarImage>` + `<AvatarFallback>` | Use as-is |
-| `packages/shared/src/config/appUrls.ts` | `appUrls.auth` — resolved from env | Use `appUrls.auth` for profile link |
-| `apps/store/src/shared/infrastructure/i18n/messages/en.json` | Translation keys — namespace `products.detail` | Add: `viewProfile` key (existing `seller` key covers the title) |
-| `apps/store/src/shared/infrastructure/i18n/messages/es.json` | Spanish translations | Add: matching `viewProfile` key |
-| `apps/store/src/features/products/presentation/components/ProductDetail/HeroSection.test.tsx` | Reference test pattern | Follow for new component tests |
+| File                                                                                          | Purpose                                                          | Action Needed                                                                                        |
+| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `apps/store/src/features/products/presentation/pages/ProductDetailPage.tsx`                   | Product detail page — lines 77-79 are where seller card slots in | Modify: add `<SellerCard>` after `<ProductSections>`                                                 |
+| `apps/store/src/features/cart/application/hooks/useSellerProfiles.ts`                         | Fetches `Record<sellerId, displayName>` for a list of IDs        | Reference only — create a new product-scoped hook instead (it only returns display name, not avatar) |
+| `apps/store/src/features/products/domain/`                                                    | Product domain types                                             | Reference: `seller_id: string \| null` on `Product`                                                  |
+| `packages/ui/src/components/avatar.tsx`                                                       | `<Avatar>` + `<AvatarImage>` + `<AvatarFallback>`                | Use as-is                                                                                            |
+| `packages/shared/src/config/appUrls.ts`                                                       | `appUrls.auth` — resolved from env                               | Use `appUrls.auth` for profile link                                                                  |
+| `apps/store/src/shared/infrastructure/i18n/messages/en.json`                                  | Translation keys — namespace `products.detail`                   | Add: `viewProfile` key (existing `seller` key covers the title)                                      |
+| `apps/store/src/shared/infrastructure/i18n/messages/es.json`                                  | Spanish translations                                             | Add: matching `viewProfile` key                                                                      |
+| `apps/store/src/features/products/presentation/components/ProductDetail/HeroSection.test.tsx` | Reference test pattern                                           | Follow for new component tests                                                                       |
 
 ---
 
@@ -50,8 +50,9 @@ Composite API: `<Avatar>` + `<AvatarImage src={...} />` + `<AvatarFallback>{init
 **Location:** `packages/shared/src/config/appUrls.ts`
 
 `appUrls.auth` resolves to the auth app base URL. Profile link pattern:
+
 ```typescript
-`${appUrls.auth}/${locale}/profile/${sellerId}`
+`${appUrls.auth}/${locale}/profile/${sellerId}`;
 ```
 
 ### i18n Namespace
@@ -59,12 +60,14 @@ Composite API: `<Avatar>` + `<AvatarImage src={...} />` + `<AvatarFallback>{init
 **Location:** `apps/store/src/shared/infrastructure/i18n/messages/en.json` — namespace `products.detail`
 
 Existing relevant keys:
+
 - `"seller": "About the Seller"` — use as section title
 - Add: `"viewProfile": "View profile"`
 
 ### Test Pattern
 
 **Reference:** `HeroSection.test.tsx`
+
 - `vi.mock()` all external hooks
 - `vi.mock("shared", ...)` with `tid` returning `{ "data-testid": id }`
 - `vi.mock("next-intl", ...)` returning key strings
@@ -75,16 +78,16 @@ Existing relevant keys:
 
 ## Requirements Analysis
 
-| Requirement | Existing Support | Gap / Action |
-|-------------|-----------------|--------------|
-| Fetch seller display name | `useSellerProfiles()` ✅ | Must also fetch `display_avatar_url` + `avatar_url` — extend or new hook |
-| Fetch seller avatar URL | Nothing in store ❌ | New hook queries both name + avatar fields |
-| Render avatar with fallback | `<Avatar>` in ui package ✅ | None |
-| Link to public profile | `appUrls.auth` ✅ | Compose URL with locale + seller_id |
-| Hide when seller_id is null | Pattern in cart ✅ | Guard in `ProductDetailPage` |
-| i18n section title | `products.detail.seller` ✅ | None |
-| i18n "View profile" label | Missing ❌ | Add key to en.json + es.json |
-| Unit tests | Pattern established ✅ | Create `SellerCard.test.tsx` |
+| Requirement                 | Existing Support            | Gap / Action                                                             |
+| --------------------------- | --------------------------- | ------------------------------------------------------------------------ |
+| Fetch seller display name   | `useSellerProfiles()` ✅    | Must also fetch `display_avatar_url` + `avatar_url` — extend or new hook |
+| Fetch seller avatar URL     | Nothing in store ❌         | New hook queries both name + avatar fields                               |
+| Render avatar with fallback | `<Avatar>` in ui package ✅ | None                                                                     |
+| Link to public profile      | `appUrls.auth` ✅           | Compose URL with locale + seller_id                                      |
+| Hide when seller_id is null | Pattern in cart ✅          | Guard in `ProductDetailPage`                                             |
+| i18n section title          | `products.detail.seller` ✅ | None                                                                     |
+| i18n "View profile" label   | Missing ❌                  | Add key to en.json + es.json                                             |
+| Unit tests                  | Pattern established ✅      | Create `SellerCard.test.tsx`                                             |
 
 ---
 
@@ -102,20 +105,20 @@ Existing relevant keys:
 
 ### Files to Create
 
-| File | Description |
-|------|-------------|
-| `apps/store/src/features/products/application/hooks/useSellerInfo.ts` | New hook: queries `user_profiles` for a single seller, returns `displayName` + `avatarUrl` |
-| `apps/store/src/features/products/presentation/components/SellerCard/SellerCard.tsx` | New component: avatar, name, profile link |
-| `apps/store/src/features/products/presentation/components/SellerCard/SellerCard.test.tsx` | Unit tests |
-| `apps/store/src/features/products/presentation/components/SellerCard/index.ts` | Barrel export |
+| File                                                                                      | Description                                                                                |
+| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `apps/store/src/features/products/application/hooks/useSellerInfo.ts`                     | New hook: queries `user_profiles` for a single seller, returns `displayName` + `avatarUrl` |
+| `apps/store/src/features/products/presentation/components/SellerCard/SellerCard.tsx`      | New component: avatar, name, profile link                                                  |
+| `apps/store/src/features/products/presentation/components/SellerCard/SellerCard.test.tsx` | Unit tests                                                                                 |
+| `apps/store/src/features/products/presentation/components/SellerCard/index.ts`            | Barrel export                                                                              |
 
 ### Files to Modify
 
-| File | Change |
-|------|--------|
+| File                                                                        | Change                                                                      |
+| --------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | `apps/store/src/features/products/presentation/pages/ProductDetailPage.tsx` | Add `<SellerCard sellerId={product.seller_id} />` after `<ProductSections>` |
-| `apps/store/src/shared/infrastructure/i18n/messages/en.json` | Add `products.detail.viewProfile` |
-| `apps/store/src/shared/infrastructure/i18n/messages/es.json` | Add `products.detail.viewProfile` (Spanish) |
+| `apps/store/src/shared/infrastructure/i18n/messages/en.json`                | Add `products.detail.viewProfile`                                           |
+| `apps/store/src/shared/infrastructure/i18n/messages/es.json`                | Add `products.detail.viewProfile` (Spanish)                                 |
 
 ### Key Insights
 

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -537,10 +537,10 @@ After creating 02-analysis.md, show a brief handoff message:
 
 ### Artifacts Created
 
-| File                  | Status     |
-| --------------------- | ---------- |
-| `00-task-overview.md` | ✅ Created |
-| `01-setup.md`         | ✅ Created |
+| File                  | Status                                       |
+| --------------------- | -------------------------------------------- |
+| `00-task-overview.md` | ✅ Created                                   |
+| `01-setup.md`         | ✅ Created                                   |
 | `02-analysis.md`      | ✅ Created (includes Design Questions brief) |
 
 ### Key Findings
@@ -591,10 +591,12 @@ Skill('superpowers:brainstorming', args: `
 **Approach chosen:** {one-sentence summary of the selected approach}
 
 **Key decisions:**
+
 - {Decision 1}
 - {Decision 2}
 
 **Constraints identified:**
+
 - {Hard constraints surfaced during brainstorming — or "None"}
 
 **Spec:** `docs/superpowers/specs/{YYYY-MM-DD}-{topic}-design.md`

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -27,9 +27,10 @@ Initializes a new task by:
 2. **Setting up task documentation** folder with numbered artifacts
 3. **Fetching issue details** from GitHub
 4. **Automatically analyzing the codebase** to identify relevant files and patterns
-5. **Creating analysis artifact** (02-analysis.md) with findings
+5. **Creating analysis artifact** (02-analysis.md) with findings and design questions
+6. **Handing off to `/brainstorming`** — armed with codebase context to design before implementing
 
-This skill creates a structured workspace AND performs initial analysis so you're ready to implement immediately.
+This skill creates a structured workspace, performs initial analysis, and transitions directly into a design dialogue so decisions are made deliberately before any code is written.
 
 ---
 
@@ -381,11 +382,12 @@ Document the branch setup:
 
 ## Next Steps
 
-1. Analyze codebase → Creates `02-analysis.md`
-2. Create implementation plan → Creates `03-implementation-plan.md`
-3. Implement with TDD → Updates `04-implementation-log.md`
-4. Run tests → Creates `05-testing-results.md`
-5. Submit PR → `/submit-pr` (will target `{pr_target}`)
+1. Analyze codebase → Creates `02-analysis.md` (with Design Questions brief)
+2. Design session → `/brainstorming` creates spec in `docs/superpowers/specs/`
+3. Implementation plan → `/writing-plans` creates `03-implementation-plan.md`
+4. Implement with TDD → Updates `04-implementation-log.md`
+5. Run tests → Creates `05-testing-results.md`
+6. Submit PR → `/submit-pr` (will target `{pr_target}`)
 ```
 
 ### Step 9: Display Setup Summary
@@ -502,24 +504,36 @@ Create `.ai-context/task-outputs/GH-{number}/02-analysis.md`:
 ## Questions/Blockers
 
 - [ ] {Any clarifications needed}
+
+## Design Questions
+
+> Seed context for /brainstorming. These questions were surfaced by codebase analysis
+> and will drive the clarifying questions phase.
+
+### What we know (pre-answered by analysis)
+
+- Relevant files: [list key files from Relevant Files table above]
+- Existing patterns to follow: [list key patterns from Existing Patterns above]
+- Hard constraints: [migrations needed, breaking changes, DB schema impacts — or "None identified"]
+
+### Open questions for design dialogue
+
+- [ ] {Genuine unknown 1 surfaced during analysis — e.g., "Should this be a new hook or extend the existing one?"}
+- [ ] {Genuine unknown 2 — e.g., "Does this belong in the feature layer or shared?"}
+
+> If no real unknowns exist, this list may have 0–1 items. Brainstorming will move quickly to approach proposals.
+
+### Suggested design scope
+
+{1–2 sentences on what a complete implementation covers, derived from the issue requirements and analysis findings}
 ```
 
 ### Step 12: Display Analysis Summary
 
-After creating 02-analysis.md, show:
+After creating 02-analysis.md, show a brief handoff message:
 
 ```markdown
 ## Analysis Complete
-
-### Files Analyzed
-
-- {count} relevant files identified
-- {count} existing patterns documented
-
-### Key Findings
-
-- {Finding 1}
-- {Finding 2}
 
 ### Artifacts Created
 
@@ -527,31 +541,69 @@ After creating 02-analysis.md, show:
 | --------------------- | ---------- |
 | `00-task-overview.md` | ✅ Created |
 | `01-setup.md`         | ✅ Created |
-| `02-analysis.md`      | ✅ Created |
+| `02-analysis.md`      | ✅ Created (includes Design Questions brief) |
 
-### Ready for Implementation
+### Key Findings
 
-The analysis phase is complete. You can now:
+- {count} relevant files identified
+- {count} existing patterns documented
+- {count} open design questions surfaced
 
-1. **Review the analysis** in `02-analysis.md`
-2. **Start implementation** - I'll create `03-implementation-plan.md` as we go
-3. **Ask questions** about specific patterns or approaches
-
-### Testing Requirements (TDD)
-
-Before implementing, write tests first:
-
-- [ ] Write failing unit tests for new components
-- [ ] Write failing unit tests for new hooks
-- [ ] Write failing unit tests for new utilities
-
-### Related Skills
-
-- `/run-tests` - Run unit tests with Vitest
-- `/run-e2e` - Run E2E tests with Playwright
-- `/submit-pr` - Create pull request to develop
-- `/checkpoint` - Save progress for later
+**Proceeding to design dialogue...**
 ```
+
+> **Do NOT add "Ready for Implementation" or Related Skills here.** The next step is brainstorming, not implementation.
+
+### Step 13: Hand off to brainstorming
+
+> **CRITICAL: This is the terminal step. Invoke brainstorming automatically — do NOT wait for the user to ask.**
+
+Invoke the brainstorming skill with pre-loaded context:
+
+```
+Skill('superpowers:brainstorming', args: `
+  Context pre-loaded from start-task for GH-{number}.
+
+  Before starting:
+  1. Read .ai-context/task-outputs/GH-{number}/02-analysis.md
+  2. Skip the "Explore project context" step — codebase analysis is already done
+  3. Open the dialogue using the "Design Questions" section of 02-analysis.md as your agenda
+
+  Start your first message with:
+  "I've reviewed the codebase analysis for GH-{number}. [Summarize what we know in 1-2 sentences.]
+   I want to understand [first open question from Design Questions]..."
+
+  Then continue the normal brainstorming flow:
+  - Clarifying questions (one at a time, using Design Questions as agenda)
+  - 2–3 approach proposals with trade-offs
+  - Design sections presented for approval
+  - Spec doc written to docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md
+  - GitHub issue comment posted with design decisions (if issue exists)
+  - writing-plans invoked as terminal step
+`)
+```
+
+**GitHub issue comment** (posted by brainstorming after spec approval, before writing-plans):
+
+```markdown
+## Design Decision — {YYYY-MM-DD}
+
+**Approach chosen:** {one-sentence summary of the selected approach}
+
+**Key decisions:**
+- {Decision 1}
+- {Decision 2}
+
+**Constraints identified:**
+- {Hard constraints surfaced during brainstorming — or "None"}
+
+**Spec:** `docs/superpowers/specs/{YYYY-MM-DD}-{topic}-design.md`
+**Implementation plan:** Will be created at `.ai-context/task-outputs/GH-{number}/03-implementation-plan.md`
+```
+
+Post via: `mcp__github__add_issue_comment({ owner, repo, issue_number: {number}, body: comment })`
+
+Only post if a GitHub issue exists (branch contains `GH-{number}` and issue was successfully fetched in Step 2). Skip silently if no issue.
 
 ---
 
@@ -624,6 +676,28 @@ Before implementing, write tests first:
 ## Questions/Blockers
 
 - [ ] Any clarifications needed
+
+## Design Questions
+
+> Seed context for /brainstorming. These questions were surfaced by codebase analysis
+> and will drive the clarifying questions phase.
+
+### What we know (pre-answered by analysis)
+
+- Relevant files: [list key files from Relevant Files table above]
+- Existing patterns to follow: [list key patterns from Existing Patterns above]
+- Hard constraints: [migrations needed, breaking changes, DB schema impacts — or "None identified"]
+
+### Open questions for design dialogue
+
+- [ ] {Genuine unknown 1 surfaced during analysis}
+- [ ] {Genuine unknown 2 — if any}
+
+> If no real unknowns exist, this list may have 0–1 items. Brainstorming will move quickly to approach proposals.
+
+### Suggested design scope
+
+{1–2 sentences on what a complete implementation covers, derived from the issue requirements and analysis findings}
 ```
 
 ### 03-implementation-plan.md (Created During Planning Phase)
@@ -927,6 +1001,7 @@ Options:
 10. **Document source branch choice** in 01-setup.md and 02-analysis.md for fix branches
 11. **ALWAYS proceed to Phase 2** - After creating 00 and 01, automatically analyze the codebase and create 02-analysis.md
 12. **Use Task tool with Explore agent** for complex codebase analysis to find relevant files and patterns
+13. **ALWAYS invoke brainstorming at Step 13** - Do NOT end at analysis. The brainstorming handoff is automatic and non-optional. The Design Questions section of 02-analysis.md is the brief; brainstorming reads it and skips its own context-gathering step.
 
 ### Title Formatting Function
 

--- a/apps/store/e2e/product-detail-seller-card.spec.ts
+++ b/apps/store/e2e/product-detail-seller-card.spec.ts
@@ -60,5 +60,4 @@ test.describe("Product detail — seller card", () => {
       new RegExp(`/profile/${product.seller_id as string}`),
     );
   });
-
 });

--- a/apps/store/e2e/product-detail-seller-card.spec.ts
+++ b/apps/store/e2e/product-detail-seller-card.spec.ts
@@ -1,0 +1,64 @@
+import path from "node:path";
+
+import { test, expect } from "@playwright/test";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { resolveE2EAppUrls } = require(
+  path.resolve(__dirname, "../../../scripts/app-url-resolver.js"),
+);
+
+const { store: STORE_URL } = resolveE2EAppUrls();
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getSupabaseAdmin() {
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) return null;
+  const { createClient } = await import("@supabase/supabase-js");
+  return createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Product detail — seller card", () => {
+  test("renders seller card when product has a seller", async ({ page }) => {
+    const supabase = await getSupabaseAdmin();
+    if (!supabase) return test.skip();
+
+    const { data: product } = await supabase
+      .from("products")
+      .select("id, seller_id")
+      .not("seller_id", "is", null)
+      .limit(1)
+      .single();
+
+    if (!product) return test.skip();
+
+    await page.goto(`${STORE_URL}/en/products/${product.id}`);
+
+    await expect(page.getByTestId("seller-card")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId("seller-card-title")).toBeVisible();
+
+    const sellerName = page.getByTestId("seller-name");
+    await expect(sellerName).toBeVisible();
+    await expect(sellerName).not.toBeEmpty();
+
+    const profileLink = page.getByTestId("seller-profile-link");
+    await expect(profileLink).toBeVisible();
+    await expect(profileLink).toHaveAttribute(
+      "href",
+      new RegExp(`/profile/${product.seller_id as string}`),
+    );
+  });
+
+});

--- a/apps/store/src/features/products/application/hooks/useSellerInfo.test.ts
+++ b/apps/store/src/features/products/application/hooks/useSellerInfo.test.ts
@@ -1,0 +1,165 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { useSellerInfo } from "./useSellerInfo";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockSingle = vi.fn();
+
+vi.mock("shared", () => ({
+  useSupabase: () => ({
+    from: () => ({
+      select: mockSelect,
+    }),
+  }),
+}));
+
+mockSelect.mockReturnValue({ eq: mockEq });
+mockEq.mockReturnValue({ single: mockSingle });
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useSellerInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ single: mockSingle });
+  });
+
+  it("returns undefined data and is disabled when sellerId is null", () => {
+    const { result } = renderHook(() => useSellerInfo(null), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("fetches and returns displayName and avatarUrl when sellerId is provided", async () => {
+    mockSingle.mockResolvedValue({
+      data: {
+        id: "seller-1",
+        display_name: "Jane Doe",
+        email: "jane@example.com",
+        display_avatar_url: "https://cdn.example.com/jane.jpg",
+        avatar_url: null,
+      },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useSellerInfo("seller-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual({
+      displayName: "Jane Doe",
+      avatarUrl: "https://cdn.example.com/jane.jpg",
+    });
+  });
+
+  it("falls back to avatar_url when display_avatar_url is null", async () => {
+    mockSingle.mockResolvedValue({
+      data: {
+        id: "seller-1",
+        display_name: "Jane Doe",
+        email: "jane@example.com",
+        display_avatar_url: null,
+        avatar_url: "https://cdn.example.com/jane-auth.jpg",
+      },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useSellerInfo("seller-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.avatarUrl).toBe(
+      "https://cdn.example.com/jane-auth.jpg",
+    );
+  });
+
+  it("returns null avatarUrl when both avatar fields are null", async () => {
+    mockSingle.mockResolvedValue({
+      data: {
+        id: "seller-1",
+        display_name: "Jane Doe",
+        email: "jane@example.com",
+        display_avatar_url: null,
+        avatar_url: null,
+      },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useSellerInfo("seller-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.avatarUrl).toBeNull();
+  });
+
+  it("falls back to email prefix when display_name is null", async () => {
+    mockSingle.mockResolvedValue({
+      data: {
+        id: "seller-1",
+        display_name: null,
+        email: "jane@example.com",
+        display_avatar_url: null,
+        avatar_url: null,
+      },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useSellerInfo("seller-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.displayName).toBe("jane");
+  });
+
+  it("sets isError when the query fails", async () => {
+    mockSingle.mockResolvedValue({
+      data: null,
+      error: { message: "Not found" },
+    });
+
+    const { result } = renderHook(() => useSellerInfo("seller-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/store/src/features/products/application/hooks/useSellerInfo.ts
+++ b/apps/store/src/features/products/application/hooks/useSellerInfo.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useSupabase } from "shared";
+
+export interface SellerInfo {
+  displayName: string;
+  avatarUrl: string | null;
+}
+
+export function useSellerInfo(sellerId: string | null) {
+  const supabase = useSupabase();
+
+  return useQuery({
+    queryKey: ["seller-info", sellerId],
+    queryFn: async (): Promise<SellerInfo> => {
+      const { data, error } = await supabase
+        .from("user_profiles")
+        .select("id, display_name, email, display_avatar_url, avatar_url")
+        .eq("id", sellerId as string)
+        .single();
+
+      if (error) throw new Error(error.message);
+
+      return {
+        displayName: data.display_name ?? data.email.split("@")[0],
+        avatarUrl: data.display_avatar_url ?? data.avatar_url ?? null,
+      };
+    },
+    enabled: sellerId !== null,
+    staleTime: 60_000,
+  });
+}

--- a/apps/store/src/features/products/presentation/components/SellerCard/SellerCard.test.tsx
+++ b/apps/store/src/features/products/presentation/components/SellerCard/SellerCard.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { SellerCard } from "./SellerCard";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseSellerInfo = vi.fn();
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
+}));
+
+vi.mock("shared", () => ({
+  tid: (id: string) => ({ "data-testid": id }),
+  appUrls: { auth: "https://auth.example.com" },
+}));
+
+vi.mock(
+  "@/features/products/application/hooks/useSellerInfo",
+  () => ({
+    useSellerInfo: (sellerId: string | null) => mockUseSellerInfo(sellerId),
+  }),
+);
+
+vi.mock("ui", () => ({
+  Avatar: ({ children, ...props }: React.PropsWithChildren<object>) => (
+    <div data-testid="avatar" {...props}>
+      {children}
+    </div>
+  ),
+  AvatarImage: ({ src, alt }: { src?: string; alt?: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element -- test mock, not production code
+    <img data-testid="avatar-image" src={src} alt={alt} />
+  ),
+  AvatarFallback: ({ children }: React.PropsWithChildren<object>) => (
+    <div data-testid="avatar-fallback">{children}</div>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSellerInfo(
+  overrides: Partial<{ displayName: string; avatarUrl: string | null }> = {},
+) {
+  return {
+    displayName: "Jane Doe",
+    avatarUrl: "https://cdn.example.com/jane.jpg",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SellerCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when sellerId is null", () => {
+    mockUseSellerInfo.mockReturnValue({ data: undefined, isLoading: false });
+    const { container } = render(<SellerCard sellerId={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing while loading", () => {
+    mockUseSellerInfo.mockReturnValue({ data: undefined, isLoading: true });
+    const { container } = render(<SellerCard sellerId="seller-1" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders seller card with name when data is available", () => {
+    mockUseSellerInfo.mockReturnValue({
+      data: makeSellerInfo(),
+      isLoading: false,
+    });
+    render(<SellerCard sellerId="seller-1" />);
+    expect(screen.getByTestId("seller-card")).toBeInTheDocument();
+    expect(screen.getByTestId("seller-name")).toHaveTextContent("Jane Doe");
+  });
+
+  it("renders avatar image when avatarUrl is provided", () => {
+    mockUseSellerInfo.mockReturnValue({
+      data: makeSellerInfo({ avatarUrl: "https://cdn.example.com/jane.jpg" }),
+      isLoading: false,
+    });
+    render(<SellerCard sellerId="seller-1" />);
+    expect(screen.getByTestId("avatar-image")).toHaveAttribute(
+      "src",
+      "https://cdn.example.com/jane.jpg",
+    );
+  });
+
+  it("renders initials as fallback when avatarUrl is null", () => {
+    mockUseSellerInfo.mockReturnValue({
+      data: makeSellerInfo({ displayName: "Jane Doe", avatarUrl: null }),
+      isLoading: false,
+    });
+    render(<SellerCard sellerId="seller-1" />);
+    expect(screen.getByTestId("avatar-fallback")).toHaveTextContent("J");
+  });
+
+  it("renders a link to the seller profile", () => {
+    mockUseSellerInfo.mockReturnValue({
+      data: makeSellerInfo(),
+      isLoading: false,
+    });
+    render(<SellerCard sellerId="seller-1" />);
+    const link = screen.getByTestId("seller-profile-link");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://auth.example.com/en/profile/seller-1",
+    );
+  });
+
+  it("renders view profile label from i18n", () => {
+    mockUseSellerInfo.mockReturnValue({
+      data: makeSellerInfo(),
+      isLoading: false,
+    });
+    render(<SellerCard sellerId="seller-1" />);
+    expect(screen.getByTestId("seller-profile-link")).toHaveTextContent(
+      "detail.viewProfile",
+    );
+  });
+
+  it("renders section title from i18n", () => {
+    mockUseSellerInfo.mockReturnValue({
+      data: makeSellerInfo(),
+      isLoading: false,
+    });
+    render(<SellerCard sellerId="seller-1" />);
+    expect(screen.getByTestId("seller-card-title")).toHaveTextContent(
+      "detail.seller",
+    );
+  });
+});

--- a/apps/store/src/features/products/presentation/components/SellerCard/SellerCard.test.tsx
+++ b/apps/store/src/features/products/presentation/components/SellerCard/SellerCard.test.tsx
@@ -19,12 +19,9 @@ vi.mock("shared", () => ({
   appUrls: { auth: "https://auth.example.com" },
 }));
 
-vi.mock(
-  "@/features/products/application/hooks/useSellerInfo",
-  () => ({
-    useSellerInfo: (sellerId: string | null) => mockUseSellerInfo(sellerId),
-  }),
-);
+vi.mock("@/features/products/application/hooks/useSellerInfo", () => ({
+  useSellerInfo: (sellerId: string | null) => mockUseSellerInfo(sellerId),
+}));
 
 vi.mock("ui", () => ({
   Avatar: ({ children, ...props }: React.PropsWithChildren<object>) => (

--- a/apps/store/src/features/products/presentation/components/SellerCard/SellerCard.tsx
+++ b/apps/store/src/features/products/presentation/components/SellerCard/SellerCard.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useLocale, useTranslations } from "next-intl";
+import { appUrls, tid } from "shared";
+import { Avatar, AvatarFallback, AvatarImage } from "ui";
+
+import { useSellerInfo } from "@/features/products/application/hooks/useSellerInfo";
+
+interface SellerCardProps {
+  sellerId: string | null;
+}
+
+export function SellerCard({ sellerId }: SellerCardProps) {
+  const t = useTranslations("products");
+  const locale = useLocale();
+  const { data, isLoading } = useSellerInfo(sellerId);
+
+  if (!sellerId || isLoading || !data) return null;
+
+  const profileUrl = `${appUrls.auth}/${locale}/profile/${sellerId}`;
+  const initial = data.displayName.charAt(0).toUpperCase();
+
+  return (
+    <section
+      className="mx-auto w-full max-w-6xl px-4 py-6"
+      {...tid("seller-card")}
+    >
+      <h2
+        className="font-display text-xs font-bold uppercase tracking-widest text-muted-foreground mb-4"
+        {...tid("seller-card-title")}
+      >
+        {t("detail.seller")}
+      </h2>
+
+      <div className="flex items-center gap-3">
+        <Avatar className="size-10">
+          {data.avatarUrl ? (
+            <AvatarImage src={data.avatarUrl} alt={data.displayName} />
+          ) : null}
+          <AvatarFallback>{initial}</AvatarFallback>
+        </Avatar>
+
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span
+            className="font-display text-sm/tight font-semibold truncate"
+            {...tid("seller-name")}
+          >
+            {data.displayName}
+          </span>
+
+          <a
+            href={profileUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-display text-xs font-bold uppercase tracking-widest text-muted-foreground hover:text-foreground transition-colors"
+            {...tid("seller-profile-link")}
+          >
+            {t("detail.viewProfile")}
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/store/src/features/products/presentation/components/SellerCard/index.ts
+++ b/apps/store/src/features/products/presentation/components/SellerCard/index.ts
@@ -1,0 +1,1 @@
+export { SellerCard } from "./SellerCard";

--- a/apps/store/src/features/products/presentation/pages/ProductDetailPage.test.tsx
+++ b/apps/store/src/features/products/presentation/pages/ProductDetailPage.test.tsx
@@ -57,6 +57,15 @@ vi.mock(
   }),
 );
 
+vi.mock(
+  "@/features/products/presentation/components/SellerCard",
+  () => ({
+    SellerCard: ({ sellerId }: { sellerId: string | null }) => (
+      <div data-testid="seller-card-mock" data-seller-id={sellerId ?? ""} />
+    ),
+  }),
+);
+
 vi.mock("@/shared/domain/categoryConstants", () => ({
   getCategoryTheme: () => ({
     bg: "var(--mint)",

--- a/apps/store/src/features/products/presentation/pages/ProductDetailPage.test.tsx
+++ b/apps/store/src/features/products/presentation/pages/ProductDetailPage.test.tsx
@@ -57,14 +57,11 @@ vi.mock(
   }),
 );
 
-vi.mock(
-  "@/features/products/presentation/components/SellerCard",
-  () => ({
-    SellerCard: ({ sellerId }: { sellerId: string | null }) => (
-      <div data-testid="seller-card-mock" data-seller-id={sellerId ?? ""} />
-    ),
-  }),
-);
+vi.mock("@/features/products/presentation/components/SellerCard", () => ({
+  SellerCard: ({ sellerId }: { sellerId: string | null }) => (
+    <div data-testid="seller-card-mock" data-seller-id={sellerId ?? ""} />
+  ),
+}));
 
 vi.mock("@/shared/domain/categoryConstants", () => ({
   getCategoryTheme: () => ({

--- a/apps/store/src/features/products/presentation/pages/ProductDetailPage.tsx
+++ b/apps/store/src/features/products/presentation/pages/ProductDetailPage.tsx
@@ -6,6 +6,7 @@ import { tid } from "shared";
 import { useStoreProduct } from "@/features/products/application/hooks/useStoreProducts";
 import { MobileBarWithCart } from "@/features/products/presentation/components/ProductDetail/MobileBarWithCart";
 import { ProductSections } from "@/features/products/presentation/components/ProductDetail/ProductSections";
+import { SellerCard } from "@/features/products/presentation/components/SellerCard";
 import { getCategoryTheme } from "@/shared/domain/categoryConstants";
 import { Link } from "@/shared/infrastructure/i18n";
 
@@ -75,6 +76,8 @@ export function ProductDetailPage({ productId }: ProductDetailPageProps) {
       </div>
 
       <ProductSections product={product} />
+
+      <SellerCard sellerId={product.seller_id} />
 
       <MobileBarWithCart product={product} theme={theme} />
     </div>

--- a/apps/store/src/shared/infrastructure/i18n/messages/en.json
+++ b/apps/store/src/shared/infrastructure/i18n/messages/en.json
@@ -105,6 +105,7 @@
       "stars": "{rating} out of 5 stars",
       "faq": "Frequently Asked Questions",
       "seller": "About the Seller",
+      "viewProfile": "View profile",
       "contactSeller": "Contact Seller",
       "comingSoon": "Coming Soon",
       "totalSales": "{count} sales",

--- a/apps/store/src/shared/infrastructure/i18n/messages/es.json
+++ b/apps/store/src/shared/infrastructure/i18n/messages/es.json
@@ -105,6 +105,7 @@
       "stars": "{rating} de 5 estrellas",
       "faq": "Preguntas frecuentes",
       "seller": "Sobre el vendedor",
+      "viewProfile": "Ver perfil",
       "contactSeller": "Contactar vendedor",
       "comingSoon": "Próximamente",
       "totalSales": "{count} ventas",

--- a/docs/superpowers/plans/2026-05-14-start-task-brainstorming-integration.md
+++ b/docs/superpowers/plans/2026-05-14-start-task-brainstorming-integration.md
@@ -1,0 +1,482 @@
+# start-task + brainstorming Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Modify `.claude/skills/start-task/SKILL.md` so that after codebase analysis, `start-task` automatically hands off to `/brainstorming` — using `02-analysis.md` as a pre-built brief that seeds the design dialogue.
+
+**Architecture:** `02-analysis.md` gains a "Design Questions" terminal section that brainstorming reads to skip context-gathering and open at clarifying questions. Step 12 is changed from a terminal "ready to implement" message to a brief handoff summary. A new Step 13 invokes `Skill('brainstorming')` with pre-loaded context args. No changes to the brainstorming skill itself.
+
+**Tech Stack:** Markdown only — one file, `.claude/skills/start-task/SKILL.md`
+
+**Spec:** `docs/superpowers/specs/2026-05-14-start-task-brainstorming-integration-design.md`
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|------|--------|-------------|
+| `.claude/skills/start-task/SKILL.md` | Modify | 7 targeted edits — see tasks below |
+
+---
+
+### Task 1: Update the Description section
+
+**Files:**
+- Modify: `.claude/skills/start-task/SKILL.md` (lines 24–33)
+
+The Description currently says the skill ends with "ready to implement." Update it to reflect the brainstorming handoff.
+
+- [ ] **Step 1: Edit the Description bullet list**
+
+Find this block (around line 24):
+
+```markdown
+Initializes a new task by:
+
+1. **Creating a git branch** with proper naming conventions
+2. **Setting up task documentation** folder with numbered artifacts
+3. **Fetching issue details** from GitHub
+4. **Automatically analyzing the codebase** to identify relevant files and patterns
+5. **Creating analysis artifact** (02-analysis.md) with findings
+
+This skill creates a structured workspace AND performs initial analysis so you're ready to implement immediately.
+```
+
+Replace with:
+
+```markdown
+Initializes a new task by:
+
+1. **Creating a git branch** with proper naming conventions
+2. **Setting up task documentation** folder with numbered artifacts
+3. **Fetching issue details** from GitHub
+4. **Automatically analyzing the codebase** to identify relevant files and patterns
+5. **Creating analysis artifact** (02-analysis.md) with findings and design questions
+6. **Handing off to `/brainstorming`** — armed with codebase context to design before implementing
+
+This skill creates a structured workspace, performs initial analysis, and transitions directly into a design dialogue so decisions are made deliberately before any code is written.
+```
+
+- [ ] **Step 2: Verify the edit looks correct**
+
+Read lines 20–40 of the file and confirm the description now ends with the brainstorming handoff line.
+
+---
+
+### Task 2: Update 01-setup.md Next Steps (Step 8 template)
+
+**Files:**
+- Modify: `.claude/skills/start-task/SKILL.md` (Step 8 template, around lines 382–389)
+
+The "Next Steps" in `01-setup.md` currently lists "Create implementation plan" as step 2. Update it to reflect the new flow.
+
+- [ ] **Step 1: Edit the Next Steps block inside the Step 8 template**
+
+Find this block (inside the `01-setup.md` template in Step 8):
+
+```markdown
+## Next Steps
+
+1. Analyze codebase → Creates `02-analysis.md`
+2. Create implementation plan → Creates `03-implementation-plan.md`
+3. Implement with TDD → Updates `04-implementation-log.md`
+4. Run tests → Creates `05-testing-results.md`
+5. Submit PR → `/submit-pr` (will target `{pr_target}`)
+```
+
+Replace with:
+
+```markdown
+## Next Steps
+
+1. Analyze codebase → Creates `02-analysis.md` (with Design Questions brief)
+2. Design session → `/brainstorming` creates spec in `docs/superpowers/specs/`
+3. Implementation plan → `/writing-plans` creates `03-implementation-plan.md`
+4. Implement with TDD → Updates `04-implementation-log.md`
+5. Run tests → Creates `05-testing-results.md`
+6. Submit PR → `/submit-pr` (will target `{pr_target}`)
+```
+
+- [ ] **Step 2: Verify the edit looks correct**
+
+Read the Step 8 section and confirm the Next Steps now shows the brainstorming and writing-plans steps between analysis and implementation.
+
+---
+
+### Task 3: Add Design Questions section to the Step 11 inline template
+
+**Files:**
+- Modify: `.claude/skills/start-task/SKILL.md` (Step 11 template, around lines 448–505)
+
+Step 11 contains an inline template for the content of `02-analysis.md`. Add the "Design Questions" section at the end of this template.
+
+- [ ] **Step 1: Edit the Step 11 template**
+
+Find this block at the end of the Step 11 template (around lines 498–505):
+
+```markdown
+### Key Insights
+
+- {Insight 1}
+- {Insight 2}
+
+## Questions/Blockers
+
+- [ ] {Any clarifications needed}
+```
+
+Replace with:
+
+```markdown
+### Key Insights
+
+- {Insight 1}
+- {Insight 2}
+
+## Questions/Blockers
+
+- [ ] {Any clarifications needed}
+
+## Design Questions
+
+> Seed context for /brainstorming. These questions were surfaced by codebase analysis
+> and will drive the clarifying questions phase.
+
+### What we know (pre-answered by analysis)
+
+- Relevant files: [list key files from Relevant Files table above]
+- Existing patterns to follow: [list key patterns from Existing Patterns above]
+- Hard constraints: [migrations needed, breaking changes, DB schema impacts — or "None identified"]
+
+### Open questions for design dialogue
+
+- [ ] {Genuine unknown 1 surfaced during analysis — e.g., "Should this be a new hook or extend the existing one?"}
+- [ ] {Genuine unknown 2 — e.g., "Does this belong in the feature layer or shared?"}
+
+> If no real unknowns exist, this list may have 0–1 items. Brainstorming will move quickly to approach proposals.
+
+### Suggested design scope
+
+{1–2 sentences on what a complete implementation covers, derived from the issue requirements and analysis findings}
+```
+
+- [ ] **Step 2: Verify the edit looks correct**
+
+Read the Step 11 section and confirm the template now ends with the Design Questions section.
+
+---
+
+### Task 4: Add Design Questions section to the Artifact Templates copy of 02-analysis.md
+
+**Files:**
+- Modify: `.claude/skills/start-task/SKILL.md` (Artifact Templates section, around lines 560–627)
+
+The Artifact Templates section contains a second copy of the `02-analysis.md` template (used as reference). Add the Design Questions section to this copy too so both are in sync.
+
+- [ ] **Step 1: Edit the Artifact Templates copy**
+
+Find this block at the end of the `02-analysis.md` template in the Artifact Templates section (around lines 620–627):
+
+```markdown
+## Technical Considerations
+
+- Performance implications
+- Breaking changes
+- Migration needs
+  {For hotfixes, add:}
+- Impact on current `develop` branch (need to sync after merge)
+
+## Questions/Blockers
+
+- [ ] Any clarifications needed
+```
+
+Replace with:
+
+```markdown
+## Technical Considerations
+
+- Performance implications
+- Breaking changes
+- Migration needs
+  {For hotfixes, add:}
+- Impact on current `develop` branch (need to sync after merge)
+
+## Questions/Blockers
+
+- [ ] Any clarifications needed
+
+## Design Questions
+
+> Seed context for /brainstorming. These questions were surfaced by codebase analysis
+> and will drive the clarifying questions phase.
+
+### What we know (pre-answered by analysis)
+
+- Relevant files: [list key files from Relevant Files table above]
+- Existing patterns to follow: [list key patterns from Existing Patterns above]
+- Hard constraints: [migrations needed, breaking changes, DB schema impacts — or "None identified"]
+
+### Open questions for design dialogue
+
+- [ ] {Genuine unknown 1 surfaced during analysis}
+- [ ] {Genuine unknown 2 — if any}
+
+> If no real unknowns exist, this list may have 0–1 items. Brainstorming will move quickly to approach proposals.
+
+### Suggested design scope
+
+{1–2 sentences on what a complete implementation covers, derived from the issue requirements and analysis findings}
+```
+
+- [ ] **Step 2: Verify the edit looks correct**
+
+Read the Artifact Templates section and confirm the `02-analysis.md` template ends with Design Questions.
+
+---
+
+### Task 5: Replace Step 12 Display Analysis Summary (remove terminal message)
+
+**Files:**
+- Modify: `.claude/skills/start-task/SKILL.md` (Step 12, around lines 507–554)
+
+Step 12 currently shows a "Ready for Implementation" terminal block with TDD checklist and Related Skills. Replace the entire Step 12 display block with a brief handoff summary that leads into Step 13.
+
+- [ ] **Step 1: Edit Step 12**
+
+Find this entire block (Step 12 Display Analysis Summary, around lines 507–554):
+
+```markdown
+### Step 12: Display Analysis Summary
+
+After creating 02-analysis.md, show:
+
+```markdown
+## Analysis Complete
+
+### Files Analyzed
+
+- {count} relevant files identified
+- {count} existing patterns documented
+
+### Key Findings
+
+- {Finding 1}
+- {Finding 2}
+
+### Artifacts Created
+
+| File                  | Status     |
+| --------------------- | ---------- |
+| `00-task-overview.md` | ✅ Created |
+| `01-setup.md`         | ✅ Created |
+| `02-analysis.md`      | ✅ Created |
+
+### Ready for Implementation
+
+The analysis phase is complete. You can now:
+
+1. **Review the analysis** in `02-analysis.md`
+2. **Start implementation** - I'll create `03-implementation-plan.md` as we go
+3. **Ask questions** about specific patterns or approaches
+
+### Testing Requirements (TDD)
+
+Before implementing, write tests first:
+
+- [ ] Write failing unit tests for new components
+- [ ] Write failing unit tests for new hooks
+- [ ] Write failing unit tests for new utilities
+
+### Related Skills
+
+- `/run-tests` - Run unit tests with Vitest
+- `/run-e2e` - Run E2E tests with Playwright
+- `/submit-pr` - Create pull request to develop
+- `/checkpoint` - Save progress for later
+` `` `
+```
+
+Replace the entire Step 12 block with:
+
+```markdown
+### Step 12: Display Analysis Summary
+
+After creating 02-analysis.md, show a brief handoff message:
+
+```markdown
+## Analysis Complete
+
+### Artifacts Created
+
+| File                  | Status     |
+| --------------------- | ---------- |
+| `00-task-overview.md` | ✅ Created |
+| `01-setup.md`         | ✅ Created |
+| `02-analysis.md`      | ✅ Created (includes Design Questions brief) |
+
+### Key Findings
+
+- {count} relevant files identified
+- {count} existing patterns documented
+- {count} open design questions surfaced
+
+**Proceeding to design dialogue...**
+` `` `
+```
+
+> **Do NOT add "Ready for Implementation" or Related Skills here.** The next step is brainstorming, not implementation.
+
+- [ ] **Step 2: Verify the edit looks correct**
+
+Read Step 12 and confirm it no longer contains "Ready for Implementation," the TDD checklist, or the Related Skills block.
+
+---
+
+### Task 6: Add Step 13 — Invoke brainstorming
+
+**Files:**
+- Modify: `.claude/skills/start-task/SKILL.md` (after Step 12, before the Artifact Templates section)
+
+Add Step 13 as the new terminal step of the skill.
+
+- [ ] **Step 1: Insert Step 13 after Step 12**
+
+Find the line that reads `---` immediately after the Step 12 block (the separator before `## Artifact Templates`). Insert the following before that separator:
+
+```markdown
+### Step 13: Hand off to brainstorming
+
+> **CRITICAL: This is the terminal step. Invoke brainstorming automatically — do NOT wait for the user to ask.**
+
+Invoke the brainstorming skill with pre-loaded context:
+
+```
+Skill('superpowers:brainstorming', args: `
+  Context pre-loaded from start-task for GH-{number}.
+
+  Before starting:
+  1. Read .ai-context/task-outputs/GH-{number}/02-analysis.md
+  2. Skip the "Explore project context" step — codebase analysis is already done
+  3. Open the dialogue using the "Design Questions" section of 02-analysis.md as your agenda
+
+  Start your first message with:
+  "I've reviewed the codebase analysis for GH-{number}. [Summarize what we know in 1-2 sentences.]
+   I want to understand [first open question from Design Questions]..."
+
+  Then continue the normal brainstorming flow:
+  - Clarifying questions (one at a time, using Design Questions as agenda)
+  - 2–3 approach proposals with trade-offs
+  - Design sections presented for approval
+  - Spec doc written to docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md
+  - GitHub issue comment posted with design decisions (if issue exists)
+  - writing-plans invoked as terminal step
+`)
+```
+
+**GitHub issue comment** (posted by brainstorming after spec approval, before writing-plans):
+
+```markdown
+## Design Decision — {YYYY-MM-DD}
+
+**Approach chosen:** {one-sentence summary of the selected approach}
+
+**Key decisions:**
+- {Decision 1}
+- {Decision 2}
+
+**Constraints identified:**
+- {Hard constraints surfaced during brainstorming — or "None"}
+
+**Spec:** `docs/superpowers/specs/{YYYY-MM-DD}-{topic}-design.md`
+**Implementation plan:** Will be created at `.ai-context/task-outputs/GH-{number}/03-implementation-plan.md`
+```
+
+Post via: `mcp__github__add_issue_comment({ owner, repo, issue_number: {number}, body: comment })`
+
+Only post if a GitHub issue exists (branch contains `GH-{number}` and issue was successfully fetched in Step 2). Skip silently if no issue.
+
+```
+
+- [ ] **Step 2: Verify the edit looks correct**
+
+Read Step 13 and confirm it invokes `Skill('superpowers:brainstorming')` with explicit args instructing the context skip and the Design Questions agenda.
+
+---
+
+### Task 7: Update Implementation Notes
+
+**Files:**
+- Modify: `.claude/skills/start-task/SKILL.md` (Implementation Notes section, around lines 914–929)
+
+Update the numbered notes to reflect the brainstorming handoff and add point 13.
+
+- [ ] **Step 1: Edit the Implementation Notes list**
+
+Find this block (around lines 914–929):
+
+```markdown
+1. **Always use MCP tools** for git and GitHub operations
+2. **Parse ticket flexibly** - accept #42, GH-42, or just 42
+3. **Format titles consistently** - Title-Case with hyphens
+4. **Auto-detect branch type** from labels when possible
+5. **For fix branches, ALWAYS ask for source branch** (develop or main) - see Step 3b
+6. **Create all artifacts** in `.ai-context/task-outputs/GH-{number}/`
+7. **Download images** from issue body and comments
+8. **Handle errors gracefully** with helpful messages
+9. **Verify source branch** is up to date before branching (develop or main depending on fix type)
+10. **Document source branch choice** in 01-setup.md and 02-analysis.md for fix branches
+11. **ALWAYS proceed to Phase 2** - After creating 00 and 01, automatically analyze the codebase and create 02-analysis.md
+12. **Use Task tool with Explore agent** for complex codebase analysis to find relevant files and patterns
+```
+
+Replace with:
+
+```markdown
+1. **Always use MCP tools** for git and GitHub operations
+2. **Parse ticket flexibly** - accept #42, GH-42, or just 42
+3. **Format titles consistently** - Title-Case with hyphens
+4. **Auto-detect branch type** from labels when possible
+5. **For fix branches, ALWAYS ask for source branch** (develop or main) - see Step 3b
+6. **Create all artifacts** in `.ai-context/task-outputs/GH-{number}/`
+7. **Download images** from issue body and comments
+8. **Handle errors gracefully** with helpful messages
+9. **Verify source branch** is up to date before branching (develop or main depending on fix type)
+10. **Document source branch choice** in 01-setup.md and 02-analysis.md for fix branches
+11. **ALWAYS proceed to Phase 2** - After creating 00 and 01, automatically analyze the codebase and create 02-analysis.md
+12. **Use Task tool with Explore agent** for complex codebase analysis to find relevant files and patterns
+13. **ALWAYS invoke brainstorming at Step 13** - Do NOT end at analysis. The brainstorming handoff is automatic and non-optional. The Design Questions section of 02-analysis.md is the brief; brainstorming reads it and skips its own context-gathering step.
+```
+
+- [ ] **Step 2: Verify the edit looks correct**
+
+Read the Implementation Notes and confirm point 13 is present and clearly states the handoff is mandatory.
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+| Spec section | Covered by task |
+|---|---|
+| Section 1: Flow change (Steps 1–11 unchanged, Step 12 → handoff, Step 13 → brainstorming) | Tasks 5, 6 |
+| Section 2: Design Questions in 02-analysis.md | Tasks 3, 4 |
+| Section 3: Brainstorming picks up context via args | Task 6 |
+| Section 4: Artifact lifecycle (01-setup.md Next Steps updated) | Task 2 |
+| Section 5: GitHub issue comment (in Step 13 invocation) | Task 6 |
+| Description update | Task 1 |
+| Implementation Notes | Task 7 |
+
+All spec sections covered. ✓
+
+### Placeholder scan
+
+No TBDs or "fill in later" patterns. Every edit shows the exact text to find and the exact replacement. ✓
+
+### Consistency check
+
+- The Design Questions template is identical in Task 3 (Step 11) and Task 4 (Artifact Templates) — the two copies stay in sync. ✓
+- Step 13 invocation args reference `GH-{number}` and `.ai-context/task-outputs/GH-{number}/02-analysis.md` — consistent with artifact paths used everywhere else in the skill. ✓
+- "Implementation Notes" point 13 explicitly says "non-optional" — consistent with the spec's "not a conditional flow" rule. ✓

--- a/docs/superpowers/plans/2026-05-14-start-task-brainstorming-integration.md
+++ b/docs/superpowers/plans/2026-05-14-start-task-brainstorming-integration.md
@@ -14,8 +14,8 @@
 
 ## File Map
 
-| File | Action | What changes |
-|------|--------|-------------|
+| File                                 | Action | What changes                       |
+| ------------------------------------ | ------ | ---------------------------------- |
 | `.claude/skills/start-task/SKILL.md` | Modify | 7 targeted edits — see tasks below |
 
 ---
@@ -23,6 +23,7 @@
 ### Task 1: Update the Description section
 
 **Files:**
+
 - Modify: `.claude/skills/start-task/SKILL.md` (lines 24–33)
 
 The Description currently says the skill ends with "ready to implement." Update it to reflect the brainstorming handoff.
@@ -67,6 +68,7 @@ Read lines 20–40 of the file and confirm the description now ends with the bra
 ### Task 2: Update 01-setup.md Next Steps (Step 8 template)
 
 **Files:**
+
 - Modify: `.claude/skills/start-task/SKILL.md` (Step 8 template, around lines 382–389)
 
 The "Next Steps" in `01-setup.md` currently lists "Create implementation plan" as step 2. Update it to reflect the new flow.
@@ -107,6 +109,7 @@ Read the Step 8 section and confirm the Next Steps now shows the brainstorming a
 ### Task 3: Add Design Questions section to the Step 11 inline template
 
 **Files:**
+
 - Modify: `.claude/skills/start-task/SKILL.md` (Step 11 template, around lines 448–505)
 
 Step 11 contains an inline template for the content of `02-analysis.md`. Add the "Design Questions" section at the end of this template.
@@ -170,6 +173,7 @@ Read the Step 11 section and confirm the template now ends with the Design Quest
 ### Task 4: Add Design Questions section to the Artifact Templates copy of 02-analysis.md
 
 **Files:**
+
 - Modify: `.claude/skills/start-task/SKILL.md` (Artifact Templates section, around lines 560–627)
 
 The Artifact Templates section contains a second copy of the `02-analysis.md` template (used as reference). Add the Design Questions section to this copy too so both are in sync.
@@ -239,6 +243,7 @@ Read the Artifact Templates section and confirm the `02-analysis.md` template en
 ### Task 5: Replace Step 12 Display Analysis Summary (remove terminal message)
 
 **Files:**
+
 - Modify: `.claude/skills/start-task/SKILL.md` (Step 12, around lines 507–554)
 
 Step 12 currently shows a "Ready for Implementation" terminal block with TDD checklist and Related Skills. Replace the entire Step 12 display block with a brief handoff summary that leads into Step 13.
@@ -247,7 +252,7 @@ Step 12 currently shows a "Ready for Implementation" terminal block with TDD che
 
 Find this entire block (Step 12 Display Analysis Summary, around lines 507–554):
 
-```markdown
+````markdown
 ### Step 12: Display Analysis Summary
 
 After creating 02-analysis.md, show:
@@ -295,12 +300,13 @@ Before implementing, write tests first:
 - `/run-e2e` - Run E2E tests with Playwright
 - `/submit-pr` - Create pull request to develop
 - `/checkpoint` - Save progress for later
-` `` `
+  ` `` `
 ```
+````
 
 Replace the entire Step 12 block with:
 
-```markdown
+````markdown
 ### Step 12: Display Analysis Summary
 
 After creating 02-analysis.md, show a brief handoff message:
@@ -310,10 +316,10 @@ After creating 02-analysis.md, show a brief handoff message:
 
 ### Artifacts Created
 
-| File                  | Status     |
-| --------------------- | ---------- |
-| `00-task-overview.md` | ✅ Created |
-| `01-setup.md`         | ✅ Created |
+| File                  | Status                                       |
+| --------------------- | -------------------------------------------- |
+| `00-task-overview.md` | ✅ Created                                   |
+| `01-setup.md`         | ✅ Created                                   |
 | `02-analysis.md`      | ✅ Created (includes Design Questions brief) |
 
 ### Key Findings
@@ -325,6 +331,7 @@ After creating 02-analysis.md, show a brief handoff message:
 **Proceeding to design dialogue...**
 ` `` `
 ```
+````
 
 > **Do NOT add "Ready for Implementation" or Related Skills here.** The next step is brainstorming, not implementation.
 
@@ -337,6 +344,7 @@ Read Step 12 and confirm it no longer contains "Ready for Implementation," the T
 ### Task 6: Add Step 13 — Invoke brainstorming
 
 **Files:**
+
 - Modify: `.claude/skills/start-task/SKILL.md` (after Step 12, before the Artifact Templates section)
 
 Add Step 13 as the new terminal step of the skill.
@@ -351,29 +359,32 @@ Find the line that reads `---` immediately after the Step 12 block (the separato
 > **CRITICAL: This is the terminal step. Invoke brainstorming automatically — do NOT wait for the user to ask.**
 
 Invoke the brainstorming skill with pre-loaded context:
-
 ```
+
 Skill('superpowers:brainstorming', args: `
-  Context pre-loaded from start-task for GH-{number}.
+Context pre-loaded from start-task for GH-{number}.
 
-  Before starting:
-  1. Read .ai-context/task-outputs/GH-{number}/02-analysis.md
-  2. Skip the "Explore project context" step — codebase analysis is already done
-  3. Open the dialogue using the "Design Questions" section of 02-analysis.md as your agenda
+Before starting:
 
-  Start your first message with:
-  "I've reviewed the codebase analysis for GH-{number}. [Summarize what we know in 1-2 sentences.]
-   I want to understand [first open question from Design Questions]..."
+1. Read .ai-context/task-outputs/GH-{number}/02-analysis.md
+2. Skip the "Explore project context" step — codebase analysis is already done
+3. Open the dialogue using the "Design Questions" section of 02-analysis.md as your agenda
 
-  Then continue the normal brainstorming flow:
-  - Clarifying questions (one at a time, using Design Questions as agenda)
-  - 2–3 approach proposals with trade-offs
-  - Design sections presented for approval
-  - Spec doc written to docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md
-  - GitHub issue comment posted with design decisions (if issue exists)
-  - writing-plans invoked as terminal step
-`)
-```
+Start your first message with:
+"I've reviewed the codebase analysis for GH-{number}. [Summarize what we know in 1-2 sentences.]
+I want to understand [first open question from Design Questions]..."
+
+Then continue the normal brainstorming flow:
+
+- Clarifying questions (one at a time, using Design Questions as agenda)
+- 2–3 approach proposals with trade-offs
+- Design sections presented for approval
+- Spec doc written to docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md
+- GitHub issue comment posted with design decisions (if issue exists)
+- writing-plans invoked as terminal step
+  `)
+
+````
 
 **GitHub issue comment** (posted by brainstorming after spec approval, before writing-plans):
 
@@ -391,13 +402,13 @@ Skill('superpowers:brainstorming', args: `
 
 **Spec:** `docs/superpowers/specs/{YYYY-MM-DD}-{topic}-design.md`
 **Implementation plan:** Will be created at `.ai-context/task-outputs/GH-{number}/03-implementation-plan.md`
-```
+````
 
 Post via: `mcp__github__add_issue_comment({ owner, repo, issue_number: {number}, body: comment })`
 
 Only post if a GitHub issue exists (branch contains `GH-{number}` and issue was successfully fetched in Step 2). Skip silently if no issue.
 
-```
+````
 
 - [ ] **Step 2: Verify the edit looks correct**
 
@@ -429,7 +440,7 @@ Find this block (around lines 914–929):
 10. **Document source branch choice** in 01-setup.md and 02-analysis.md for fix branches
 11. **ALWAYS proceed to Phase 2** - After creating 00 and 01, automatically analyze the codebase and create 02-analysis.md
 12. **Use Task tool with Explore agent** for complex codebase analysis to find relevant files and patterns
-```
+````
 
 Replace with:
 
@@ -459,15 +470,15 @@ Read the Implementation Notes and confirm point 13 is present and clearly states
 
 ### Spec coverage
 
-| Spec section | Covered by task |
-|---|---|
-| Section 1: Flow change (Steps 1–11 unchanged, Step 12 → handoff, Step 13 → brainstorming) | Tasks 5, 6 |
-| Section 2: Design Questions in 02-analysis.md | Tasks 3, 4 |
-| Section 3: Brainstorming picks up context via args | Task 6 |
-| Section 4: Artifact lifecycle (01-setup.md Next Steps updated) | Task 2 |
-| Section 5: GitHub issue comment (in Step 13 invocation) | Task 6 |
-| Description update | Task 1 |
-| Implementation Notes | Task 7 |
+| Spec section                                                                              | Covered by task |
+| ----------------------------------------------------------------------------------------- | --------------- |
+| Section 1: Flow change (Steps 1–11 unchanged, Step 12 → handoff, Step 13 → brainstorming) | Tasks 5, 6      |
+| Section 2: Design Questions in 02-analysis.md                                             | Tasks 3, 4      |
+| Section 3: Brainstorming picks up context via args                                        | Task 6          |
+| Section 4: Artifact lifecycle (01-setup.md Next Steps updated)                            | Task 2          |
+| Section 5: GitHub issue comment (in Step 13 invocation)                                   | Task 6          |
+| Description update                                                                        | Task 1          |
+| Implementation Notes                                                                      | Task 7          |
 
 All spec sections covered. ✓
 

--- a/docs/superpowers/specs/2026-05-14-start-task-brainstorming-integration-design.md
+++ b/docs/superpowers/specs/2026-05-14-start-task-brainstorming-integration-design.md
@@ -1,0 +1,179 @@
+# Design Spec: start-task + brainstorming Integration
+
+**Date:** 2026-05-14
+**Status:** Approved
+**Scope:** Modify `/start-task` to hand off to `/brainstorming` after codebase analysis, using `02-analysis.md` as a pre-built brainstorming brief.
+
+---
+
+## Problem
+
+`/start-task` ends at codebase analysis and tells you to "start implementing." There is no structured design step before implementation begins, which means:
+
+- Design decisions happen ad-hoc during implementation
+- There's no record of *why* a particular approach was chosen
+- The GitHub issue has no trace of design discussions that happened in the editor
+
+---
+
+## Approach: Option C — Brainstorming as handoff at the end (Approach 3)
+
+After `start-task` completes branch setup and codebase analysis, it automatically hands off to `/brainstorming`. Brainstorming is armed with the already-fetched issue details and the codebase analysis (`02-analysis.md`), so it skips its own context-gathering phase and opens directly at clarifying questions.
+
+`02-analysis.md` is restructured to double as a brainstorming brief — it ends with a "Design Questions" section that seeds the brainstorming dialogue.
+
+---
+
+## Section 1: Flow change to start-task
+
+### Before
+
+```
+Steps 1–12: setup + analysis
+Step 12: Display "Analysis Complete — ready to implement" (terminal)
+```
+
+### After
+
+```
+Steps 1–11: setup + analysis (unchanged)
+Step 12:    Create 02-analysis.md (restructured — see Section 2)
+Step 12b:   Display brief analysis summary (not "ready to implement")
+Step 13:    Invoke Skill('brainstorming') with context args (new terminal step)
+```
+
+The "Related Skills" block at the end of Step 12 is removed. The `start-task` skill no longer ends by listing `/run-tests`, `/submit-pr`, etc. — those belong in the writing-plans output.
+
+---
+
+## Section 2: Restructured 02-analysis.md — the brainstorming brief
+
+All existing sections are preserved. A new terminal section is added:
+
+```markdown
+## Design Questions
+
+> Seed context for /brainstorming. These questions were surfaced by codebase analysis
+> and will drive the clarifying questions phase.
+
+### What we know (pre-answered by analysis)
+- Relevant files: [list from analysis above]
+- Existing patterns to follow: [from analysis above]
+- Hard constraints: [migrations needed, breaking changes, DB schema impacts, etc.]
+
+### Open questions for design dialogue
+- [ ] {Question 1 — e.g., "Should this be a new hook or extend the existing one?"}
+- [ ] {Question 2 — e.g., "Does this belong in the feature layer or shared?"}
+- [ ] {Question 3 — anything ambiguous from the issue or codebase}
+
+### Suggested design scope
+{1–2 sentences on what a complete implementation covers, derived from the issue + analysis}
+```
+
+**Rules for generating the Design Questions section:**
+- Open questions are genuine unknowns surfaced during analysis — not invented
+- If the task is clear and there are no real unknowns, the list is short (0–1 items) and brainstorming moves quickly to approach proposals
+- The "What we know" block summarizes findings already in the analysis — it does not duplicate detail, just points back to the sections above
+
+---
+
+## Section 3: How brainstorming picks up the context
+
+When `start-task` invokes `Skill('brainstorming')`, it passes args that instruct brainstorming to:
+
+1. Read `.ai-context/task-outputs/GH-{number}/02-analysis.md` as its starting context
+2. Skip the "Explore project context" step (Step 1 of the brainstorming checklist) — that work is already done
+3. Open the dialogue using the Design Questions section as its agenda
+
+Brainstorming's first user-facing message becomes:
+
+> "I've reviewed the codebase analysis for GH-{number}. I want to understand [first open question]..."
+
+The rest of the brainstorming flow is unchanged:
+- Clarifying questions (one at a time)
+- 2–3 approach proposals with trade-offs
+- Design sections presented for approval
+- Spec doc written to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+- GitHub issue comment posted (see Section 5)
+- `writing-plans` invoked as terminal step
+
+**No changes are made to the brainstorming skill file itself.** The context skip is communicated through invocation args.
+
+---
+
+## Section 4: Artifact lifecycle
+
+```
+start-task creates:
+  .ai-context/task-outputs/GH-{number}/
+    00-task-overview.md     ← issue details, acceptance criteria
+    01-setup.md             ← branch info, PR target, environment
+    02-analysis.md          ← codebase analysis + Design Questions brief
+
+brainstorming creates:
+  docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md   ← approved spec
+
+writing-plans creates (invoked by brainstorming as its terminal step):
+  .ai-context/task-outputs/GH-{number}/
+    03-implementation-plan.md   ← concrete steps, references the spec
+```
+
+- Artifact numbers 00–06 do not change
+- The spec doc lives in `docs/superpowers/specs/` (brainstorming's standard location)
+- `03-implementation-plan.md` is produced by writing-plans reading both `02-analysis.md` and the spec — no conflict, they serve different roles:
+  - `02-analysis.md` = "what exists in the codebase"
+  - spec doc = "what we decided to build"
+
+---
+
+## Section 5: GitHub issue comment with brainstorming outcome
+
+After the spec is written and approved, and before brainstorming invokes `writing-plans`, a comment is posted to the GitHub issue via `mcp__github__add_issue_comment`.
+
+**Comment format:**
+
+```markdown
+## Design Decision — YYYY-MM-DD
+
+**Approach chosen:** [one-sentence summary of the selected approach]
+
+**Key decisions:**
+- [Decision 1]
+- [Decision 2]
+- [Decision 3]
+
+**Constraints identified:**
+- [Hard constraints surfaced during brainstorming]
+
+**Spec:** `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+**Implementation plan:** Will be created at `.ai-context/task-outputs/GH-{number}/03-implementation-plan.md`
+```
+
+**Rules:**
+- Only posted if a GitHub issue exists (branch name contains `GH-{number}` and issue was successfully fetched in start-task)
+- Posted once — after spec approval, before writing-plans
+- Not updated later
+
+---
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `.claude/skills/start-task/SKILL.md` | Add Step 13 (invoke brainstorming); restructure Step 12 to remove terminal message; update 02-analysis.md template to include Design Questions section |
+| `.claude/skills/brainstorming/` | No changes — context skip is handled via invocation args |
+
+## Files to leave unchanged
+
+- All artifact templates (00–06)
+- `docs/superpowers/plans/` structure
+- `writing-plans` skill
+- `submit-pr`, `merge-pr`, `create-release` skills
+
+---
+
+## What this is NOT
+
+- Not a conditional flow — brainstorming always runs after start-task
+- Not a new artifact number — spec lives in `docs/superpowers/specs/`, not the task-outputs folder
+- Not a change to how brainstorming or writing-plans work internally

--- a/docs/superpowers/specs/2026-05-14-start-task-brainstorming-integration-design.md
+++ b/docs/superpowers/specs/2026-05-14-start-task-brainstorming-integration-design.md
@@ -11,7 +11,7 @@
 `/start-task` ends at codebase analysis and tells you to "start implementing." There is no structured design step before implementation begins, which means:
 
 - Design decisions happen ad-hoc during implementation
-- There's no record of *why* a particular approach was chosen
+- There's no record of _why_ a particular approach was chosen
 - The GitHub issue has no trace of design discussions that happened in the editor
 
 ---
@@ -57,20 +57,24 @@ All existing sections are preserved. A new terminal section is added:
 > and will drive the clarifying questions phase.
 
 ### What we know (pre-answered by analysis)
+
 - Relevant files: [list from analysis above]
 - Existing patterns to follow: [from analysis above]
 - Hard constraints: [migrations needed, breaking changes, DB schema impacts, etc.]
 
 ### Open questions for design dialogue
+
 - [ ] {Question 1 — e.g., "Should this be a new hook or extend the existing one?"}
 - [ ] {Question 2 — e.g., "Does this belong in the feature layer or shared?"}
 - [ ] {Question 3 — anything ambiguous from the issue or codebase}
 
 ### Suggested design scope
+
 {1–2 sentences on what a complete implementation covers, derived from the issue + analysis}
 ```
 
 **Rules for generating the Design Questions section:**
+
 - Open questions are genuine unknowns surfaced during analysis — not invented
 - If the task is clear and there are no real unknowns, the list is short (0–1 items) and brainstorming moves quickly to approach proposals
 - The "What we know" block summarizes findings already in the analysis — it does not duplicate detail, just points back to the sections above
@@ -90,6 +94,7 @@ Brainstorming's first user-facing message becomes:
 > "I've reviewed the codebase analysis for GH-{number}. I want to understand [first open question]..."
 
 The rest of the brainstorming flow is unchanged:
+
 - Clarifying questions (one at a time)
 - 2–3 approach proposals with trade-offs
 - Design sections presented for approval
@@ -138,11 +143,13 @@ After the spec is written and approved, and before brainstorming invokes `writin
 **Approach chosen:** [one-sentence summary of the selected approach]
 
 **Key decisions:**
+
 - [Decision 1]
 - [Decision 2]
 - [Decision 3]
 
 **Constraints identified:**
+
 - [Hard constraints surfaced during brainstorming]
 
 **Spec:** `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
@@ -150,6 +157,7 @@ After the spec is written and approved, and before brainstorming invokes `writin
 ```
 
 **Rules:**
+
 - Only posted if a GitHub issue exists (branch name contains `GH-{number}` and issue was successfully fetched in start-task)
 - Posted once — after spec approval, before writing-plans
 - Not updated later
@@ -158,10 +166,10 @@ After the spec is written and approved, and before brainstorming invokes `writin
 
 ## Files to modify
 
-| File | Change |
-|------|--------|
+| File                                 | Change                                                                                                                                                 |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `.claude/skills/start-task/SKILL.md` | Add Step 13 (invoke brainstorming); restructure Step 12 to remove terminal message; update 02-analysis.md template to include Design Questions section |
-| `.claude/skills/brainstorming/` | No changes — context skip is handled via invocation args |
+| `.claude/skills/brainstorming/`      | No changes — context skip is handled via invocation args                                                                                               |
 
 ## Files to leave unchanged
 


### PR DESCRIPTION
## Summary

Closes #319

Adds a seller card to the product detail page showing who created/sells the item, with avatar, display name, and a link to their read-only public profile.

- New `useSellerInfo` hook fetches seller profile from `user_profiles` via Supabase
- New `SellerCard` component renders avatar (with initials fallback), display name, and profile link
- `ProductDetailPage` wired to render `SellerCard` with `sellerId`; hidden when `seller_id` is null
- i18n strings added for both `en` and `es`

## Changes

- `apps/store/src/features/products/application/hooks/useSellerInfo.ts` — new hook (Supabase query on `user_profiles`)
- `apps/store/src/features/products/presentation/components/SellerCard/SellerCard.tsx` — new component
- `apps/store/src/features/products/presentation/pages/ProductDetailPage.tsx` — wired `SellerCard`
- `apps/store/src/shared/infrastructure/i18n/messages/{en,es}.json` — seller card strings
- `apps/store/e2e/product-detail-seller-card.spec.ts` — E2E spec (verified on staging)
- Unit tests for `useSellerInfo` and `SellerCard`

**Also bundled:** updates to `.claude/skills/start-task/SKILL.md` adding Step 13 brainstorming handoff, Design Questions section in `02-analysis.md` template, and associated spec/plan docs under `docs/superpowers/`.

## Testing

- ✅ Unit tests: 7 cases for `SellerCard`, hook tested with mock Supabase client
- ✅ E2E staging: `renders seller card when product has a seller` — PASSED (seller-card, seller-name, seller-profile-link verified)
- ✅ No-seller path covered by unit test (renders nothing when `sellerId` is null)

---

Generated with [Claude Code](https://claude.com/claude-code)