### PR TITLE
chore(ci): run CI on the merged result, not just the PR head [GH-000]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI
 on:
   pull_request:
     branches: [main, develop]
+  # Also run on the merged result. Without this, CI only ever saw the PR head:
+  # two PRs that each passed alone could break develop together, and nobody
+  # would find out until the next pull request opened.
+  push:
+    branches: [main, develop]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

CI triggered on `pull_request` only. It never ran on `main` or `develop` after a merge — it only ever saw the PR head in isolation.

That leaves a real hole: two PRs that each pass alone can break `develop` together. Nobody finds out until the next pull request opens, and the breakage then gets attributed to whoever happened to open it rather than to either change that caused it.

Adds a `push` trigger for `main` and `develop`.

## Safety

Checked every PR-context dependency in the workflow first. There is exactly one — the `bundle-analysis` job — and it is already guarded on `github.event_name == 'pull_request'`, so it correctly skips on push. No other job reads PR context, and `dorny/paths-filter` compares before/after on push, so change detection stays accurate.

## Context

This is the last of the "gates that cannot fail" items from the gap analysis against AeleOS. It pairs with the fix in #353, which made CI able to validate changes to itself — before that, a workflow edit counted as docs-only and skipped every job.

Together they close the two ways CI could be blind: not running on the code that actually lands, and not running on changes to CI itself.

## Note

Authored without independent subagent review (session rate limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt