### PR TITLE
docs: rename the project to Libra [GH-000]

### DIFF
--- a/.claude/skills/e2e-eval/SKILL.md
+++ b/.claude/skills/e2e-eval/SKILL.md
@@ -361,7 +361,7 @@ curl -sI {tunnel_url} --max-time 5 | head -1
 Wait until port 7542 responds (the tunnel script does this internally). If it times out, check Docker container logs:
 
 ```bash
-docker logs candyshop-staging --tail 50
+docker logs libra-staging --tail 50
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ This is a **pnpm workspace monorepo** — a store and payment platform for selli
 ### Structure
 
 ```
-candyshop/
+libra/
 ├── apps/                          # Applications
 │   ├── store/                     # Main storefront (REFERENCE STANDARD)
 │   ├── landing/                   # Public landing page

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ pnpm staging:public:stop     # stop
 Defined in `docker/compose.staging.yml`. First start applies all migrations and seeds the DB automatically. To reset:
 
 ```bash
-docker volume rm candyshop-staging_db-data
+docker volume rm libra-staging_db-data
 ```
 
 ### Expose dev to the internet

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -50,12 +50,12 @@ APPS_MODE=local|docker          # how apps run
 SUPABASE_MODE=local|docker|cloud # how Supabase runs
 
 # ─── Container identity ───────────────────────────────────────────
-SITE_PROD_IMAGE_NAME=candyshop-staging
-SITE_PROD_CONTAINER_NAME=candyshop-staging
+SITE_PROD_IMAGE_NAME=libra-staging
+SITE_PROD_CONTAINER_NAME=libra-staging
 
 # ─── App origins ──────────────────────────────────────────────────
 HOST_PORT=3000   # host port for Docker container
-APP_INTERNAL_ORIGIN=http://candyshop-staging:8080  # internal nginx address
+APP_INTERNAL_ORIGIN=http://libra-staging:8080  # internal nginx address
 
 # ─── Supabase ─────────────────────────────────────────────────────
 NEXT_PUBLIC_SUPABASE_URL=http://localhost:3030   # or https://... for cloud

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -16,7 +16,7 @@ GitHub push → main
         ├─ 1. Build   — pnpm build (7 Next.js apps, standalone)
         │
         ├─ 2. Docker  — docker build + push → GHCR
-        │               (ghcr.io/furrycolombia-sys/candyshop-prod:sha + :latest)
+        │               (ghcr.io/vaoan/libra-prod:sha + :latest)
         │
         ├─ 3. Deploy  — SSH → GCP VM (candyshop-prod, us-central1-a)
         │                   └─ deploy-production.sh (nohup, survives SSH drop)
@@ -100,9 +100,9 @@ build (20 min timeout)
 1. **Sets up SSH** — writes private key and nginx-style SSH config targeting `ssh.furrycolombia.com` → GCP VM
 2. **Creates ControlMaster** — persistent connection so all SSH calls share one TCP session
 3. **Copies deploy script** — `scp scripts/deploy-production.sh` fresh from repo on every run (guarantees script changes take effect immediately)
-4. **Writes env file** — 24 secrets piped over SSH to `/tmp/.candyshop-build.env` (umask 077)
+4. **Writes env file** — 24 secrets piped over SSH to `/tmp/.libra-build.env` (umask 077)
 5. **Launches deploy** — `nohup bash /tmp/deploy-production.sh` relaunches itself detached from the SSH session so a connection drop doesn't abort it
-6. **Polls for completion** — checks `/tmp/deploy-candyshop.done` every 15s for up to 80 polls (20 min window); tails `/tmp/deploy-candyshop.log` to CI output
+6. **Polls for completion** — checks `/tmp/deploy-libra.done` every 15s for up to 80 polls (20 min window); tails `/tmp/deploy-libra.log` to CI output
 
 #### `purge-cloudflare-cache` job
 
@@ -288,7 +288,7 @@ A template is committed at `scripts/server/docker-prod.env.example`.
 | URL           | `https://deploy.furrycolombia.com/deploy`   |
 | Health        | `https://deploy.furrycolombia.com/health`   |
 | Port          | 9091                                        |
-| PM2 name      | candyshop-webhook                           |
+| PM2 name      | libra-webhook                               |
 | Script        | `/home/furrycolombia/webhook-deploy.mjs`    |
 | Deploy script | `/home/furrycolombia/deploy.sh`             |
 | Secret        | Stored in GitHub webhook settings + PM2 env |
@@ -357,31 +357,31 @@ Google credentials are also registered in Google Cloud Console with the Supabase
 
 ## Hestia CP
 
-| Property   | Value                                                       |
-| ---------- | ----------------------------------------------------------- |
-| Admin URL  | `https://server.furrycolombia.com:8083`                     |
-| Admin user | useradmin                                                   |
-| Domain     | store.furrycolombia.com (custom `candyshop` nginx template) |
-| Template   | Proxies to `127.0.0.1:9090` (Docker container)              |
+| Property   | Value                                                   |
+| ---------- | ------------------------------------------------------- |
+| Admin URL  | `https://server.furrycolombia.com:8083`                 |
+| Admin user | useradmin                                               |
+| Domain     | store.furrycolombia.com (custom `libra` nginx template) |
+| Template   | Proxies to `127.0.0.1:9090` (Docker container)          |
 
 ## File Locations on Server
 
-| Path                                       | Purpose                                              |
-| ------------------------------------------ | ---------------------------------------------------- |
-| `/home/furrycolombia/candyshop/`           | Git repo clone                                       |
-| `/home/furrycolombia/.env.prod`            | Docker env file (secrets, chmod 600)                 |
-| `/home/furrycolombia/deploy.sh`            | Deploy script (called by webhook)                    |
-| `/home/furrycolombia/webhook-deploy.mjs`   | Webhook receiver                                     |
-| `/home/furrycolombia/candyshop-nginx.conf` | Standalone nginx config (unused, Docker has its own) |
-| `/home/furrycolombia/candyshop-proxy.inc`  | Nginx proxy headers (unused, Docker has its own)     |
-| `/etc/cloudflared/config.yml`              | Cloudflare tunnel config                             |
-| `/etc/cloudflared/af85209b-*.json`         | Tunnel credentials                                   |
+| Path                                     | Purpose                                              |
+| ---------------------------------------- | ---------------------------------------------------- |
+| `/home/furrycolombia/libra/`             | Git repo clone                                       |
+| `/home/furrycolombia/.env.prod`          | Docker env file (secrets, chmod 600)                 |
+| `/home/furrycolombia/deploy.sh`          | Deploy script (called by webhook)                    |
+| `/home/furrycolombia/webhook-deploy.mjs` | Webhook receiver                                     |
+| `/home/furrycolombia/libra-nginx.conf`   | Standalone nginx config (unused, Docker has its own) |
+| `/home/furrycolombia/libra-proxy.inc`    | Nginx proxy headers (unused, Docker has its own)     |
+| `/etc/cloudflared/config.yml`            | Cloudflare tunnel config                             |
+| `/etc/cloudflared/af85209b-*.json`       | Tunnel credentials                                   |
 
 ## PM2 Processes
 
-| Name              | Script                                   | Purpose                 |
-| ----------------- | ---------------------------------------- | ----------------------- |
-| candyshop-webhook | `/home/furrycolombia/webhook-deploy.mjs` | GitHub webhook receiver |
+| Name          | Script                                   | Purpose                 |
+| ------------- | ---------------------------------------- | ----------------------- |
+| libra-webhook | `/home/furrycolombia/webhook-deploy.mjs` | GitHub webhook receiver |
 
 The 7 Next.js apps run inside the Docker container (managed by supervisord), not PM2.
 
@@ -471,7 +471,7 @@ sudo cloudflared service install
 ### 6. Clone repo and create env file
 
 ```bash
-git clone --branch main --depth 1 https://github.com/furrycolombia-sys/candyshop.git ~/candyshop
+git clone --branch main --depth 1 https://github.com/vaoan/libra.git ~/libra
 
 # Create env file OUTSIDE the repo (won't be wiped by git clean)
 cat > ~/.env.prod << 'EOF'
@@ -499,7 +499,7 @@ chmod 600 ~/.env.prod
 ### 7. Build and start the container
 
 ```bash
-cd ~/candyshop
+cd ~/libra
 docker compose -f docker/compose.yml --env-file ~/.env.prod build --no-cache
 docker compose -f docker/compose.yml --env-file ~/.env.prod up -d
 ```
@@ -510,7 +510,7 @@ docker compose -f docker/compose.yml --env-file ~/.env.prod up -d
 # Upload webhook-deploy.mjs and deploy.sh to ~/
 # Then start with PM2:
 WEBHOOK_SECRET=<secret> DEPLOY_SCRIPT=/home/furrycolombia/deploy.sh \
-  pm2 start ~/webhook-deploy.mjs --name candyshop-webhook
+  pm2 start ~/webhook-deploy.mjs --name libra-webhook
 pm2 save
 ```
 
@@ -547,20 +547,20 @@ docker ps
 docker logs candyshop-prod -f
 
 # Restart
-docker compose -f ~/candyshop/docker/compose.yml --env-file ~/.env.prod restart
+docker compose -f ~/libra/docker/compose.yml --env-file ~/.env.prod restart
 
 # Rebuild and restart (no cache)
-docker compose -f ~/candyshop/docker/compose.yml --env-file ~/.env.prod up -d --build --no-cache
+docker compose -f ~/libra/docker/compose.yml --env-file ~/.env.prod up -d --build --no-cache
 
 # Stop
-docker compose -f ~/candyshop/docker/compose.yml --env-file ~/.env.prod down
+docker compose -f ~/libra/docker/compose.yml --env-file ~/.env.prod down
 ```
 
 ### Webhook
 
 ```bash
-pm2 logs candyshop-webhook
-pm2 restart candyshop-webhook
+pm2 logs libra-webhook
+pm2 restart libra-webhook
 curl https://deploy.furrycolombia.com/health
 ```
 
@@ -590,7 +590,7 @@ To run E2E tests against the live site (with test IDs enabled):
 ```bash
 # Add to .env.prod temporarily
 echo "NEXT_PUBLIC_ENABLE_TEST_IDS=true" >> ~/.env.prod
-docker compose -f ~/candyshop/docker/compose.yml --env-file ~/.env.prod up -d --build
+docker compose -f ~/libra/docker/compose.yml --env-file ~/.env.prod up -d --build
 ```
 
 2. Run tests locally:
@@ -604,7 +604,7 @@ pnpm --filter store exec playwright test --reporter=list
 
 ```bash
 sed -i '/ENABLE_TEST_IDS/d' ~/.env.prod
-docker compose -f ~/candyshop/docker/compose.yml --env-file ~/.env.prod up -d --build --no-cache
+docker compose -f ~/libra/docker/compose.yml --env-file ~/.env.prod up -d --build --no-cache
 ```
 
 Production deploys via webhook never include test IDs.
@@ -627,7 +627,7 @@ Production deploys via webhook never include test IDs.
 | Deploy hangs / `Broken pipe` during build | Cloudflare Access timeout — deploy script handles this via `nohup + poll`; do not change                |
 | Auth redirect to localhost                | Check Supabase Site URL setting in dashboard                                                            |
 | OAuth provider error                      | Check provider is enabled in Supabase dashboard                                                         |
-| Webhook not triggering                    | `pm2 logs candyshop-webhook`                                                                            |
+| Webhook not triggering                    | `pm2 logs libra-webhook`                                                                                |
 | Build fails (disk)                        | `df -h` and `docker system prune` on server                                                             |
 
 ---

--- a/docs/production-incident-playbook.md
+++ b/docs/production-incident-playbook.md
@@ -103,7 +103,7 @@ Run these on the server after SSH-ing in:
 
 ```bash
 # Container status
-docker ps -a --filter name=candyshop
+docker ps -a --filter name=libra
 
 # Live logs
 docker logs candyshop-prod -f
@@ -128,11 +128,11 @@ docker exec candyshop-prod ls -la /app/apps/store/.next/standalone/node_modules/
 
 # PM2 health watcher
 pm2 status
-pm2 logs candyshop-watcher
+pm2 logs libra-watcher
 
 # Deploy log from last CI deploy
-cat /tmp/deploy-candyshop.log
-cat /tmp/deploy-candyshop.done   # 0 = success, non-0 = failed
+cat /tmp/deploy-libra.log
+cat /tmp/deploy-libra.done   # 0 = success, non-0 = failed
 
 # Cloudflare tunnel
 sudo systemctl status cloudflared
@@ -160,7 +160,7 @@ If the image is bad or missing but CI artifacts are already rsynced:
 
 ```bash
 ssh furrycolombia@192.168.2.71
-cd ~/candyshop
+cd ~/libra
 
 # Ensure dirs exist (they might be empty after a bad sync)
 for APP in store admin auth landing payments studio playground; do
@@ -397,20 +397,20 @@ push to main              │   GitHub Actions          │
                     │  5. rsync .next/ dirs to server       │
                     │  6. copy deploy-production.sh         │
                     │  7. SSH: nohup deploy.sh &            │
-                    │  8. poll /tmp/deploy-candyshop.done   │
+                    │  8. poll /tmp/deploy-libra.done   │
                     └──────────────────┬──────────────────┘
                                        │
                     ┌──────────────────▼──────────────────┐
                     │  Server: deploy-production.sh         │
                     │                                       │
                     │  1. git pull origin main              │
-                    │  2. source /tmp/.candyshop-build.env  │
+                    │  2. source /tmp/.libra-build.env  │
                     │  3. docker build -f docker/prod/...   │
                     │  4. docker rm + docker run            │
-                    │  5. pm2 start candyshop-watcher       │
+                    │  5. pm2 start libra-watcher       │
                     │  6. health check (curl × 7 apps)      │
                     │  7. JIT warm-up (all routes × 3)      │
-                    │  8. echo 0 > /tmp/deploy-candyshop.done│
+                    │  8. echo 0 > /tmp/deploy-libra.done│
                     └──────────────────┬──────────────────┘
                                        │
                     ┌──────────────────▼──────────────────┐
@@ -430,19 +430,19 @@ push to main              │   GitHub Actions          │
 | `docker/prod/Dockerfile`                  | Production Docker image (uses pre-built .next/)                      |
 | `docker/ci/Dockerfile`                    | CI/local Docker image (builds inside container)                      |
 | `scripts/docker-health-check.sh`          | Pre-push hook — builds + health-checks Docker image                  |
-| `docker/watcher.mjs`                      | Host-side health monitor (runs via PM2 as candyshop-watcher)         |
+| `docker/watcher.mjs`                      | Host-side health monitor (runs via PM2 as libra-watcher)             |
 | `.npmrc`                                  | `node-linker=hoisted` — required for pnpm to survive ZIP round-trips |
 | `.dockerignore`                           | Must re-include `!apps/**/.next/standalone/node_modules/**`          |
 
 ### Where secrets live
 
-| Secret                    | Location                                               | Used by                                        |
-| ------------------------- | ------------------------------------------------------ | ---------------------------------------------- |
-| Supabase anon key         | GitHub secret + `.env.prod` on server                  | Build (baked into NEXT_PUBLIC) + runtime       |
-| Supabase service role key | GitHub secret → written to `/tmp/.candyshop-build.env` | Server runtime only (injected at `docker run`) |
-| Telegram bot token        | GitHub secret + `.secrets` locally                     | Deploy script (Telegram notifications)         |
-| Prod SSH key              | GitHub secret `PROD_SERVER_SSH_KEY`                    | CI → server SSH                                |
-| `.env.prod` on server     | `~/.env.prod` (chmod 600, outside repo)                | `docker run --env-file`                        |
+| Secret                    | Location                                           | Used by                                        |
+| ------------------------- | -------------------------------------------------- | ---------------------------------------------- |
+| Supabase anon key         | GitHub secret + `.env.prod` on server              | Build (baked into NEXT_PUBLIC) + runtime       |
+| Supabase service role key | GitHub secret → written to `/tmp/.libra-build.env` | Server runtime only (injected at `docker run`) |
+| Telegram bot token        | GitHub secret + `.secrets` locally                 | Deploy script (Telegram notifications)         |
+| Prod SSH key              | GitHub secret `PROD_SERVER_SSH_KEY`                | CI → server SSH                                |
+| `.env.prod` on server     | `~/.env.prod` (chmod 600, outside repo)            | `docker run --env-file`                        |
 
 ---
 

--- a/docs/superpowers/plans/2026-05-08-boot-progress-notifications.md
+++ b/docs/superpowers/plans/2026-05-08-boot-progress-notifications.md
@@ -503,12 +503,12 @@ Delete the `notify_telegram "$(printf '🔄 <b>Container restarted</b>..."` line
 
 - [ ] **Step 4: Add boot-notifier PM2 start before pm2 save**
 
-After `pm2 start candyshop-watcher` and before `pm2 save`:
+After `pm2 start libra-watcher` and before `pm2 save`:
 
 ```bash
-pm2 delete candyshop-boot-notifier 2>/dev/null || true
+pm2 delete libra-boot-notifier 2>/dev/null || true
 WATCHER_NGINX_PORT=$HOST_PORT pm2 start "$DEPLOY_DIR/scripts/server/boot-notifier.mjs" \
-  --name candyshop-boot-notifier
+  --name libra-boot-notifier
 ```
 
 - [ ] **Step 5: Move APPS definition before sleep 60 and replace sleep with poll loop**

--- a/docs/superpowers/plans/2026-05-18-e2e-eval-merge.md
+++ b/docs/superpowers/plans/2026-05-18-e2e-eval-merge.md
@@ -226,7 +226,7 @@ git commit -m "feat(e2e-eval): cache Supabase startup in dev environment"
 
 - [ ] **Step 1: Replace the staging Phase 2 body**
 
-Find `#### Staging environment` under PHASE 2. Replace its entire body (the `Execute in this exact order:` line through the existing `docker logs candyshop-staging --tail 50` block) with:
+Find `#### Staging environment` under PHASE 2. Replace its entire body (the `Execute in this exact order:` line through the existing `docker logs libra-staging --tail 50` block) with:
 
 ````markdown
 Execute in this exact order. **Each step probes first, then starts only if not responding.** `--skip-infra` bypasses all probes; `--clean` forces a Supabase reset regardless of probe result.
@@ -299,7 +299,7 @@ curl -sI {tunnel_url} --max-time 5 | head -1
 Wait until port 7542 responds (the tunnel script does this internally). If it times out, check Docker container logs:
 
 ```bash
-docker logs candyshop-staging --tail 50
+docker logs libra-staging --tail 50
 ```
 ````
 

--- a/docs/superpowers/specs/2026-03-18-candy-shop-mvp-design.md
+++ b/docs/superpowers/specs/2026-03-18-candy-shop-mvp-design.md
@@ -330,9 +330,9 @@ Bus Departure — checked in by @volunteer at 8:06 AM
 
 ## QR Code System
 
-- **Master QR** per order item — encodes URL: `candyshop.furrycolombia.com/verify/{order_item_qr}`
+- **Master QR** per order item — encodes URL: `libra.furrycolombia.com/verify/{order_item_qr}`
   - Resolves to full entitlement checklist for staff
-- **Individual QR** per entitlement — encodes URL: `candyshop.furrycolombia.com/verify/{check_in_qr}`
+- **Individual QR** per entitlement — encodes URL: `libra.furrycolombia.com/verify/{check_in_qr}`
   - Resolves to single entitlement for third-party verification
 - **Transfer QR** — encodes the transfer link for physical gifting
 - On ticket transfer, all QR codes regenerate (old ones return "invalid")

--- a/docs/superpowers/specs/2026-05-08-boot-progress-notifications-design.md
+++ b/docs/superpowers/specs/2026-05-08-boot-progress-notifications-design.md
@@ -140,9 +140,9 @@ Progress bar uses Unicode block characters: `█` (filled) and `░` (empty), 16
 **deploy-production.sh additions:**
 
 ```bash
-pm2 delete candyshop-boot-notifier 2>/dev/null || true
+pm2 delete libra-boot-notifier 2>/dev/null || true
 WATCHER_NGINX_PORT=$HOST_PORT pm2 start "$DEPLOY_DIR/scripts/server/boot-notifier.mjs" \
-  --name candyshop-boot-notifier
+  --name libra-boot-notifier
 pm2 save
 ```
 


### PR DESCRIPTION
The repository is now **`vaoan/libra`** — the constellation of the Scales: the merchant''s balance, and the root of the pound as both a weight and a currency.

**Documentation only.** The product still serves at the `store` subdomain and is still called Store in the UI, so nothing user-facing changes.

## Deliberately not renamed

**Infrastructure identifiers.** `candyshop-prod` containers and images still exist under that name — renaming them in prose would make these docs *wrong* rather than current. **42 such identifiers were preserved** across `infrastructure.md`, the incident playbook and the standards docs. They change when the deploy path is repaired (consolidation plan, Task 5), not before.

**`.ai-context/task-outputs`** — records of past agent runs, not living documentation.

Part of the rename across the platform: aeleos#7, vaoan/Puck#17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)