### PR TITLE
fix(studio): enable noUncheckedIndexedAccess and fix what it found [GH-000]

### DIFF
--- a/apps/studio/src/features/products/presentation/components/InlineEditor/InlineImageCarousel.test.tsx
+++ b/apps/studio/src/features/products/presentation/components/InlineEditor/InlineImageCarousel.test.tsx
@@ -86,20 +86,20 @@ describe("InlineImageCarousel", () => {
   it("renders empty state when no images", () => {
     render(<Wrapper />);
     expect(
-      screen.getAllByTestId("image-gallery-main-empty")[0],
+      screen.getAllByTestId("image-gallery-main-empty")[0]!,
     ).toBeInTheDocument();
   });
 
   it("renders add thumbnail button", () => {
     render(<Wrapper />);
-    expect(screen.getAllByTestId("image-thumb-add")[0]).toBeInTheDocument();
+    expect(screen.getAllByTestId("image-thumb-add")[0]!).toBeInTheDocument();
   });
 
   it("adds an image when add button is clicked", () => {
     render(<Wrapper />);
-    fireEvent.click(screen.getAllByTestId("image-thumb-add")[0]);
+    fireEvent.click(screen.getAllByTestId("image-thumb-add")[0]!);
     // After adding, the main image should appear
-    expect(screen.getAllByTestId("image-gallery-main")[0]).toBeInTheDocument();
+    expect(screen.getAllByTestId("image-gallery-main")[0]!).toBeInTheDocument();
   });
 
   it("renders images when provided", () => {
@@ -111,9 +111,9 @@ describe("InlineImageCarousel", () => {
         ]}
       />,
     );
-    expect(screen.getAllByTestId("image-gallery-main")[0]).toBeInTheDocument();
+    expect(screen.getAllByTestId("image-gallery-main")[0]!).toBeInTheDocument();
     expect(
-      screen.getAllByTestId("image-gallery-thumbs")[0],
+      screen.getAllByTestId("image-gallery-thumbs")[0]!,
     ).toBeInTheDocument();
   });
 
@@ -121,7 +121,7 @@ describe("InlineImageCarousel", () => {
     render(
       <Wrapper images={[{ url: "https://example.com/img.jpg", alt: "Img" }]} />,
     );
-    expect(screen.getAllByTestId("image-edit-bar")[0]).toBeInTheDocument();
+    expect(screen.getAllByTestId("image-edit-bar")[0]!).toBeInTheDocument();
   });
 
   it("renders set-as-cover buttons on each thumbnail", () => {
@@ -141,8 +141,12 @@ describe("InlineImageCarousel", () => {
         ]}
       />,
     );
-    expect(screen.getAllByTestId("image-thumb-cover-0")[0]).toBeInTheDocument();
-    expect(screen.getAllByTestId("image-thumb-cover-1")[0]).toBeInTheDocument();
+    expect(
+      screen.getAllByTestId("image-thumb-cover-0")[0]!,
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByTestId("image-thumb-cover-1")[0]!,
+    ).toBeInTheDocument();
   });
 
   it("clicking set-as-cover updates the cover image", () => {
@@ -166,7 +170,7 @@ describe("InlineImageCarousel", () => {
     );
 
     // Click "Set as cover" on the second image
-    const coverBtn = screen.getAllByTestId("image-thumb-cover-1")[0];
+    const coverBtn = screen.getAllByTestId("image-thumb-cover-1")[0]!;
     fireEvent.click(coverBtn);
 
     // After clicking, the second image's cover button should reflect filled state

--- a/apps/studio/src/features/products/presentation/components/InlineEditor/InlineTagEditor.test.tsx
+++ b/apps/studio/src/features/products/presentation/components/InlineEditor/InlineTagEditor.test.tsx
@@ -62,7 +62,7 @@ describe("InlineTagEditor", () => {
   it("removes a tag when remove button is clicked", () => {
     render(<Wrapper initialTags="alpha, beta" />);
     const removeButtons = screen.getAllByLabelText("removeTag");
-    fireEvent.click(removeButtons[0]);
+    fireEvent.click(removeButtons[0]!);
     expect(screen.queryByText(/#alpha/)).not.toBeInTheDocument();
     expect(screen.getByText(/#beta/)).toBeInTheDocument();
   });

--- a/apps/studio/src/features/products/presentation/components/ProductTable.tsx
+++ b/apps/studio/src/features/products/presentation/components/ProductTable.tsx
@@ -71,6 +71,9 @@ export function ProductTable({
       // Build new order
       const reordered = [...products];
       const [moved] = reordered.splice(source.index, 1);
+      // splice returns nothing if source.index is out of range; inserting
+      // `undefined` here would corrupt the order that is about to be persisted.
+      if (!moved) return;
       reordered.splice(destination.index, 0, moved);
 
       // Compute new sortOrder values (1-based sequential)

--- a/apps/studio/src/features/seller-admins/infrastructure/delegateMutations.test.ts
+++ b/apps/studio/src/features/seller-admins/infrastructure/delegateMutations.test.ts
@@ -30,7 +30,7 @@ function createMockSupabase(overrides: {
   // Every chain method returns the resolved promise decorated with chain methods
   const chainable = Object.assign(resolved, chain);
   for (const key of Object.keys(chain)) {
-    chain[key].mockReturnValue(chainable);
+    chain[key]?.mockReturnValue(chainable);
   }
 
   const from = vi.fn().mockReturnValue(chainable);

--- a/apps/studio/src/features/seller-admins/infrastructure/delegateQueries.test.ts
+++ b/apps/studio/src/features/seller-admins/infrastructure/delegateQueries.test.ts
@@ -30,7 +30,7 @@ function createMockSupabase(overrides: {
 
   const chainable = Object.assign(resolved, chain);
   for (const key of Object.keys(chain)) {
-    chain[key].mockReturnValue(chainable);
+    chain[key]?.mockReturnValue(chainable);
   }
 
   const from = vi.fn().mockReturnValue(chainable);

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
       "@/*": ["./src/*"],
       "ui": ["../../packages/ui/src"],
@@ -14,7 +18,8 @@
       "api/*": ["../../packages/api/src/*"],
       "@api/*": ["../../packages/api/src/*"]
     },
-    "noEmit": true
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary

Ninth workspace onto `noUncheckedIndexedAccess`, continuing the ratchet from #351. Leaves `store` (43), `payments` (53) and `admin` (67).

Seven errors — **one of them in production code**.

## The production one

`ProductTable`'s drag-and-drop reorder:

```ts
const [moved] = reordered.splice(source.index, 1);
reordered.splice(destination.index, 0, moved);   // moved: T | undefined
```

If `source.index` is ever out of range, `splice` returns nothing and `undefined` is inserted into the array that is then **persisted as the new product order**. Now guarded with an early return.

Narrow — it needs a bad index from the drag library to trigger — but the failure mode is silent data corruption in a seller's catalogue rather than an error, which is the kind worth closing.

## The other six

Test files indexing into query results: `screen.getAllByTestId(...)[0]`. `getAllBy*` throws when it finds nothing, so index 0 genuinely is present — the type checker just can't know that. Asserted rather than restructured, which is exactly why the lint config permits non-null assertions in test scopes and not in source.

## Verification

`apps/studio`: **0 type errors**, 56 test files, **416 tests passing**. Monorepo `pnpm typecheck` → 0, `pnpm lint` → 0, `prettier --check` → clean.

## Note

Authored without independent subagent review (session rate limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt