### PR TITLE
fix(deploy): tolerate Cloudflare cache-purge failures

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -545,6 +545,8 @@ jobs:
           done
 
       - name: Purge Cloudflare cache
+        id: cf_purge
+        continue-on-error: true
         env:
           CF_API_TOKEN: ${{ secrets.PROD_CF_API_TOKEN }}
           CF_ZONE_ID: ${{ secrets.PROD_CF_ZONE_ID }}
@@ -558,15 +560,27 @@ jobs:
           BODY=$(printf '%s' "$RESPONSE" | head -n -1)
           echo "Cloudflare response ($HTTP_CODE): $BODY"
           if [ "$HTTP_CODE" != "200" ]; then
-            echo "Cloudflare purge failed with HTTP $HTTP_CODE"
+            # Non-fatal: the deploy already succeeded; cache will roll over
+            # naturally on its TTL. The job-level summary warns the operator
+            # (see "Warn on cache-purge failure" step below).
+            echo "::warning::Cloudflare purge failed with HTTP $HTTP_CODE — token may be missing the Zone.Cache Purge scope."
             exit 1
           fi
+
+      - name: Warn on cache-purge failure
+        if: steps.cf_purge.outcome == 'failure'
+        run: |
+          echo "::warning::Deploy succeeded but Cloudflare cache purge failed."
+          echo "Cached static assets will refresh on their natural TTL instead of immediately."
+          echo "To restore immediate purging, ensure PROD_CF_API_TOKEN has the"
+          echo "'Zone — Cache Purge — Purge' permission on the production zone."
 
       - name: Notify deploy complete
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           TELEGRAM_THREAD_ID: ${{ secrets.TELEGRAM_THREAD_ID }}
+          CF_PURGE_OUTCOME: ${{ steps.cf_purge.outcome }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 - <<'EOF'
@@ -580,11 +594,17 @@ jobs:
 
           sha = os.environ.get("GITHUB_SHA", "")[:7]
           repo = os.environ.get("GITHUB_REPOSITORY", "")
+          cf_outcome = os.environ.get("CF_PURGE_OUTCOME", "")
+          cf_line = (
+              "Cloudflare cache purged ✓"
+              if cf_outcome == "success"
+              else "⚠️ Cloudflare cache purge failed (non-fatal — assets refresh on TTL)"
+          )
           text = (
               "✅ <b>GCP Deploy Complete</b>\n\n"
               f"Commit: <code>{html.escape(sha)}</code>\n"
               f"Triggered by: {html.escape(os.environ.get('GITHUB_ACTOR', ''))}\n"
-              f"Cloudflare cache purged ✓\n\n"
+              f"{cf_line}\n\n"
               f"🔗 {html.escape(os.environ.get('RUN_URL', ''))}\n\n"
               f"\U0001F4CD github.com/{html.escape(repo)}"
           )


### PR DESCRIPTION
## Summary

Today's release (`v2026.05.18.1`, PR #323) was reported as a deploy failure even though prod was successfully running the new code. The build, image push, SSH deploy, container restart, and health checks all succeeded — but the very last step in the workflow (Cloudflare cache purge) returned **HTTP 401**, which under the old logic marked the entire job as failed.

Diagnosis:
- ✅ `PROD_CF_API_TOKEN` authenticates fine — `GET /user/tokens/verify` → 200
- ❌ It cannot purge the prod zone — `POST /zones/.../purge_cache` → 401

The token is valid but **missing the `Zone — Cache Purge — Purge` permission** on the prod zone. That's an operational issue, not a code one — but the workflow shouldn't fail an otherwise-successful deploy because of it.

## Changes

- The `Purge Cloudflare cache` step now uses `continue-on-error: true` and an `id`. A failure logs `::warning::` (visible in the job summary) but does not fail the job.
- A new `Warn on cache-purge failure` step runs only when the purge step's outcome is `failure`, producing a second job-summary warning that explicitly names the likely cause (missing `Zone.Cache Purge` scope on `PROD_CF_API_TOKEN`).
- The Telegram success notification now branches on the purge step's outcome — success says **"Cloudflare cache purged ✓"**; failure says **"⚠️ Cloudflare cache purge failed (non-fatal — assets refresh on TTL)"**, so the operator is informed without the success notification being suppressed.

## Why non-fatal is correct

The cache purge is a post-deploy optimization, not part of the deploy itself. When it fails:
- Pages still render with the new code immediately (`cf-cache-status: DYNAMIC` on all relevant routes — verified on `store.furrycolombia.com/`, `/store/en`, `/admin/en/reports`).
- Static assets (CSS/JS chunks, images) are content-hashed by Next.js, so browser-cache invalidation is automatic on the next page load.
- Worst case: stale static assets at the CDN edge until their natural TTL expires (typically minutes).

## Operational follow-up (separate from this PR)

Restore the `Zone — Cache Purge — Purge` permission on `PROD_CF_API_TOKEN` in the Cloudflare API Tokens page → ensures future deploys see a green ✓ instead of the warning. If a new token value is issued, update `.secrets` and run `pnpm sync-secrets`.

## Test plan

- [ ] `Branch Target` CI passes (`fix/*` → `main` is allowed per workflow rules)
- [ ] After merge, the next prod deploy (whenever the next release ships) reports as **successful** with a warning, not as failed
- [ ] Verify a successful purge (after the Cloudflare token is fixed separately) still reports the ✓ symbol in Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)