### PR TITLE
fix(ci): restore the secrets sync, and test it this time [GH-000]

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -203,6 +203,17 @@ jobs:
       - name: Run secretlint
         run: pnpm run secretlint
 
+      # Guards .github/workflows/sync-secrets.yml, which produces the only
+      # backup of secrets GitHub stores write-only. Both bugs it has had failed
+      # silently — the sync reported success while omitting secrets — so it is
+      # gated here rather than left to be noticed during a restore.
+      #
+      # Scoped to this one file on purpose: vitest.config.scripts.js also picks
+      # up scripts/__tests__/load-env.test.js, which is currently failing for an
+      # unrelated reason (vite dynamic import). Widen this once that is fixed.
+      - name: Run workflow config tests
+        run: pnpm run test:workflows
+
   # ============================================
   # Accessibility Check (on store/package changes)
   # ============================================

--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -5,19 +5,29 @@
 # one-time passphrase provided as input, uploads the encrypted artifact
 # (1-day retention), and deletes the unencrypted file.
 #
-# Secrets are enumerated with `toJSON(secrets)` rather than listed by hand.
-# The previous version named each secret twice — once in `env:`, once in the
-# output block — and the two drifted: 17 of the repository's 64 secrets were
-# never written, including PROD_SERVER_SSH_KEY, GCP_PROD_SERVER_SSH_KEY and
-# WEBHOOK_SECRET. GCP_PROD_SERVER_SSH_KEY was even read into `env:` and then
-# never echoed, which is exactly the failure a hand-maintained list invites.
-# A backup missing the production SSH key is not a backup, so there is now no
-# list to maintain: whatever the repository holds is what gets written.
+# Why the S_ prefix and the loop:
 #
-# Multi-line values (PEM keys, tunnel configs) cannot be expressed as a single
-# KEY=VALUE line, which is why the old list quietly skipped them in favour of
-# hand-made *_B64 twins. They are now base64-encoded automatically as
-# <NAME>_BASE64. No existing secret name ends in _BASE64, so nothing collides.
+#   The original version named each secret TWICE — once in env:, once in the
+#   output block — and the two drifted. 17 of 64 secrets were never written,
+#   including PROD_SERVER_SSH_KEY, GCP_PROD_SERVER_SSH_KEY and WEBHOOK_SECRET.
+#   GCP_PROD_SERVER_SSH_KEY was read into env: and then never echoed; nothing
+#   fails when that happens, so the sync reported success while omitting the
+#   production SSH key.
+#
+#   env: below is now the ONLY list. The loop discovers names from the
+#   environment (compgen -e), so the output can never fall behind env: again.
+#   Adding a repository secret means adding one line here, nothing else.
+#
+#   toJSON(secrets) would remove even that line, but GitHub rejects the run
+#   outright: zero jobs, conclusion action_required, and not approvable — the
+#   approve endpoint reports the run is not awaiting approval. Runs 31200831010
+#   and 31200881938 failed that way on sha 0d9e785, while the previous
+#   hand-listed run on d414425 succeeded. Do not reintroduce it; the test in
+#   tests/sync-secrets-workflow.test.mjs fails if anyone does.
+#
+# Multi-line values (PEM keys, tunnel configs) cannot be one KEY=VALUE line, so
+# they are base64-encoded as <NAME>_BASE64. No secret name ends in _BASE64, so
+# nothing collides, and the hand-made *_B64 secrets keep working untouched.
 
 name: Sync Secrets
 
@@ -38,61 +48,116 @@ jobs:
     steps:
       - name: Write secrets to file
         env:
-          ALL_SECRETS: ${{ toJSON(secrets) }}
+          S_CI_SUPABASE_ANON_KEY: ${{ secrets.CI_SUPABASE_ANON_KEY }}
+          S_CI_SUPABASE_DB_PASSWORD: ${{ secrets.CI_SUPABASE_DB_PASSWORD }}
+          S_CI_SUPABASE_JWT_SECRET: ${{ secrets.CI_SUPABASE_JWT_SECRET }}
+          S_CI_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.CI_SUPABASE_SERVICE_ROLE_KEY }}
+          S_CLOUDFLARE_FFXIVBE_ZERO_TRUST_API_TOKEN: ${{ secrets.CLOUDFLARE_FFXIVBE_ZERO_TRUST_API_TOKEN }}
+          S_CLOUDFLARED_CONFIG: ${{ secrets.CLOUDFLARED_CONFIG }}
+          S_CLOUDFLARED_DOCKER_CONFIG: ${{ secrets.CLOUDFLARED_DOCKER_CONFIG }}
+          S_CLOUDFLARED_TUNNEL_CREDENTIALS: ${{ secrets.CLOUDFLARED_TUNNEL_CREDENTIALS }}
+          S_DEV_SSH_PUBLIC_KEY: ${{ secrets.DEV_SSH_PUBLIC_KEY }}
+          S_DEV_SUPABASE_ACCESS_TOKEN: ${{ secrets.DEV_SUPABASE_ACCESS_TOKEN }}
+          S_DEV_SUPABASE_ANON_KEY: ${{ secrets.DEV_SUPABASE_ANON_KEY }}
+          S_DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI: ${{ secrets.DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI }}
+          S_DEV_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.DEV_SUPABASE_SERVICE_ROLE_KEY }}
+          S_DEV_SUPABASE_URL: ${{ secrets.DEV_SUPABASE_URL }}
+          S_E2E_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          S_E2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+          S_GCP_PROD_SA_KEY_B64: ${{ secrets.GCP_PROD_SA_KEY_B64 }}
+          S_GCP_PROD_SERVER_HOST: ${{ secrets.GCP_PROD_SERVER_HOST }}
+          S_GCP_PROD_SERVER_SSH_KEY: ${{ secrets.GCP_PROD_SERVER_SSH_KEY }}
+          S_GCP_PROD_SERVER_SSH_KEY_B64: ${{ secrets.GCP_PROD_SERVER_SSH_KEY_B64 }}
+          S_GCP_PROD_SERVER_SSH_PUBLIC_KEY: ${{ secrets.GCP_PROD_SERVER_SSH_PUBLIC_KEY }}
+          S_GCP_PROD_SERVER_USER: ${{ secrets.GCP_PROD_SERVER_USER }}
+          S_GOOGLE_TEST_EMAIL: ${{ secrets.GOOGLE_TEST_EMAIL }}
+          S_GOOGLE_TEST_PASSWORD: ${{ secrets.GOOGLE_TEST_PASSWORD }}
+          S_NEXT_PUBLIC_ADMIN_URL: ${{ secrets.NEXT_PUBLIC_ADMIN_URL }}
+          S_NEXT_PUBLIC_API_PREFIX: ${{ secrets.NEXT_PUBLIC_API_PREFIX }}
+          S_NEXT_PUBLIC_AUTH_HOST_URL: ${{ secrets.NEXT_PUBLIC_AUTH_HOST_URL }}
+          S_NEXT_PUBLIC_AUTH_URL: ${{ secrets.NEXT_PUBLIC_AUTH_URL }}
+          S_NEXT_PUBLIC_ENABLE_MOCKS: ${{ secrets.NEXT_PUBLIC_ENABLE_MOCKS }}
+          S_NEXT_PUBLIC_LANDING_URL: ${{ secrets.NEXT_PUBLIC_LANDING_URL }}
+          S_NEXT_PUBLIC_PAYMENTS_URL: ${{ secrets.NEXT_PUBLIC_PAYMENTS_URL }}
+          S_NEXT_PUBLIC_PLAYGROUND_URL: ${{ secrets.NEXT_PUBLIC_PLAYGROUND_URL }}
+          S_NEXT_PUBLIC_STORE_URL: ${{ secrets.NEXT_PUBLIC_STORE_URL }}
+          S_NEXT_PUBLIC_STUDIO_URL: ${{ secrets.NEXT_PUBLIC_STUDIO_URL }}
+          S_NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          S_NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          S_PROD_CF_API_TOKEN: ${{ secrets.PROD_CF_API_TOKEN }}
+          S_PROD_CF_DNS_API_TOKEN: ${{ secrets.PROD_CF_DNS_API_TOKEN }}
+          S_PROD_CF_ZONE_ID: ${{ secrets.PROD_CF_ZONE_ID }}
+          S_PROD_SERVER_HOST: ${{ secrets.PROD_SERVER_HOST }}
+          S_PROD_SERVER_SSH_KEY: ${{ secrets.PROD_SERVER_SSH_KEY }}
+          S_PROD_SERVER_USER: ${{ secrets.PROD_SERVER_USER }}
+          S_PROD_SUPABASE_ACCESS_TOKEN: ${{ secrets.PROD_SUPABASE_ACCESS_TOKEN }}
+          S_PROD_SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
+          S_PROD_SUPABASE_DB_PASSWORD: ${{ secrets.PROD_SUPABASE_DB_PASSWORD }}
+          S_PROD_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
+          S_STAGING_CLOUDFLARE_TUNNEL_APP_TOKEN: ${{ secrets.STAGING_CLOUDFLARE_TUNNEL_APP_TOKEN }}
+          S_STAGING_CLOUDFLARE_TUNNEL_TOKEN: ${{ secrets.STAGING_CLOUDFLARE_TUNNEL_TOKEN }}
+          S_STAGING_JWT_SECRET: ${{ secrets.STAGING_JWT_SECRET }}
+          S_STAGING_POSTGRES_PASSWORD: ${{ secrets.STAGING_POSTGRES_PASSWORD }}
+          S_STAGING_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
+          S_STAGING_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
+          S_SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID }}
+          S_SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET }}
+          S_SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
+          S_SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
+          S_TALLY_FORM_ID: ${{ secrets.TALLY_FORM_ID }}
+          S_TELEGRAM_BACKUPS_THREAD_ID: ${{ secrets.TELEGRAM_BACKUPS_THREAD_ID }}
+          S_TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          S_TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          S_TELEGRAM_CRITICAL_THREAD_ID: ${{ secrets.TELEGRAM_CRITICAL_THREAD_ID }}
+          S_TELEGRAM_REVIEWS_THREAD_ID: ${{ secrets.TELEGRAM_REVIEWS_THREAD_ID }}
+          S_TELEGRAM_THREAD_ID: ${{ secrets.TELEGRAM_THREAD_ID }}
+          S_WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
         shell: bash
         run: |
-          # Refuse to write a truncated backup. An empty or tiny secrets context
-          # means something is wrong with the context, not that the repo has no
-          # secrets — and overwriting a good local .secrets with it loses data.
-          COUNT=$(printf '%s' "$ALL_SECRETS" | jq '
-            to_entries
-            | map(select(.key | ascii_downcase != "github_token"))
-            | length
-          ')
-
-          if [ -z "$COUNT" ] || [ "$COUNT" -lt 10 ]; then
-            echo "::error::Only ${COUNT:-0} secrets visible — refusing to write a truncated backup."
-            exit 1
-          fi
-
-          # A short spot-check that the context really is this repository's.
-          # Not a maintained inventory — just enough to fail loudly if it is not.
-          MISSING=""
-          for KEY in \
-            PROD_SUPABASE_ANON_KEY PROD_SUPABASE_SERVICE_ROLE_KEY \
-            PROD_SERVER_HOST PROD_SERVER_SSH_KEY WEBHOOK_SECRET; do
-            if ! printf '%s' "$ALL_SECRETS" | jq -e --arg k "$KEY" 'has($k)' > /dev/null; then
-              MISSING="$MISSING $KEY"
-            fi
-          done
-
-          if [ -n "$MISSING" ]; then
-            echo "::error::Missing required GitHub secrets:$MISSING"
-            exit 1
-          fi
-
           {
             echo "# Auto-generated by the sync-secrets workflow — do not edit manually."
             echo "# Re-run 'pnpm sync-secrets' to refresh. Last synced: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
             echo "#"
-            echo "# Contains every repository secret (${COUNT}), enumerated via toJSON(secrets)."
-            echo "# There is no hardcoded list, so this file cannot drift from GitHub."
-            echo "#"
-            echo "# Multi-line values are base64-encoded as <NAME>_BASE64, because this"
-            echo "# file is one KEY=VALUE per line. Restore one with:"
-            echo "#   echo \"\$<NAME>_BASE64\" | base64 -d > <file> && chmod 600 <file>"
+            echo "# Multi-line values are base64-encoded as <NAME>_BASE64, because this file"
+            echo "# is one KEY=VALUE per line. Restore one with:"
+            echo "#   echo \"\$NAME_BASE64\" | base64 -d > outfile && chmod 600 outfile"
             echo ""
-            printf '%s' "$ALL_SECRETS" | jq -r '
-              to_entries
-              | map(select(.key | ascii_downcase != "github_token"))
-              | sort_by(.key)
-              | .[]
-              | if (.value | contains("\n"))
-                then (.key + "_BASE64=" + (.value | @base64))
-                else (.key + "=" + .value)
-                end
-            '
           } > secrets-plain.txt
+
+          COUNT=0
+          EMPTY=""
+
+          for VAR in $(compgen -e | grep '^S_' | sort); do
+            NAME="${VAR#S_}"
+            VAL="${!VAR}"
+
+            case "$VAL" in
+              *$'\n'*)
+                printf '%s_BASE64=%s\n' "$NAME" "$(printf '%s' "$VAL" | base64 -w 0)" >> secrets-plain.txt
+                ;;
+              *)
+                printf '%s=%s\n' "$NAME" "$VAL" >> secrets-plain.txt
+                ;;
+            esac
+
+            if [ -z "$VAL" ]; then
+              EMPTY="$EMPTY $NAME"
+            fi
+            COUNT=$((COUNT + 1))
+          done
+
+          # This file overwrites a local backup, so a truncated write is worse
+          # than no write at all.
+          if [ "$COUNT" -lt 10 ]; then
+            echo "::error::Only $COUNT secrets written — refusing to publish a truncated backup."
+            exit 1
+          fi
+
+          if [ -n "$EMPTY" ]; then
+            echo "::warning::Secrets present but empty:$EMPTY"
+          fi
+
+          echo "Wrote $COUNT secrets."
 
       - name: Encrypt secrets file
         env:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "turbo test",
     "test:watch": "vitest",
     "test:coverage": "turbo test:coverage",
+    "test:workflows": "vitest run -c vitest.config.scripts.js scripts/__tests__/sync-secrets-workflow.test.mjs",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "fix:staged": "lint-staged --concurrent false",

--- a/scripts/__tests__/sync-secrets-workflow.test.mjs
+++ b/scripts/__tests__/sync-secrets-workflow.test.mjs
@@ -1,0 +1,210 @@
+/**
+ * Tests for .github/workflows/sync-secrets.yml
+ *
+ * This workflow produces the ONLY backup of secrets that GitHub itself stores
+ * write-only — including the production SSH key and WEBHOOK_SECRET. When it is
+ * wrong, nothing fails loudly: the sync reports success and writes a file that
+ * silently lacks whatever was missed. Both bugs it has had were of that shape.
+ *
+ *   1. Drift. Secrets were named twice (env: and the output block) and the two
+ *      diverged: 17 of 64 were never written. GCP_PROD_SERVER_SSH_KEY was read
+ *      into env: and then never echoed.
+ *
+ *   2. toJSON(secrets). The fix for (1) removed the list entirely, but GitHub
+ *      rejects such a run outright — zero jobs, conclusion action_required, and
+ *      not approvable. It only shows up after the workflow is merged and
+ *      dispatched, so nothing local caught it.
+ *
+ * Strategy: assert the static shape, then EXTRACT THE REAL SHELL SCRIPT from
+ * the workflow and execute it against synthetic S_* variables. The script under
+ * test is the one that ships — it cannot drift from this test the way the two
+ * hand-kept lists drifted from each other.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), "../../..");
+const workflowPath = join(repoRoot, ".github/workflows/sync-secrets.yml");
+const workflow = readFileSync(workflowPath, "utf8");
+
+const hasBash =
+  spawnSync("bash", ["-c", "echo ok"], { encoding: "utf8" }).status === 0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Extraction — no YAML dependency, so this test adds no packages
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** `S_NAME: ${{ secrets.NAME }}` lines from the env: block. */
+function envEntries(src) {
+  const entries = [];
+  for (const line of src.split("\n")) {
+    const m =
+      /^\s+S_([A-Z0-9_]+):\s*\$\{\{\s*secrets\.([A-Z0-9_]+)\s*\}\}\s*$/.exec(
+        line,
+      );
+    if (m) entries.push({ prefixed: m[1], secret: m[2] });
+  }
+  return entries;
+}
+
+/** The first step's `run: |` block, dedented to column zero. */
+function runScript(src) {
+  const start = src.indexOf("        run: |");
+  const after = src.indexOf("      - name: Encrypt secrets file");
+  const body = src.slice(start + "        run: |\n".length, after);
+  return body
+    .split("\n")
+    .map((l) => l.replace(/^ {10}/, ""))
+    .join("\n");
+}
+
+/** Run the extracted script in a scratch dir with the given S_* vars. */
+function runWith(vars) {
+  const dir = mkdtempSync(join(tmpdir(), "sync-secrets-"));
+  try {
+    const script = join(dir, "step.sh");
+    writeFileSync(script, runScript(workflow));
+    const res = spawnSync("bash", ["-e", script], {
+      cwd: dir,
+      encoding: "utf8",
+      env: { PATH: process.env.PATH, ...vars },
+    });
+    let output = "";
+    try {
+      output = readFileSync(join(dir, "secrets-plain.txt"), "utf8");
+    } catch {
+      /* the guard may have exited before writing */
+    }
+    return { ...res, output };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function parse(output) {
+  const map = new Map();
+  for (const line of output.split("\n")) {
+    const m = /^([A-Z0-9_]+)=(.*)$/.exec(line);
+    if (m) map.set(m[1], m[2]);
+  }
+  return map;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("sync-secrets workflow: static shape", () => {
+  it("does not use toJSON(secrets) in an expression", () => {
+    // Regression guard. Runs 31200831010 and 31200881938 were rejected with
+    // zero jobs on sha 0d9e785 because of this. Mentioning it in a comment is
+    // fine; evaluating it is not.
+    const expressions = workflow.match(/\$\{\{[^}]*\}\}/g) ?? [];
+    const offenders = expressions.filter((e) =>
+      /toJSON\s*\(\s*secrets\s*\)/.test(e),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("maps every S_ variable to the secret of the same name", () => {
+    const entries = envEntries(workflow);
+    const mismatched = entries.filter((e) => e.prefixed !== e.secret);
+    expect(mismatched).toEqual([]);
+  });
+
+  it("declares no duplicate secrets", () => {
+    const names = envEntries(workflow).map((e) => e.secret);
+    expect(names.length).toBe(new Set(names).size);
+  });
+
+  it("still declares a plausible number of secrets", () => {
+    // Not an inventory — a floor. A large silent drop is the failure mode that
+    // went unnoticed for months.
+    expect(envEntries(workflow).length).toBeGreaterThanOrEqual(50);
+  });
+
+  it("keeps the credentials whose loss would be unrecoverable", () => {
+    const names = new Set(envEntries(workflow).map((e) => e.secret));
+    for (const critical of [
+      "PROD_SERVER_SSH_KEY",
+      "GCP_PROD_SERVER_SSH_KEY",
+      "WEBHOOK_SECRET",
+      "PROD_SUPABASE_SERVICE_ROLE_KEY",
+    ]) {
+      expect(names.has(critical), `${critical} missing from env:`).toBe(true);
+    }
+  });
+});
+
+describe.skipIf(!hasBash)("sync-secrets workflow: the shipped script", () => {
+  it("writes every S_ variable it is given", () => {
+    const vars = Object.fromEntries(
+      Array.from({ length: 12 }, (_, i) => [`S_SECRET_${i}`, `value-${i}`]),
+    );
+    const { status, output } = runWith(vars);
+    expect(status).toBe(0);
+
+    const written = parse(output);
+    for (const key of Object.keys(vars)) {
+      const name = key.slice(2);
+      expect(written.get(name), `${name} not written`).toBe(vars[key]);
+    }
+  });
+
+  it("base64-encodes multi-line values and round-trips them exactly", () => {
+    const pem =
+      "-----BEGIN OPENSSH PRIVATE KEY-----\nabc\ndef\n-----END OPENSSH PRIVATE KEY-----\n";
+    const vars = Object.fromEntries(
+      Array.from({ length: 11 }, (_, i) => [`S_FILLER_${i}`, `v${i}`]),
+    );
+    vars.S_PROD_SERVER_SSH_KEY = pem;
+
+    const { status, output } = runWith(vars);
+    expect(status).toBe(0);
+
+    const written = parse(output);
+    // The raw name must NOT appear — it would corrupt the one-per-line format.
+    expect(written.has("PROD_SERVER_SSH_KEY")).toBe(false);
+
+    const encoded = written.get("PROD_SERVER_SSH_KEY_BASE64");
+    expect(encoded).toBeTruthy();
+    expect(encoded).not.toMatch(/\s/);
+    expect(Buffer.from(encoded, "base64").toString("utf8")).toBe(pem);
+  });
+
+  it("emits empty secrets rather than dropping them", () => {
+    const vars = Object.fromEntries(
+      Array.from({ length: 11 }, (_, i) => [`S_FILLER_${i}`, `v${i}`]),
+    );
+    vars.S_UNSET_ONE = "";
+
+    const { status, output } = runWith(vars);
+    expect(status).toBe(0);
+    expect(parse(output).has("UNSET_ONE")).toBe(true);
+    expect(parse(output).get("UNSET_ONE")).toBe("");
+  });
+
+  it("refuses to write a truncated backup", () => {
+    // The file overwrites a good local .secrets, so writing a short one is
+    // worse than writing nothing.
+    const { status, stdout } = runWith({ S_ONLY_ONE: "x" });
+    expect(status).not.toBe(0);
+    expect(stdout).toContain("refusing to publish a truncated backup");
+  });
+
+  it("ignores environment variables that are not secrets", () => {
+    const vars = Object.fromEntries(
+      Array.from({ length: 11 }, (_, i) => [`S_FILLER_${i}`, `v${i}`]),
+    );
+    vars.NOT_A_SECRET = "leak-me";
+    vars.HOME_ISH = "also-not";
+
+    const { status, output } = runWith(vars);
+    expect(status).toBe(0);
+    expect(output).not.toContain("leak-me");
+    expect(output).not.toContain("also-not");
+  });
+});


### PR DESCRIPTION
**Reverts the regression I introduced in #334, and adds the test that would have caught it.**

## What broke

#334 replaced the hand-listed secrets with `toJSON(secrets)` to stop the two lists drifting. GitHub **rejects** a run that does this — zero jobs, conclusion `action_required`, and not approvable (the approve endpoint reports the run is not awaiting approval).

| run | sha | workflow version | result |
|---|---|---|---|
| 31141014216 | `d414425` | hand-listed | success |
| 31200831010 | `0d9e785` | `toJSON(secrets)` | action_required, 0 jobs |
| 31200881938 | `0d9e785` | `toJSON(secrets)` | action_required, 0 jobs |

`develop` has been unable to produce a secrets backup since that merge.

## The fix

`env:` is a list again — but it is now the **only** list. Each secret binds to `S_<NAME>`, and the output loop discovers names from the environment (`compgen -e`), so output can no longer fall behind `env:`. That was the original bug that hid 17 of 64 secrets, including `PROD_SERVER_SSH_KEY`, `GCP_PROD_SERVER_SSH_KEY` and `WEBHOOK_SECRET`. Adding a secret is one line here and nothing else. Multi-line values are base64-encoded as `<NAME>_BASE64`.

## The test is the point of this PR

Both bugs shared a failure mode: **the sync reports success while writing an incomplete file**, so nothing surfaces until a restore needs a key that was never captured.

The test extracts the real shell script out of the workflow and executes it against synthetic `S_*` variables — what is tested is what ships. Plus static assertions: `S_` names match their secrets, no duplicates, at least 50 declared, the unrecoverable credentials present, and no `toJSON(secrets)` in any expression.

**Verified it fails on the bugs, not just passes on the fix:**

- against `0d9e785` (toJSON): **8 tests fail**, including the explicit guard — `expected [ '${{ toJSON(secrets) }}' ] to deeply equal []`
- against `d414425` (original drift): **7 tests fail**
- against this version: **10 pass**

## `scripts/__tests__` has never run anywhere

`vitest.config.scripts.js` existed but was wired to nothing — no package script, no CI step. That is how a one-line drift survived for months. Now gated via `pnpm test:workflows` in the `security` job of `pr-checks.yml`, which runs on every non-docs PR.

**Scoped to this one test file on purpose:** the same config also picks up `scripts/__tests__/load-env.test.js`, which fails for an unrelated reason (vite dynamic import, 6 failures). Wiring the whole suite would land a red gate. Flagged in a comment beside the CI step as an obvious follow-up.

## After merge

`pnpm sync-secrets` should report **64** secrets. Until then this repo has no complete backup, and the ownership transfer stays on hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)