### PR TITLE
fix(deploy): repair Docker image pruning on the prod VM

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -366,12 +366,26 @@ rm -f "$_CONTAINER_ENV"
 
 log "Container started (took $(_dur $_STEP_START))"
 
-# Keep only the 2 most recent images by creation time; prune older ones
+# Keep only the 2 most recent candyshop-prod images by creation time and
+# prune everything older. Then sweep dangling layers + stopped containers.
+#
+# Bug fixed 2026-05-18: `.CreatedAt` renders as "YYYY-MM-DD HH:MM:SS ZZZ TZ"
+# — multi-word — so awk's default whitespace splitter put a time string in
+# $2 instead of the image tag. `docker rmi 17:30:00` silently failed under
+# `|| true`, so NO images ever got pruned and the VM disk slowly filled.
+# Setting -F'\t' splits on the tab we emit in the format string, so $2 is
+# now the Repository:Tag we actually want to remove.
 docker images --format '{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}' \
   | grep 'candyshop-prod' \
   | sort -rk1 \
-  | awk 'NR>2{print $2}' \
+  | awk -F'\t' 'NR>2{print $2}' \
   | xargs -r docker rmi 2>/dev/null || true
+
+# Sweep dangling layers freed by the rmi above, plus any stopped containers
+# left behind by past `docker rm -f`. Both are no-ops when there's nothing
+# to clean.
+docker image prune -f >/dev/null 2>&1 || true
+docker container prune -f >/dev/null 2>&1 || true
 
 # Clean up env file — secrets must not persist on disk
 rm -f "$ENV_FILE"


### PR DESCRIPTION
## Summary

The disk-usage warning ("80% of root filesystem • candyshop-prod") fired earlier today. Root cause: the post-deploy image-prune block in `scripts/deploy-production.sh` has never actually removed any images.

## The bug

```bash
docker images --format '{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}' \
  | grep 'candyshop-prod' \
  | sort -rk1 \
  | awk 'NR>2{print $2}' \      # ← default whitespace splitter
  | xargs -r docker rmi 2>/dev/null || true
```

`{{.CreatedAt}}` renders as `2026-05-18 17:30:00 +0000 UTC` — multi-word. awk's default whitespace splitter parses each line as:

| Field | Value |
| --- | --- |
| `$1` | `2026-05-18` |
| `$2` | `17:30:00` ← what `print $2` actually emitted |
| `$3` | `+0000` |
| `$4` | `UTC` |
| `$5` | `ghcr.io/.../candyshop-prod:abc1234` ← what was intended |

So `docker rmi 17:30:00` failed silently under `|| true`, **no images were ever pruned**, and every release has been adding a ~282 MB GHCR image to the e2-micro's root filesystem forever.

## Fix

One character: change `awk 'NR>2{print $2}'` to `awk -F'\t' 'NR>2{print $2}'` so the tab we already emit in the format string is what splits the fields. `$2` is now the image tag we actually want to remove.

Plus two defensive sweeps:

- `docker image prune -f` — removes dangling intermediate layers freed up when the old tags get rmi'd.
- `docker container prune -f` — removes any stopped containers left from past `docker rm -f` operations.

Both are no-ops when there's nothing to clean.

## Effective from

The next prod deploy. Existing accumulation will sit on the VM until then. **Operational follow-up (separate from this PR):** to reclaim it immediately, run on the prod VM:

```bash
docker image prune -af --filter "until=24h"
docker container prune -f
```

From the second deploy after this PR onwards, prod disk usage should plateau instead of growing.

## Test plan

- [ ] CI `Branch Target` passes (`fix/*` → `main` is allowed)
- [ ] After merge + next prod deploy, watch the deploy log for the new `docker image prune` lines and verify they don't error
- [ ] Watch the next watcher report — disk should not climb further, and after a few deploys should start to decrease as old tags age out

🤖 Generated with [Claude Code](https://claude.com/claude-code)