### PR TITLE
fix(store): compose ESLint's core rules and fix what they found [GH-000]

### DIFF
--- a/apps/store/src/features/cart/application/CartContext.tsx
+++ b/apps/store/src/features/cart/application/CartContext.tsx
@@ -94,11 +94,15 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
       } catch {
         // Ignore invalid stored data
       } finally {
-        if (!isActive) return;
-        requestAnimationFrame(() => {
-          if (!isActive) return;
-          mountedRef.current = true;
-        });
+        // Guarded with a conditional rather than an early `return`: a return
+        // inside `finally` discards any exception propagating out of the
+        // try/catch, which would silently swallow a real failure here.
+        if (isActive) {
+          requestAnimationFrame(() => {
+            if (!isActive) return;
+            mountedRef.current = true;
+          });
+        }
       }
     }
 

--- a/apps/store/src/features/products/presentation/components/FeaturedRibbon.tsx
+++ b/apps/store/src/features/products/presentation/components/FeaturedRibbon.tsx
@@ -155,7 +155,7 @@ export function FeaturedRibbon({
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    let ctx: CanvasRenderingContext2D | null = null;
+    let ctx: CanvasRenderingContext2D | null;
     try {
       ctx = canvas.getContext(
         // eslint-disable-next-line i18next/no-literal-string -- HTML canvas API context identifier

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,4 @@
+import js from "@eslint/js";
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
@@ -22,6 +23,17 @@ const sonarRules = sonarjs.configs.recommended.rules;
 const unicornRules = unicorn.configs["flat/recommended"].rules;
 
 const eslintConfig = defineConfig([
+  // ESLint's own core correctness rules. These were never composed here, so 41
+  // rules that catch real defects (no-unsafe-finally, no-dupe-keys,
+  // no-unreachable, ...) were simply absent. Scoped to source, matching how the
+  // other recommended sets below are scoped.
+  {
+    files: [
+      `${APP_SRC}/**/*.{ts,tsx,js,jsx}`,
+      `${PKG_SRC}/**/*.{ts,tsx,js,jsx}`,
+    ],
+    ...js.configs.recommended,
+  },
   ...nextVitals,
   ...nextTs,
   i18next.configs["flat/recommended"],

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "clean": "pnpm clean:builds && find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@ls-lint/ls-lint": "^2.3.1",
     "@playwright/test": "^1.59.1",
     "@secretlint/secretlint-rule-preset-recommend": "^12.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
 
   .:
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@9.39.4(jiti@2.6.1))
       '@ls-lint/ls-lint':
         specifier: ^2.3.1
         version: 2.3.1
@@ -1917,6 +1920,15 @@ packages:
   '@eslint/eslintrc@3.3.5':
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/js@9.39.4':
     resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
@@ -9582,6 +9594,10 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@eslint/js@10.0.1(eslint@9.39.4(jiti@2.6.1))':
+    optionalDependencies:
+      eslint: 9.39.4(jiti@2.6.1)
 
   '@eslint/js@9.39.4': {}
 


### PR DESCRIPTION
## Summary

`eslint.config.mjs` composes the recommended sets from **six** plugins — sonarjs, unicorn, i18next, tanstack-query, vitest, better-tailwindcss — but never composed `js.configs.recommended`, ESLint's own core rules.

So a monorepo that lints for cognitive complexity and Tailwind class ordering was not checking for `no-unsafe-finally`, `no-dupe-keys`, `no-unreachable`, `no-const-assign` or the other 37 rules that catch outright broken code.

Found by a gap analysis against the sibling AeleOS repo, which composes it.

## What it found

Exactly two violations across the whole monorepo — **both real**.

### `CartContext.tsx:97` — a `return` inside `finally`, in the live cart

```js
} finally {
  if (!isActive) return;      // ← discards any in-flight exception
  requestAnimationFrame(...);
}
```

A `return` in `finally` swallows an exception propagating out of the `try`/`catch`. If cart hydration ever failed in a way the `catch` re-raised, it would vanish with no trace. Rewritten as a conditional, preserving behaviour exactly.

### `FeaturedRibbon.tsx:158` — an initializer that can never be read

```js
let ctx: CanvasRenderingContext2D | null = null;
try { ctx = canvas.getContext("2d"); } catch { return; }
```

The only paths out are "assigned in `try`" or "returned from `catch`", so `= null` is dead. Removed.

## Verification

- `pnpm lint` → 0, `pnpm typecheck` → 0.
- **Proved the rules actually fire.** A config change that silently matches no files looks identical to one that works, so I linted a temporary probe containing a `return` inside `finally`: rejected with `no-unsafe-finally` plus two more. Probe removed.
- `@eslint/js` added as a direct devDependency; it was previously only present transitively.

## Note

Authored without independent subagent review (session rate limit). The two source changes are small and behaviour-preserving, and the probe demonstrates the rules are live rather than inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt