### PR TITLE
fix(db): stop the audit view bypassing its own RLS [GH-000]

### DIFF
--- a/supabase/migrations/20260830100000_audit_view_definer_leak.sql
+++ b/supabase/migrations/20260830100000_audit_view_definer_leak.sql
@@ -1,0 +1,43 @@
+-- =============================================================================
+-- Fix: audit.logged_actions_with_user bypassed audit.logged_actions RLS
+-- =============================================================================
+-- public.logged_actions_with_user was switched to SECURITY INVOKER in
+-- 20260422100000_audit_view_security_invoker.sql, but that only controls how
+-- Postgres checks privileges for THIS view's own underlying relation, which is
+-- audit.logged_actions_with_user (a nested view). That inner view
+-- (defined in 20260325600000_user_profiles.sql) was never given
+-- security_invoker, so by default Postgres still executes its query with the
+-- privileges of the view's owner (postgres) rather than the caller. postgres
+-- has BYPASSRLS, so every SELECT against audit.logged_actions made through
+-- this path ran unfiltered — the `audit_read` policy
+-- (has_permission(current_user_id(), 'audit.read')) was never evaluated.
+--
+-- Net effect: any signed-in (authenticated) caller, including one with no
+-- matching user_profiles row (current_user_id() IS NULL) and no permissions
+-- at all, could read every row of every audited table's history via
+-- GET /rest/v1/logged_actions_with_user. anon was correctly denied (no grant
+-- on the public proxy view), so this was authenticated-only exposure — but
+-- audit rows record who did what across every audited table, so no signed-in
+-- customer should be able to read them.
+--
+-- Fix: set security_invoker = true on audit.logged_actions_with_user too, so
+-- the whole view chain runs as the calling role and audit_read is evaluated
+-- against the *actual* caller, not the view owner. This is the same pattern
+-- already used for the public proxy and is the standard Postgres 15+ fix for
+-- definer-by-default views (Postgres version here is 17, so it's supported).
+--
+-- Table-level SELECT on audit.logged_actions was never actually granted to
+-- authenticated: the blanket `grant select on all tables in schema audit to
+-- authenticated` in 20260325400000_audit_system.sql ran before this table
+-- existed (it's created later in the same file), so it silently didn't apply.
+-- Under the old SECURITY DEFINER-by-default view, that didn't matter — the
+-- view owner's own privileges were used. Under SECURITY INVOKER it does
+-- matter: without a real grant, an admin with audit.read would get
+-- "permission denied for table logged_actions" instead of their rows. Grant
+-- SELECT explicitly; the audit_read RLS policy remains the actual gate on
+-- which rows come back — this only fixes table-level ACL, not row access.
+-- =============================================================================
+
+grant select on audit.logged_actions to authenticated;
+
+alter view audit.logged_actions_with_user set (security_invoker = true);

--- a/supabase/tests/20260829_identity_migration_smoke.sql
+++ b/supabase/tests/20260829_identity_migration_smoke.sql
@@ -549,3 +549,85 @@ begin
 
   raise notice 'audit attribution: OK';
 end $$;
+
+-- =============================================================================
+-- Audit view definer leak: public/audit.logged_actions_with_user must enforce
+-- audit.logged_actions RLS for the actual caller, not the view owner
+-- =============================================================================
+-- Before 20260830100000_audit_view_definer_leak.sql, audit.logged_actions_with_user
+-- had no security_invoker, so Postgres ran its query as the view's owner
+-- (postgres, BYPASSRLS) regardless of who queried it. The audit_read policy
+-- (has_permission(current_user_id(), 'audit.read')) was never evaluated on
+-- this path: any signed-in caller with no matching profile and no
+-- permissions at all could read every audit row. This block proves the two
+-- non-privileged cases now see nothing, and that a caller who genuinely has
+-- audit.read still sees rows (the admin audit viewer must keep working).
+do $$
+declare
+  v_visible integer;
+  v_watermark bigint;
+  v_no_perm_profile_id uuid;
+  v_admin_profile_id uuid;
+  v_resource_permission_id uuid;
+begin
+  select coalesce(max(event_id), 0) into v_watermark from audit.logged_actions;
+
+  -- Case 1: authenticated caller who resolves to a real profile, but that
+  -- profile holds no audit.read grant.
+  insert into public.user_profiles (id, email, identity_sub, first_seen_at, last_seen_at)
+  values (gen_random_uuid(), 'smoketest_audit_view_no_perm@example.com', 'user_smoketest_audit_view_no_perm', now(), now())
+  returning id into v_no_perm_profile_id;
+
+  perform set_config('request.jwt.claims', '{"sub":"user_smoketest_audit_view_no_perm"}', true);
+  perform set_config('role', 'authenticated', true);
+  select count(*) into v_visible from public.logged_actions_with_user;
+  perform set_config('role', 'postgres', true);
+
+  assert v_visible = 0,
+    format('FAIL: authenticated caller without audit.read saw %s audit rows', v_visible);
+
+  -- Case 2: authenticated caller whose sub matches no profile at all
+  -- (current_user_id() IS NULL) -- the exact case that was fully exposed.
+  perform set_config('request.jwt.claims', '{"sub":"user_smoketest_audit_view_nobody"}', true);
+  perform set_config('role', 'authenticated', true);
+  select count(*) into v_visible from public.logged_actions_with_user;
+  perform set_config('role', 'postgres', true);
+
+  assert v_visible = 0,
+    format('FAIL: unresolved authenticated caller (current_user_id() IS NULL) saw %s audit rows', v_visible);
+
+  -- Case 3 (control): a caller who genuinely holds audit.read must still see
+  -- rows. A fix that starves the admin audit viewer is a failure, not a
+  -- success.
+  select rp.id into v_resource_permission_id
+  from public.resource_permissions rp
+  join public.permissions p on p.id = rp.permission_id
+  where p.key = 'audit.read' and rp.resource_type = 'global';
+
+  assert v_resource_permission_id is not null,
+    'FAIL: no global audit.read resource_permission row to test against';
+
+  insert into public.user_profiles (id, email, identity_sub, first_seen_at, last_seen_at)
+  values (gen_random_uuid(), 'smoketest_audit_view_admin@example.com', 'user_smoketest_audit_view_admin', now(), now())
+  returning id into v_admin_profile_id;
+
+  insert into public.user_permissions (user_id, resource_permission_id, mode, granted_by)
+  values (v_admin_profile_id, v_resource_permission_id, 'grant', v_admin_profile_id);
+
+  perform set_config('request.jwt.claims', '{"sub":"user_smoketest_audit_view_admin"}', true);
+  perform set_config('role', 'authenticated', true);
+  select count(*) into v_visible from public.logged_actions_with_user;
+  perform set_config('role', 'postgres', true);
+
+  assert v_visible > 0,
+    'FAIL: a caller with audit.read saw zero rows through the audit view (admin viewer broken)';
+
+  -- Clean up: remove every row this block created, including the audit rows
+  -- these very inserts generated (user_profiles and user_permissions are
+  -- both audited tables), so the database is left exactly as found.
+  delete from public.user_permissions where user_id = v_admin_profile_id;
+  delete from public.user_profiles where id in (v_no_perm_profile_id, v_admin_profile_id);
+  delete from audit.logged_actions where event_id > v_watermark;
+
+  raise notice 'audit view definer leak: OK';
+end $$;


### PR DESCRIPTION
## Summary

`audit.logged_actions_with_user` (exposed as `public.logged_actions_with_user`) had no `security_invoker`, so it ran as its owner `postgres` — which is `BYPASSRLS`. The `audit_read` policy on the underlying table was therefore **never evaluated on this path**: it was effectively dead code.

Any signed-in user could read the entire audit trail — who did what across all 16 audited tables — with no permission and no resolved profile.

Found during the AeleOS login migration's final review. It came in with `f52fa61` and has been live on `develop` since; it is not caused by that migration, which is why it gets its own PR.

## Impact

Read-only exposure of audit metadata to **authenticated** users. `anon` was correctly denied throughout, so this was never publicly reachable.

## Verified per role, before and after

Measured against the local stack with the production backup restored, each probe in a rolled-back transaction:

| role | before | after |
|---|---|---|
| `anon` | denied | denied |
| `authenticated`, `current_user_id()` NULL | **5041 rows** | **0** |
| `authenticated`, without `audit.read` | exposed | **0** |
| `authenticated`, **with** `audit.read` | 5041 (via bypass) | **5043** |
| `service_role` | denied | denied |

The last two rows are the point: the exposure closes **and the admin audit viewer keeps working**. A fix that silently broke the viewer would have looked identical in CI.

## Fix

`security_invoker = true` on the view, so the caller's own privileges and the underlying RLS apply, plus the table-level `GRANT SELECT` the original migration intended but never applied.

Chosen over duplicating the permission check inside the view definition, or routing reads through a gated function: `security_invoker` makes the authorization the table's own policy rather than a second copy that can drift out of step with it — which is the failure mode this codebase has hit repeatedly.

## Testing

A self-cleaning block appended to `supabase/tests/20260829_identity_migration_smoke.sql`, proven discriminating — it fails against the pre-migration schema with `FAIL: authenticated caller without audit.read saw 5090 audit rows` and passes after.

## Sibling audit

Swept `public` and `audit` for other views that read an RLS-protected table while bypassing its policies. Only these two exist and both are fixed; extension and vault views were checked and are not exposed to `anon`/`authenticated`.

## Note

`service_role` cannot read this view either — a pre-existing, unrelated gap, unchanged here. Worth its own look if any server-side code needs audit reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt