### PR TITLE
fix(ci): back up every secret, not the 47 someone remembered [GH-000]

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -1,9 +1,23 @@
 # Packages GitHub repository secrets into an encrypted artifact for local download.
 # Triggered by scripts/sync-secrets.mjs via `gh workflow run`.
 #
-# The workflow writes all required secrets to a file, encrypts it with a
+# The workflow writes every repository secret to a file, encrypts it with a
 # one-time passphrase provided as input, uploads the encrypted artifact
-# (5-minute retention), and deletes the unencrypted file.
+# (1-day retention), and deletes the unencrypted file.
+#
+# Secrets are enumerated with `toJSON(secrets)` rather than listed by hand.
+# The previous version named each secret twice — once in `env:`, once in the
+# output block — and the two drifted: 17 of the repository's 64 secrets were
+# never written, including PROD_SERVER_SSH_KEY, GCP_PROD_SERVER_SSH_KEY and
+# WEBHOOK_SECRET. GCP_PROD_SERVER_SSH_KEY was even read into `env:` and then
+# never echoed, which is exactly the failure a hand-maintained list invites.
+# A backup missing the production SSH key is not a backup, so there is now no
+# list to maintain: whatever the repository holds is what gets written.
+#
+# Multi-line values (PEM keys, tunnel configs) cannot be expressed as a single
+# KEY=VALUE line, which is why the old list quietly skipped them in favour of
+# hand-made *_B64 twins. They are now base64-encoded automatically as
+# <NAME>_BASE64. No existing secret name ends in _BASE64, so nothing collides.
 
 name: Sync Secrets
 
@@ -24,72 +38,30 @@ jobs:
     steps:
       - name: Write secrets to file
         env:
-          DEV_SUPABASE_URL: ${{ secrets.DEV_SUPABASE_URL }}
-          DEV_SUPABASE_ANON_KEY: ${{ secrets.DEV_SUPABASE_ANON_KEY }}
-          DEV_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.DEV_SUPABASE_SERVICE_ROLE_KEY }}
-          DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI: ${{ secrets.DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI }}
-          DEV_SUPABASE_ACCESS_TOKEN: ${{ secrets.DEV_SUPABASE_ACCESS_TOKEN }}
-          STAGING_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
-          STAGING_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
-          STAGING_JWT_SECRET: ${{ secrets.STAGING_JWT_SECRET }}
-          STAGING_POSTGRES_PASSWORD: ${{ secrets.STAGING_POSTGRES_PASSWORD }}
-          E2E_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
-          E2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
-          CI_SUPABASE_ANON_KEY: ${{ secrets.CI_SUPABASE_ANON_KEY }}
-          CI_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.CI_SUPABASE_SERVICE_ROLE_KEY }}
-          CI_SUPABASE_JWT_SECRET: ${{ secrets.CI_SUPABASE_JWT_SECRET }}
-          CI_SUPABASE_DB_PASSWORD: ${{ secrets.CI_SUPABASE_DB_PASSWORD }}
-          PROD_SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
-          PROD_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
-          PROD_SUPABASE_DB_PASSWORD: ${{ secrets.PROD_SUPABASE_DB_PASSWORD }}
-          PROD_SUPABASE_ACCESS_TOKEN: ${{ secrets.PROD_SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
-          SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
-          SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID }}
-          SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET }}
-          STAGING_CLOUDFLARE_TUNNEL_TOKEN: ${{ secrets.STAGING_CLOUDFLARE_TUNNEL_TOKEN }}
-          STAGING_CLOUDFLARE_TUNNEL_APP_TOKEN: ${{ secrets.STAGING_CLOUDFLARE_TUNNEL_APP_TOKEN }}
-          CLOUDFLARED_TUNNEL_CREDENTIALS: ${{ secrets.CLOUDFLARED_TUNNEL_CREDENTIALS }}
-          CLOUDFLARED_DOCKER_CONFIG: ${{ secrets.CLOUDFLARED_DOCKER_CONFIG }}
-          CLOUDFLARED_CONFIG: ${{ secrets.CLOUDFLARED_CONFIG }}
-          GOOGLE_TEST_EMAIL: ${{ secrets.GOOGLE_TEST_EMAIL }}
-          GOOGLE_TEST_PASSWORD: ${{ secrets.GOOGLE_TEST_PASSWORD }}
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          TELEGRAM_THREAD_ID: ${{ secrets.TELEGRAM_THREAD_ID }}
-          TELEGRAM_CRITICAL_THREAD_ID: ${{ secrets.TELEGRAM_CRITICAL_THREAD_ID }}
-          TELEGRAM_REVIEWS_THREAD_ID: ${{ secrets.TELEGRAM_REVIEWS_THREAD_ID }}
-          TELEGRAM_BACKUPS_THREAD_ID: ${{ secrets.TELEGRAM_BACKUPS_THREAD_ID }}
-          TALLY_FORM_ID: ${{ secrets.TALLY_FORM_ID }}
-          DEV_SSH_PUBLIC_KEY: ${{ secrets.DEV_SSH_PUBLIC_KEY }}
-          PROD_CF_API_TOKEN: ${{ secrets.PROD_CF_API_TOKEN }}
-          PROD_CF_ZONE_ID: ${{ secrets.PROD_CF_ZONE_ID }}
-          PROD_CF_DNS_API_TOKEN: ${{ secrets.PROD_CF_DNS_API_TOKEN }}
-          CLOUDFLARE_FFXIVBE_ZERO_TRUST_API_TOKEN: ${{ secrets.CLOUDFLARE_FFXIVBE_ZERO_TRUST_API_TOKEN }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          GCP_PROD_SERVER_HOST: ${{ secrets.GCP_PROD_SERVER_HOST }}
-          GCP_PROD_SERVER_USER: ${{ secrets.GCP_PROD_SERVER_USER }}
-          GCP_PROD_SERVER_SSH_PUBLIC_KEY: ${{ secrets.GCP_PROD_SERVER_SSH_PUBLIC_KEY }}
-          GCP_PROD_SERVER_SSH_KEY: ${{ secrets.GCP_PROD_SERVER_SSH_KEY }}
-          GCP_PROD_SERVER_SSH_KEY_B64: ${{ secrets.GCP_PROD_SERVER_SSH_KEY_B64 }}
-          GCP_PROD_SA_KEY_B64: ${{ secrets.GCP_PROD_SA_KEY_B64 }}
+          ALL_SECRETS: ${{ toJSON(secrets) }}
         shell: bash
         run: |
-          # Validate required secrets are present
+          # Refuse to write a truncated backup. An empty or tiny secrets context
+          # means something is wrong with the context, not that the repo has no
+          # secrets — and overwriting a good local .secrets with it loses data.
+          COUNT=$(printf '%s' "$ALL_SECRETS" | jq '
+            to_entries
+            | map(select(.key | ascii_downcase != "github_token"))
+            | length
+          ')
+
+          if [ -z "$COUNT" ] || [ "$COUNT" -lt 10 ]; then
+            echo "::error::Only ${COUNT:-0} secrets visible — refusing to write a truncated backup."
+            exit 1
+          fi
+
+          # A short spot-check that the context really is this repository's.
+          # Not a maintained inventory — just enough to fail loudly if it is not.
           MISSING=""
           for KEY in \
-            DEV_SUPABASE_URL DEV_SUPABASE_ANON_KEY DEV_SUPABASE_SERVICE_ROLE_KEY \
-            DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI \
-            STAGING_SUPABASE_ANON_KEY STAGING_SUPABASE_SERVICE_ROLE_KEY \
-            STAGING_JWT_SECRET STAGING_POSTGRES_PASSWORD \
-            E2E_SUPABASE_ANON_KEY E2E_SUPABASE_SERVICE_ROLE_KEY \
-            CI_SUPABASE_ANON_KEY CI_SUPABASE_SERVICE_ROLE_KEY \
-            CI_SUPABASE_JWT_SECRET CI_SUPABASE_DB_PASSWORD \
             PROD_SUPABASE_ANON_KEY PROD_SUPABASE_SERVICE_ROLE_KEY \
-            PROD_SUPABASE_DB_PASSWORD; do
-            VAL=$(printenv "$KEY" || true)
-            if [ -z "$VAL" ]; then
+            PROD_SERVER_HOST PROD_SERVER_SSH_KEY WEBHOOK_SECRET; do
+            if ! printf '%s' "$ALL_SECRETS" | jq -e --arg k "$KEY" 'has($k)' > /dev/null; then
               MISSING="$MISSING $KEY"
             fi
           done
@@ -99,95 +71,27 @@ jobs:
             exit 1
           fi
 
-          # Write secrets file
           {
-            echo "# Auto-generated by sync-secrets workflow — do not edit manually."
-            echo "# Last synced: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "# Auto-generated by the sync-secrets workflow — do not edit manually."
+            echo "# Re-run 'pnpm sync-secrets' to refresh. Last synced: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "#"
+            echo "# Contains every repository secret (${COUNT}), enumerated via toJSON(secrets)."
+            echo "# There is no hardcoded list, so this file cannot drift from GitHub."
+            echo "#"
+            echo "# Multi-line values are base64-encoded as <NAME>_BASE64, because this"
+            echo "# file is one KEY=VALUE per line. Restore one with:"
+            echo "#   echo \"\$<NAME>_BASE64\" | base64 -d > <file> && chmod 600 <file>"
             echo ""
-            echo "# ─── Dev (Supabase Cloud) ────────────────────────────────────────"
-            echo "DEV_SUPABASE_URL=${DEV_SUPABASE_URL}"
-            echo "DEV_SUPABASE_ANON_KEY=${DEV_SUPABASE_ANON_KEY}"
-            echo "DEV_SUPABASE_SERVICE_ROLE_KEY=${DEV_SUPABASE_SERVICE_ROLE_KEY}"
-            echo "DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI=${DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI}"
-            echo "DEV_SUPABASE_ACCESS_TOKEN=${DEV_SUPABASE_ACCESS_TOKEN}"
-            echo ""
-            echo "# ─── Staging (containerized Supabase) ────────────────────────────"
-            echo "STAGING_SUPABASE_ANON_KEY=${STAGING_SUPABASE_ANON_KEY}"
-            echo "STAGING_SUPABASE_SERVICE_ROLE_KEY=${STAGING_SUPABASE_SERVICE_ROLE_KEY}"
-            echo "STAGING_JWT_SECRET=${STAGING_JWT_SECRET}"
-            echo "STAGING_POSTGRES_PASSWORD=${STAGING_POSTGRES_PASSWORD}"
-            echo ""
-            echo "# ─── E2E (isolated Supabase) ─────────────────────────────────────"
-            echo "E2E_SUPABASE_ANON_KEY=${E2E_SUPABASE_ANON_KEY}"
-            echo "E2E_SUPABASE_SERVICE_ROLE_KEY=${E2E_SUPABASE_SERVICE_ROLE_KEY}"
-            echo ""
-            echo "# ─── CI (local Docker Supabase, Supabase demo keys) ──────────────"
-            echo "CI_SUPABASE_ANON_KEY=${CI_SUPABASE_ANON_KEY}"
-            echo "CI_SUPABASE_SERVICE_ROLE_KEY=${CI_SUPABASE_SERVICE_ROLE_KEY}"
-            echo "CI_SUPABASE_JWT_SECRET=${CI_SUPABASE_JWT_SECRET}"
-            echo "CI_SUPABASE_DB_PASSWORD=${CI_SUPABASE_DB_PASSWORD}"
-            echo ""
-            echo "# ─── Prod (Supabase Cloud) ───────────────────────────────────────"
-            echo "PROD_SUPABASE_ANON_KEY=${PROD_SUPABASE_ANON_KEY}"
-            echo "PROD_SUPABASE_SERVICE_ROLE_KEY=${PROD_SUPABASE_SERVICE_ROLE_KEY}"
-            echo "PROD_SUPABASE_DB_PASSWORD=${PROD_SUPABASE_DB_PASSWORD}"
-            echo "PROD_SUPABASE_ACCESS_TOKEN=${PROD_SUPABASE_ACCESS_TOKEN}"
-            echo ""
-            echo "# ─── Shared OAuth ────────────────────────────────────────────────"
-            echo "SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=${SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID}"
-            echo "SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET=${SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET}"
-            echo "SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID=${SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID}"
-            echo "SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET=${SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET}"
-            echo ""
-            echo "# ─── Cloudflare tunnel ───────────────────────────────────────────"
-            echo "STAGING_CLOUDFLARE_TUNNEL_TOKEN=${STAGING_CLOUDFLARE_TUNNEL_TOKEN}"
-            echo "STAGING_CLOUDFLARE_TUNNEL_APP_TOKEN=${STAGING_CLOUDFLARE_TUNNEL_APP_TOKEN}"
-            echo "CLOUDFLARED_TUNNEL_CREDENTIALS=${CLOUDFLARED_TUNNEL_CREDENTIALS}"
-            echo "CLOUDFLARED_DOCKER_CONFIG=${CLOUDFLARED_DOCKER_CONFIG}"
-            echo "CLOUDFLARED_CONFIG=${CLOUDFLARED_CONFIG}"
-            echo ""
-            echo "# ─── E2E Google test account ─────────────────────────────────────"
-            echo "GOOGLE_TEST_EMAIL=${GOOGLE_TEST_EMAIL}"
-            echo "GOOGLE_TEST_PASSWORD=${GOOGLE_TEST_PASSWORD}"
-            echo ""
-            echo "# ─── Telegram alerting (health watcher) ──────────────────────────"
-            echo "TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}"
-            echo "TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}"
-            echo "TELEGRAM_THREAD_ID=${TELEGRAM_THREAD_ID}"
-            echo "TELEGRAM_CRITICAL_THREAD_ID=${TELEGRAM_CRITICAL_THREAD_ID}"
-            echo "TELEGRAM_REVIEWS_THREAD_ID=${TELEGRAM_REVIEWS_THREAD_ID}"
-            echo "TELEGRAM_BACKUPS_THREAD_ID=${TELEGRAM_BACKUPS_THREAD_ID}"
-            echo ""
-            echo "# ─── Tally feedback widget ───────────────────────────────────────"
-            echo "TALLY_FORM_ID=${TALLY_FORM_ID}"
-            echo ""
-            echo "# ─── Dev tunnel SSH ──────────────────────────────────────────────"
-            echo "DEV_SSH_PUBLIC_KEY=${DEV_SSH_PUBLIC_KEY}"
-            echo ""
-            echo "# ─── Cloudflare Cache Purge ───────────────────────────────────────"
-            echo "PROD_CF_API_TOKEN=${PROD_CF_API_TOKEN}"
-            echo "PROD_CF_ZONE_ID=${PROD_CF_ZONE_ID}"
-            echo "PROD_CF_DNS_API_TOKEN=${PROD_CF_DNS_API_TOKEN}"
-            echo ""
-            echo "# ─── Cloudflare Zero Trust ───────────────────────────────────────"
-            echo "CLOUDFLARE_FFXIVBE_ZERO_TRUST_API_TOKEN=${CLOUDFLARE_FFXIVBE_ZERO_TRUST_API_TOKEN}"
-            echo ""
-            echo "# ─── Sentry error tracking ───────────────────────────────────────"
-            echo "SENTRY_DSN=${SENTRY_DSN}"
-            echo "SENTRY_ORG=furry-colombia"
-            echo "SENTRY_PROJECT=candyshop"
-            echo "SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}"
-            echo ""
-            echo "# ─── Production GCP VM (furrycolombia-candyshop) ─────────────────"
-            echo "# To restore key file: echo \$GCP_PROD_SERVER_SSH_KEY_B64 | base64 -d > ~/.ssh/candyshop_gcp && chmod 600 ~/.ssh/candyshop_gcp"
-            echo "GCP_PROD_SERVER_HOST=${GCP_PROD_SERVER_HOST}"
-            echo "GCP_PROD_SERVER_USER=${GCP_PROD_SERVER_USER}"
-            echo "GCP_PROD_SERVER_SSH_PUBLIC_KEY=${GCP_PROD_SERVER_SSH_PUBLIC_KEY}"
-            echo "GCP_PROD_SERVER_SSH_KEY_B64=${GCP_PROD_SERVER_SSH_KEY_B64}"
-            echo ""
-            echo "# GCP service account key (furrycolombia-candyshop default compute SA)"
-            echo "# To restore: echo \$GCP_PROD_SA_KEY_B64 | base64 -d > /tmp/gcp-sa-key.json && gcloud auth activate-service-account --key-file=/tmp/gcp-sa-key.json"
-            echo "GCP_PROD_SA_KEY_B64=${GCP_PROD_SA_KEY_B64}"
+            printf '%s' "$ALL_SECRETS" | jq -r '
+              to_entries
+              | map(select(.key | ascii_downcase != "github_token"))
+              | sort_by(.key)
+              | .[]
+              | if (.value | contains("\n"))
+                then (.key + "_BASE64=" + (.value | @base64))
+                else (.key + "=" + .value)
+                end
+            '
           } > secrets-plain.txt
 
       - name: Encrypt secrets file
@@ -210,5 +114,3 @@ jobs:
       - name: Clean up unencrypted file
         if: always()
         run: rm -f secrets-plain.txt
-
-


### PR DESCRIPTION
## The problem

The sync-secrets workflow named every secret **twice** — once in `env:`, once in the output block — and the two lists drifted from the repository.

Of **64** repository secrets, only **47** were written to `.secrets`. The 17 missing:

```
GCP_PROD_SERVER_SSH_KEY        PROD_SERVER_HOST
PROD_SERVER_SSH_KEY            PROD_SERVER_USER
WEBHOOK_SECRET
NEXT_PUBLIC_SUPABASE_URL       NEXT_PUBLIC_SUPABASE_ANON_KEY
NEXT_PUBLIC_AUTH_URL           NEXT_PUBLIC_AUTH_HOST_URL
NEXT_PUBLIC_ADMIN_URL          NEXT_PUBLIC_API_PREFIX
NEXT_PUBLIC_LANDING_URL        NEXT_PUBLIC_PAYMENTS_URL
NEXT_PUBLIC_PLAYGROUND_URL     NEXT_PUBLIC_STORE_URL
NEXT_PUBLIC_STUDIO_URL         NEXT_PUBLIC_ENABLE_MOCKS
```

`GCP_PROD_SERVER_SSH_KEY` shows exactly how this happens: it was read into `env:` at line 74 and then **never echoed**. Nothing fails in that case — the sync reports success and writes a file that silently lacks the production SSH key.

GitHub secrets are write-only; nobody can read those values back out. So "we have a backup" was false precisely for the credentials that would be hardest to recreate: an SSH key and a webhook secret against a live production server.

## The fix

Enumerate with `toJSON(secrets)`. **There is no list to maintain**, so the file cannot drift from the repository again — whatever the repo holds is what gets written. `github_token` is excluded; output is sorted for stable diffs.

**Multi-line values** are the reason the old list skipped some of these: a PEM key cannot be a single `KEY=VALUE` line, so hand-made `*_B64` twins were added for two of them and the rest were quietly dropped. Any multi-line value is now base64-encoded automatically as `<NAME>_BASE64`, with the restore command in the file header. No existing secret name ends in `_BASE64`, so nothing collides, and the existing `*_B64` secrets keep working untouched.

**Two guards**, since this file overwrites a local backup:
- refuse to write if fewer than 10 secrets are visible — an empty context must not truncate a good `.secrets`
- spot-check a few known names, so a wrong or empty context fails loudly instead of producing a plausible short file

## Verification

The enumeration, `github_token` exclusion, sort order and base64 round-trip were exercised against a synthetic secrets object — a multi-line PEM restores byte-identically. `jq` is already used by `ci.yml` and `pr-checks.yml`, so it is present on the runner.

After merge, the real check is `pnpm sync-secrets` producing **64** keys instead of 47.

## Context

Found while preparing this repo's ownership transfer, where the local `.secrets` is the recovery source if secrets do not survive the move. The transfer is on hold until this lands and a complete backup exists. Same root cause as the hardcoded list already fixed in the `aeleos` copy of this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)