### PR TITLE
fix(server): point the deploy webhook at vaoan/libra, overridably [GH-000]

### DIFF
--- a/scripts/server/webhook-deploy.mjs
+++ b/scripts/server/webhook-deploy.mjs
@@ -21,6 +21,10 @@ const SECRET = process.env.WEBHOOK_SECRET || "";
 const DEPLOY_SCRIPT =
   process.env.DEPLOY_SCRIPT || "/home/furrycolombia/deploy.sh";
 const BRANCH = process.env.DEPLOY_BRANCH || "main";
+// Overridable so ownership or naming can change without a code redeploy: set
+// REPO_URL in the PM2 environment, then drop it once the default matches again.
+const REPO_URL =
+  process.env.REPO_URL || "https://github.com/vaoan/libra.git";
 
 let deploying = false;
 
@@ -52,7 +56,7 @@ function runDeploy() {
       env: {
         ...process.env,
         BRANCH,
-        REPO_URL: "https://github.com/furrycolombia-sys/libra.git",
+        REPO_URL,
         ENV_FILE: process.env.ENV_FILE || "/home/furrycolombia/.env.prod",
       },
       timeout: 15 * 60 * 1000, // 15 min max


### PR DESCRIPTION
**No longer a draft-until-transfer change — the transfer and rename are done, and this now fixes a URL that is actively broken.**

## What went wrong

The clone URL was hardcoded in the deploy env:

```js
REPO_URL: "https://github.com/furrycolombia-sys/candyshop.git",
```

That **redirected** after the transfer, so it kept working while quietly being wrong. Then the rename sweep (#340) rewrote it to:

```js
REPO_URL: "https://github.com/furrycolombia-sys/libra.git",
```

which is **worse — it 404s**. GitHub redirects the *old slug*, not a slug assembled from the old owner and the new name. Verified:

| slug | resolves |
|---|---|
| `furrycolombia-sys/candyshop` | → `vaoan/libra` ✅ |
| `vaoan/libra` | ✅ |
| **`furrycolombia-sys/libra`** | **404** ❌ |

My sweep turned a stale-but-working URL into a broken one. This fixes it.

## The fix

`REPO_URL` now resolves like every other setting in the file — `process.env.X || default` — which `PORT`, `SECRET`, `DEPLOY_SCRIPT`, `BRANCH` and `ENV_FILE` already do. It was the only hardcoded one.

```js
const REPO_URL =
  process.env.REPO_URL || "https://github.com/vaoan/libra.git";
```

**The override is the point:** ownership or naming can change again without a code redeploy, and rollback becomes a PM2 environment variable rather than reverting a commit and shipping it to production under pressure.

## Verification

`node --check` passes, the resolution order was exercised (default → `vaoan/libra`, env wins when set), the default was confirmed to resolve against the GitHub API, and no stale slug remains in the file.

Rebuilt on current `develop` (post-#340). **Nothing was run against the production server.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)