### PR TITLE
fix(ci): stop classifying workflow and script changes as docs-only [GH-000]

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -147,6 +147,13 @@ jobs:
               - 'packages/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
+              # Not app code, but changing either can break production without
+              # touching apps/ at all — and docs-only skips the Security Audit
+              # job, which is where secretlint, semgrep and the sync-secrets
+              # workflow test run. A PR editing only .github/workflows/
+              # sync-secrets.yml was classified docs-only and skipped all four.
+              - 'scripts/**'
+              - '.github/workflows/**'
 
       - name: Check if docs-only
         id: check


### PR DESCRIPTION
**The guard added in #335 has never actually run on CI.** This is why.

## The hole

`Security Audit` runs only when `docs-only == false`, and `docs-only` is the negation of the `code` filter:

```yaml
code:
  - 'apps/**'
  - 'packages/**'
  - 'package.json'
  - 'pnpm-lock.yaml'
```

Neither `scripts/**` nor `.github/workflows/**` is in it. So a PR touching only those is treated as **documentation** and skips `secretlint`, `semgrep`, `pnpm audit`, and the sync-secrets workflow test.

That makes the guard inert exactly where it matters: **a PR editing only `.github/workflows/sync-secrets.yml` — the change the test exists to catch — would never run it.**

Recent evidence:

| PR | touched | Security Audit |
|---|---|---|
| #335 | `sync-secrets.yml`, `pr-checks.yml`, **`package.json`**, test | ran — only because of `package.json` |
| #336 | test file only | **skipped** (docs-only) |

So the one run it got was luck.

## The fix

Add both paths to the `code` filter. A workflow change is not documentation: it is the one kind of change that can break production deploys and secret handling without touching `apps/` at all, and it deserves a security scan for the same reason.

## Verification

Parsed the filter back out of the workflow after editing, rather than eyeballing the diff:

```
code filter:
  apps/**
  packages/**
  package.json
  pnpm-lock.yaml
  scripts/**
  .github/workflows/**
covers workflow+script changes: true
```

YAML parses; the change is additive only (+7 lines, no deletions).

**This PR itself is the test:** it touches only `.github/workflows/pr-checks.yml`, so under the old filter it would have been docs-only. If `Security Audit` runs on it, the fix works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)