### PR TITLE
fix(payments): enable noUncheckedIndexedAccess and fix what it found [GH-000]

### DIFF
--- a/apps/payments/e2e/checkout-order-integrity.spec.ts
+++ b/apps/payments/e2e/checkout-order-integrity.spec.ts
@@ -246,6 +246,6 @@ test.describe.serial("Checkout order creation integrity", () => {
       `user_id=eq.${buyer.userId}`,
     );
     expect(ordersAfter).toHaveLength(1);
-    expect(ordersAfter[0].payment_status).toBe("pending_verification");
+    expect(ordersAfter[0]!.payment_status).toBe("pending_verification");
   });
 });

--- a/apps/payments/src/features/checkout/application/hooks/useCartFromCookie.test.tsx
+++ b/apps/payments/src/features/checkout/application/hooks/useCartFromCookie.test.tsx
@@ -97,13 +97,13 @@ describe("useCartFromCookie", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.groups).toHaveLength(1);
-    expect(result.current.groups[0].sellerId).toBe("s1");
-    expect(result.current.groups[0].sellerName).toBe("Seller One");
-    expect(result.current.groups[0].items).toHaveLength(2);
-    expect(result.current.groups[0].items[0].quantity).toBe(2);
-    expect(result.current.groups[0].items[1].quantity).toBe(1);
-    expect(result.current.groups[0].subtotal).toBe(25_000);
-    expect(result.current.groups[0].currency).toBe("COP");
+    expect(result.current.groups[0]!.sellerId).toBe("s1");
+    expect(result.current.groups[0]!.sellerName).toBe("Seller One");
+    expect(result.current.groups[0]!.items).toHaveLength(2);
+    expect(result.current.groups[0]!.items[0]!.quantity).toBe(2);
+    expect(result.current.groups[0]!.items[1]!.quantity).toBe(1);
+    expect(result.current.groups[0]!.subtotal).toBe(25_000);
+    expect(result.current.groups[0]!.currency).toBe("COP");
   });
 
   it("subscribes to cart cookie changes", () => {

--- a/apps/payments/src/features/orders/domain/types.ts
+++ b/apps/payments/src/features/orders/domain/types.ts
@@ -24,5 +24,8 @@ export interface OrderWithItems {
 export interface CheckoutGroup {
   checkoutSessionId: string | null;
   createdAt: string;
+  /** Id of the group's first order. Used as a render key when the group has no
+   * checkout session id, so callers need not index into `orders` to find one. */
+  firstOrderId: string;
   orders: OrderWithItems[];
 }

--- a/apps/payments/src/features/orders/infrastructure/orderQueries.test.ts
+++ b/apps/payments/src/features/orders/infrastructure/orderQueries.test.ts
@@ -101,9 +101,9 @@ describe("fetchMyOrders", () => {
     );
 
     expect(result).toHaveLength(1);
-    expect(result[0].seller_name).toBe("Seller One");
-    expect(result[0].items).toHaveLength(1);
-    expect(result[0].receipt_url).toBe(
+    expect(result[0]!.seller_name).toBe("Seller One");
+    expect(result[0]!.items).toHaveLength(1);
+    expect(result[0]!.receipt_url).toBe(
       "https://example.com/order-1/receipt.png",
     );
   });

--- a/apps/payments/src/features/orders/infrastructure/orderQueries.ts
+++ b/apps/payments/src/features/orders/infrastructure/orderQueries.ts
@@ -50,7 +50,7 @@ export async function fetchMyOrders(
   );
 
   const urlByPath: Record<string, string | null> = Object.fromEntries(
-    receiptPaths.map((path, i) => [path, signedUrls[i]]),
+    receiptPaths.map((path, i) => [path, signedUrls[i] ?? null]),
   );
 
   return rows.map((row) => ({

--- a/apps/payments/src/features/orders/presentation/pages/OrdersPageContent.tsx
+++ b/apps/payments/src/features/orders/presentation/pages/OrdersPageContent.tsx
@@ -27,11 +27,21 @@ function groupByCheckoutSession(orders: OrderWithItems[]): CheckoutGroup[] {
     }
   }
 
-  return [...map.values()].map((groupOrders) => ({
-    checkoutSessionId: groupOrders[0].checkout_session_id,
-    createdAt: groupOrders[0].created_at,
-    orders: groupOrders,
-  }));
+  // flatMap rather than map: a group is always non-empty by construction, but
+  // that is not expressible to the type checker, and dropping an impossible
+  // empty group is safer than asserting it away.
+  return [...map.values()].flatMap((groupOrders) => {
+    const [first] = groupOrders;
+    if (!first) return [];
+    return [
+      {
+        checkoutSessionId: first.checkout_session_id,
+        createdAt: first.created_at,
+        firstOrderId: first.id,
+        orders: groupOrders,
+      },
+    ];
+  });
 }
 
 export function OrdersPageContent() {
@@ -104,7 +114,7 @@ export function OrdersPageContent() {
 
         {groups.map((group) => (
           <section
-            key={group.checkoutSessionId ?? group.orders[0].id}
+            key={group.checkoutSessionId ?? group.firstOrderId}
             className="space-y-3"
           >
             <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/apps/payments/src/features/payment-methods/application/hooks/usePaymentMethodsManager.ts
+++ b/apps/payments/src/features/payment-methods/application/hooks/usePaymentMethodsManager.ts
@@ -67,6 +67,8 @@ export function usePaymentMethodsManager(
       if (!methods || index === 0) return;
       const current = methods[index];
       const prev = methods[index - 1];
+      // An out-of-range index would make these undefined and throw on .id.
+      if (!current || !prev) return;
       updateMutation.mutate({
         id: current.id,
         patch: { sort_order: prev.sort_order },
@@ -84,6 +86,8 @@ export function usePaymentMethodsManager(
       if (!methods || index === methods.length - 1) return;
       const current = methods[index];
       const next = methods[index + 1];
+      // An out-of-range index would make these undefined and throw on .id.
+      if (!current || !next) return;
       updateMutation.mutate({
         id: current.id,
         patch: { sort_order: next.sort_order },

--- a/apps/payments/src/features/payment-methods/application/hooks/useSavePaymentMethod.test.ts
+++ b/apps/payments/src/features/payment-methods/application/hooks/useSavePaymentMethod.test.ts
@@ -118,7 +118,7 @@ describe("useSavePaymentMethod", () => {
       result.current.save();
     });
 
-    const patch = mutateMock.mock.calls[0][0].patch;
+    const patch = mutateMock.mock.calls[0]![0]!.patch;
     expect(patch.name_es).toBeUndefined();
   });
 

--- a/apps/payments/src/features/payment-methods/presentation/components/DisplaySectionEditor.tsx
+++ b/apps/payments/src/features/payment-methods/presentation/components/DisplaySectionEditor.tsx
@@ -78,6 +78,9 @@ export function DisplaySectionEditor({
 
       const reordered = [...blocks];
       const [moved] = reordered.splice(source.index, 1);
+      // splice yields nothing for an out-of-range index; inserting `undefined`
+      // would corrupt the order about to be saved.
+      if (!moved) return;
       reordered.splice(destination.index, 0, moved);
       onChange(reordered);
     },

--- a/apps/payments/src/features/payment-methods/presentation/components/FormSectionEditor.tsx
+++ b/apps/payments/src/features/payment-methods/presentation/components/FormSectionEditor.tsx
@@ -58,6 +58,9 @@ export function FormSectionEditor({
 
       const reordered = [...fields];
       const [moved] = reordered.splice(source.index, 1);
+      // splice yields nothing for an out-of-range index; inserting `undefined`
+      // would corrupt the order about to be saved.
+      if (!moved) return;
       reordered.splice(destination.index, 0, moved);
       onChange(reordered);
     },

--- a/apps/payments/src/features/payment-methods/presentation/components/PaymentMethodTable.test.tsx
+++ b/apps/payments/src/features/payment-methods/presentation/components/PaymentMethodTable.test.tsx
@@ -136,7 +136,7 @@ describe("PaymentMethodTable", () => {
 
   it("falls back to name_en when name_es is not available", () => {
     const methodNoEs: SellerPaymentMethod = {
-      ...mockMethods[0],
+      ...mockMethods[0]!,
       id: "pm-2",
       name_en: "Cash",
       name_es: "",

--- a/apps/payments/src/features/received-orders/infrastructure/receivedOrderQueries.test.ts
+++ b/apps/payments/src/features/received-orders/infrastructure/receivedOrderQueries.test.ts
@@ -106,9 +106,9 @@ describe("fetchReceivedOrders", () => {
     );
 
     expect(result).toHaveLength(1);
-    expect(result[0].buyer_name).toBe("Buyer Bob");
-    expect(result[0].payment_status).toBe("pending_verification");
-    expect(result[0].receipt_url).toBe(
+    expect(result[0]!.buyer_name).toBe("Buyer Bob");
+    expect(result[0]!.payment_status).toBe("pending_verification");
+    expect(result[0]!.receipt_url).toBe(
       "https://example.com/order-1/receipt.png",
     );
   });

--- a/apps/payments/src/features/reports/infrastructure/delegatedReportsApi.test.ts
+++ b/apps/payments/src/features/reports/infrastructure/delegatedReportsApi.test.ts
@@ -121,12 +121,12 @@ describe("fetchDelegatedReportOrders", () => {
 
     expect(res.total).toBe(1);
     expect(res.orders).toHaveLength(1);
-    const [order] = res.orders;
+    const order = res.orders[0]!;
     expect(order.id).toBe("o1");
     expect(order.delegated_subtotal).toBe(50_000);
     expect(order.items).toHaveLength(1);
-    expect(order.items[0].product_id).toBe("p1");
-    expect(order.items[0].product_name).toBe("Delegated");
+    expect(order.items[0]!.product_id).toBe("p1");
+    expect(order.items[0]!.product_name).toBe("Delegated");
     expect(order.buyer_email).toBe("buyer@example.com");
     expect("receipt_url" in order).toBe(false);
     expect("transfer_number" in order).toBe(false);
@@ -178,8 +178,8 @@ describe("fetchDelegatedReportOrders", () => {
     const res = await fetchDelegatedReportOrders(supabase, NO_FILTERS);
 
     expect(res.orders).toHaveLength(1);
-    expect(res.orders[0].items).toHaveLength(1);
-    expect(res.orders[0].items[0].product_id).toBe("p1");
+    expect(res.orders[0]!.items).toHaveLength(1);
+    expect(res.orders[0]!.items[0]!.product_id).toBe("p1");
   });
 
   it("drops orders with no delegated items", async () => {
@@ -265,7 +265,7 @@ describe("fetchDelegatedReportOrders", () => {
       amountMax: 60_000,
     });
     expect(included.orders).toHaveLength(1);
-    expect(included.orders[0].delegated_subtotal).toBe(50_000);
+    expect(included.orders[0]!.delegated_subtotal).toBe(50_000);
   });
 
   it("returns empty when there is no authenticated user", async () => {
@@ -319,7 +319,7 @@ describe("fetchDelegatedReportOrders", () => {
     });
 
     expect(res.orders).toHaveLength(1);
-    expect(res.orders[0].delegated_subtotal).toBe(25_000);
+    expect(res.orders[0]!.delegated_subtotal).toBe(25_000);
   });
 
   it("falls back gracefully when product name, buyer profile, or permissions are missing", async () => {
@@ -358,8 +358,8 @@ describe("fetchDelegatedReportOrders", () => {
     const res = await fetchDelegatedReportOrders(supabase, NO_FILTERS);
 
     expect(res.orders).toHaveLength(1);
-    expect(res.orders[0].items[0].product_name).toBe("p1");
-    expect(res.orders[0].buyer_email).toBe("");
-    expect(res.orders[0].buyer_display_name).toBeNull();
+    expect(res.orders[0]!.items[0]!.product_name).toBe("p1");
+    expect(res.orders[0]!.buyer_email).toBe("");
+    expect(res.orders[0]!.buyer_display_name).toBeNull();
   });
 });

--- a/apps/payments/tsconfig.json
+++ b/apps/payments/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
       "@/*": ["./src/*"],
       "ui": ["../../packages/ui/src"],
@@ -14,7 +18,8 @@
       "api/*": ["../../packages/api/src/*"],
       "@api/*": ["../../packages/api/src/*"]
     },
-    "noEmit": true
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary

Tenth workspace onto `noUncheckedIndexedAccess`, leaving `store` (43) and `admin` (67).

53 errors — **14 in production code**, and they cluster into one recurring bug.

## The recurring bug

`DisplaySectionEditor` and `FormSectionEditor` both do:

```ts
const [moved] = reordered.splice(source.index, 1);
reordered.splice(destination.index, 0, moved);   // moved: T | undefined
```

That is the **same** drag-and-drop reorder bug already fixed in studio's `ProductTable` (#355) — an out-of-range index inserts `undefined` into the array that is then saved. Three instances across two apps, all silent data corruption rather than an error.

## Other production fixes

- **`usePaymentMethodsManager`** — the move-up/move-down handlers read `methods[index]` and `methods[index ± 1]`, then dereference `.id` with no check. An out-of-range index throws.
- **`orderQueries`** — the signed-URL map could hold `undefined` where its type promised `string | null`.
- **`OrdersPageContent`** — indexed into a checkout group to build render keys and timestamps. Rewritten with `flatMap` so the non-empty invariant is *expressed* rather than asserted away, and `CheckoutGroup` gained `firstOrderId` so callers stop reaching into `orders[0]`.

## The other 39

Test files indexing arrays immediately after asserting their length. Those took non-null assertions — **type-only and erased at compile, so they cannot change behaviour**. That distinction matters here: an `eslint --fix` earlier in this migration silently rewrote a helper's semantics and broke it. `!` cannot do that.

## Verification

`apps/payments`: **0 type errors**, 75 test files, **549 tests passing**. Monorepo `pnpm typecheck` → 0, `pnpm lint` → 0, `prettier --check` → clean.

## Note

Authored without independent subagent review (session rate limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt