### PR TITLE
chore(ci): run four tools that were configured but never ran [GH-000]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,19 @@ jobs:
       - name: Check formatting
         run: pnpm run format:check
 
+      # These four are configured in package.json but ran in no workflow — only
+      # in the husky precommit hook, which any `--no-verify` commit bypasses.
+      # They pass today, so they are enforced here. cspell (70 issues), knip and
+      # jscpd do not pass yet and are tracked in
+      # .superpowers/sdd/aeleos-parity/plan-notes.md rather than enabled broken.
+      - name: Repo hygiene (workspace + structure checks)
+        run: |
+          set -euo pipefail
+          pnpm run sherif
+          pnpm run syncpack:lint
+          pnpm exec ls-lint
+          pnpm exec madge --circular --extensions ts,tsx,js,jsx             apps/store/src apps/studio/src apps/landing/src apps/payments/src             apps/admin/src apps/auth/src apps/playground/src             packages/ui/src packages/shared/src packages/api/src             packages/app-components/src packages/auth/src
+
       - name: Lint (scoped)
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,13 @@ jobs:
               - 'tsconfig*.json'
               - 'eslint.config.*'
               - 'prettier.config.*'
+              - 'turbo.json'
+              - '.madgerc'
+              - '.ls-lint.yml'
+              - 'cspell.json'
+              - 'knip.json'
+              - 'stylelint.config.*'
+              - 'vitest.config.*'
             code:
               - 'apps/**'
               - 'packages/**'
@@ -74,6 +81,20 @@ jobs:
               - 'tsconfig*.json'
               - 'eslint.config.*'
               - 'prettier.config.*'
+              - 'turbo.json'
+              - '.madgerc'
+              - '.ls-lint.yml'
+              - 'cspell.json'
+              - 'knip.json'
+              - 'stylelint.config.*'
+              - 'vitest.config.*'
+              # CI could not previously validate changes to itself: a workflow
+              # edit counted as docs-only, so every quality/test/build job
+              # skipped. Same for schema and container changes.
+              - '.github/workflows/**'
+              - 'supabase/**'
+              - 'docker/**'
+              - 'scripts/**'
       - name: Check if docs-only
         id: check
         run: |

--- a/.madgerc
+++ b/.madgerc
@@ -1,0 +1,10 @@
+{
+  "detectiveOptions": {
+    "ts": {
+      "skipTypeImports": true
+    },
+    "tsx": {
+      "skipTypeImports": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Seven tools — `sherif`, `syncpack`, `ls-lint`, `madge`, `cspell`, `knip`, `jscpd` — are configured in `package.json` and run in **zero workflows**. They exist only in the husky `precommit` hook, which any `--no-verify` commit bypasses.

Seven tools believed to be enforcing standards, enforcing nothing on any pull request.

The four that pass today are now a **Repo hygiene** step in the CI quality job.

## madge needed a real fix, not just wiring

It reported a circular dependency:

```
apps/studio/src/features/products/domain/constants.ts
  > apps/studio/src/features/products/domain/validationSchema.ts
```

That cycle is **type-only** — `constants.ts` uses `import type { ProductFormValues }`, which is erased at runtime, while `validationSchema.ts` imports a real value back. So there is no runtime cycle; madge simply wasn't told to skip type imports.

Added `.madgerc` with `detectiveOptions.skipTypeImports`, after which madge reports no cycles across all 12 workspaces.

This is probably **why `precommit` was being bypassed**: it has been failing on a non-problem, and a hook that cries wolf trains people to skip it — which then lets everything else in the hook through unchecked.

## Deferred, with measured counts

| tool | state |
|---|---|
| `cspell` | 70 issues across 36 files |
| `knip` | unused exports / dependencies |
| `jscpd` | duplication above threshold |

Each needs real cleanup rather than configuration, so they're left out of CI rather than wired in broken. Recorded in `.superpowers/sdd/aeleos-parity/plan-notes.md` to be enabled one at a time — the same ratchet used for the coverage thresholds and Playwright rules.

## Verification

The exact commands CI will run were executed locally: `sherif` → 0, `syncpack:lint` → 0, `ls-lint` → 0, `madge --circular` across all 12 workspaces → 0 ("No circular dependency found"). Plus `pnpm typecheck` → 0, `pnpm lint` → 0, `prettier --check` → clean.

## Note

Authored without independent subagent review (session rate limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt