### PR TITLE
chore(store): enable noUncheckedIndexedAccess [GH-000]

### DIFF
--- a/apps/store/e2e/navbar-persistence.spec.ts
+++ b/apps/store/e2e/navbar-persistence.spec.ts
@@ -141,6 +141,11 @@ async function navStateAfterFetch(
   await Promise.all([r1, r2]);
 
   // Give React one tick to flush any resulting state updates.
+  // This measures that NOTHING happens: the navbar must not re-render when the
+  // permission responses resolve. A negative assertion has no positive event to
+  // await, and waiting only until the mutation counter goes quiet would stop
+  // watching before late flicker -- so a fixed settle window is the right tool.
+  // eslint-disable-next-line playwright/no-wait-for-timeout -- see above
   await page.waitForTimeout(500);
 
   const mutations = await page.evaluate(
@@ -188,7 +193,7 @@ test.describe("Navbar permission caching across apps", () => {
     // Navigate to the first app so the hook fetches permissions and writes
     // the cookie. Wait until the studio link is visible to confirm the cookie
     // was written with the new permission set.
-    await page.goto(`${NAV_APPS[0].url}/en`);
+    await page.goto(`${NAV_APPS[0]!.url}/en`);
     await expect(page.getByTestId("nav-link-studio")).toBeVisible({
       timeout: 10_000,
     });
@@ -226,14 +231,14 @@ test.describe("Navbar permission caching across apps", () => {
     const {
       studioVisibleBeforeApi: studioBeforeRevoke,
       mutations: firstMutations,
-    } = await navStateAfterFetch(page, NAV_APPS[0].url);
+    } = await navStateAfterFetch(page, NAV_APPS[0]!.url);
     expect(
       studioBeforeRevoke,
-      `[phase 4] ${NAV_APPS[0].name}: old cookie should still show studio link before API returns`,
+      `[phase 4] ${NAV_APPS[0]!.name}: old cookie should still show studio link before API returns`,
     ).toBe(true);
     expect(
       firstMutations,
-      `[re-render] ${NAV_APPS[0].name}: stale cookie — expected nav mutations after API fetch`,
+      `[re-render] ${NAV_APPS[0]!.name}: stale cookie — expected nav mutations after API fetch`,
     ).toBeGreaterThan(0);
     // Confirm the studio link is now gone (permissions were revoked).
     await expect(page.getByTestId("nav-link-studio")).not.toBeVisible({

--- a/apps/store/src/features/cart/application/CartContext.test.tsx
+++ b/apps/store/src/features/cart/application/CartContext.test.tsx
@@ -94,8 +94,8 @@ describe("CartContext", () => {
       });
 
       expect(result.current.items).toHaveLength(1);
-      expect(result.current.items[0].id).toBe("p1");
-      expect(result.current.items[0].quantity).toBe(1);
+      expect(result.current.items[0]!.id).toBe("p1");
+      expect(result.current.items[0]!.quantity).toBe(1);
     });
 
     it("adds item with explicit quantity", () => {
@@ -106,7 +106,7 @@ describe("CartContext", () => {
         result.current.addItem({ ...product, quantity: 3 });
       });
 
-      expect(result.current.items[0].quantity).toBe(3);
+      expect(result.current.items[0]!.quantity).toBe(3);
     });
 
     it("increments quantity for existing item", () => {
@@ -122,7 +122,7 @@ describe("CartContext", () => {
       });
 
       expect(result.current.items).toHaveLength(1);
-      expect(result.current.items[0].quantity).toBe(2);
+      expect(result.current.items[0]!.quantity).toBe(2);
     });
 
     it("increments by explicit quantity for existing item", () => {
@@ -137,7 +137,7 @@ describe("CartContext", () => {
         result.current.addItem({ ...product, quantity: 3 });
       });
 
-      expect(result.current.items[0].quantity).toBe(5);
+      expect(result.current.items[0]!.quantity).toBe(5);
     });
 
     it("caps added quantity at max_quantity", () => {
@@ -156,7 +156,7 @@ describe("CartContext", () => {
         result.current.addItem(product);
       });
 
-      expect(result.current.items[0].quantity).toBe(2);
+      expect(result.current.items[0]!.quantity).toBe(2);
     });
 
     it("keeps different products separate", () => {
@@ -188,7 +188,7 @@ describe("CartContext", () => {
       });
 
       expect(result.current.items).toHaveLength(1);
-      expect(result.current.items[0].id).toBe("p2");
+      expect(result.current.items[0]!.id).toBe("p2");
     });
 
     it("does nothing when removing non-existent item", () => {
@@ -218,7 +218,7 @@ describe("CartContext", () => {
         result.current.updateQuantity("p1", 5);
       });
 
-      expect(result.current.items[0].quantity).toBe(5);
+      expect(result.current.items[0]!.quantity).toBe(5);
     });
 
     it("caps updated quantity at max_quantity", () => {
@@ -234,7 +234,7 @@ describe("CartContext", () => {
         result.current.updateQuantity("p1", 5);
       });
 
-      expect(result.current.items[0].quantity).toBe(3);
+      expect(result.current.items[0]!.quantity).toBe(3);
     });
 
     it("removes item when quantity set to 0", () => {

--- a/apps/store/src/features/cart/application/cartCookiePersistence.test.ts
+++ b/apps/store/src/features/cart/application/cartCookiePersistence.test.ts
@@ -125,7 +125,7 @@ describe("persistCartCookie", () => {
     persistCartCookie(items);
 
     expect(mockSetCookie).toHaveBeenCalledOnce();
-    const [key, value] = mockSetCookie.mock.calls[0] as [
+    const [key, value] = mockSetCookie.mock.calls[0]! as [
       string,
       string,
       unknown,
@@ -161,7 +161,7 @@ describe("persistCartCookie", () => {
 
   it("includes maxAge in setCookie options", () => {
     persistCartCookie([]);
-    const options = mockSetCookie.mock.calls[0][2] as Record<string, unknown>;
+    const options = mockSetCookie.mock.calls[0]![2] as Record<string, unknown>;
     expect(options.maxAge).toBe(COOKIE_MAX_AGE_S);
   });
 });
@@ -194,7 +194,7 @@ describe("removeCartCookie", () => {
 
     expect(mockDeleteCookie).toHaveBeenCalledTimes(2);
     const calls = mockDeleteCookie.mock.calls as [string, unknown][];
-    expect(calls[0][0]).toBe("libra-cart");
+    expect(calls[0]![0]).toBe("libra-cart");
     expect(calls[1]).toEqual(["libra-cart", { path: "/" }]);
   });
 

--- a/apps/store/src/features/cart/application/groupBySeller.test.ts
+++ b/apps/store/src/features/cart/application/groupBySeller.test.ts
@@ -74,9 +74,9 @@ describe("groupCartBySeller", () => {
     const result = groupCartBySeller(items);
 
     expect(result).toHaveLength(1);
-    expect(result[0].sellerId).toBe("seller-a");
-    expect(result[0].items).toHaveLength(2);
-    expect(result[0].subtotal).toBe(10 * 2 + 5 * 1);
+    expect(result[0]!.sellerId).toBe("seller-a");
+    expect(result[0]!.items).toHaveLength(2);
+    expect(result[0]!.subtotal).toBe(10 * 2 + 5 * 1);
   });
 
   it("groups items by different sellers", () => {
@@ -126,9 +126,9 @@ describe("groupCartBySeller", () => {
     const result = groupCartBySeller(items);
 
     expect(result).toHaveLength(1);
-    expect(result[0].sellerId).toBe("unknown");
-    expect(result[0].items).toHaveLength(2);
-    expect(result[0].subtotal).toBe(10 * 1 + 15 * 2);
+    expect(result[0]!.sellerId).toBe("unknown");
+    expect(result[0]!.items).toHaveLength(2);
+    expect(result[0]!.subtotal).toBe(10 * 1 + 15 * 2);
   });
 
   it("mixes known sellers with unknown seller_id", () => {
@@ -166,7 +166,7 @@ describe("groupCartBySeller", () => {
 
     const result = groupCartBySeller(items);
 
-    expect(result[0].subtotal).toBeCloseTo(29.97, 2);
+    expect(result[0]!.subtotal).toBeCloseTo(29.97, 2);
   });
 
   it("handles single item cart", () => {
@@ -182,9 +182,9 @@ describe("groupCartBySeller", () => {
     const result = groupCartBySeller(items);
 
     expect(result).toHaveLength(1);
-    expect(result[0].sellerId).toBe("seller-x");
-    expect(result[0].items).toHaveLength(1);
-    expect(result[0].subtotal).toBe(42);
+    expect(result[0]!.sellerId).toBe("seller-x");
+    expect(result[0]!.items).toHaveLength(1);
+    expect(result[0]!.subtotal).toBe(42);
   });
 
   it("preserves item order within each group", () => {
@@ -201,7 +201,7 @@ describe("groupCartBySeller", () => {
 
     const result = groupCartBySeller(items);
 
-    expect(result[0].items.map((i) => i.id)).toEqual([
+    expect(result[0]!.items.map((i) => i.id)).toEqual([
       "first",
       "second",
       "third",

--- a/apps/store/src/features/cart/application/hooks/useSellerProfiles.ts
+++ b/apps/store/src/features/cart/application/hooks/useSellerProfiles.ts
@@ -27,7 +27,8 @@ export function useSellerProfiles(sellerIds: string[]) {
 
       const map: Record<string, string> = {};
       for (const profile of data ?? []) {
-        map[profile.id] = profile.display_name ?? profile.email.split("@")[0];
+        map[profile.id] =
+          profile.display_name ?? profile.email.split("@")[0] ?? profile.email;
       }
       return map;
     },

--- a/apps/store/src/features/products/application/buildGridOrder.test.ts
+++ b/apps/store/src/features/products/application/buildGridOrder.test.ts
@@ -294,7 +294,7 @@ describe.each([
 
     assertSameProducts(input, result);
     assertNoOrphans(result, cols);
-    expect(result[0].id).toBe("F1");
+    expect(result[0]!.id).toBe("F1");
   });
 
   it("handles consecutive featured items", () => {

--- a/apps/store/src/features/products/application/buildGridOrder.ts
+++ b/apps/store/src/features/products/application/buildGridOrder.ts
@@ -18,9 +18,10 @@ function createRegularPool(products: Product[]) {
     pull(): Product | null {
       while (ptr < indices.length) {
         const idx = indices[ptr++];
+        if (idx === undefined) continue;
         if (!consumed.has(idx)) {
           consumed.add(idx);
-          return products[idx];
+          return products[idx] ?? null;
         }
       }
       return null;

--- a/apps/store/src/features/products/application/hooks/useSellerInfo.ts
+++ b/apps/store/src/features/products/application/hooks/useSellerInfo.ts
@@ -23,7 +23,8 @@ export function useSellerInfo(sellerId: string | null) {
       if (error) throw new Error(error.message);
 
       return {
-        displayName: data.display_name ?? data.email.split("@")[0],
+        displayName:
+          data.display_name ?? data.email.split("@")[0] ?? data.email,
         avatarUrl: data.display_avatar_url ?? data.avatar_url ?? null,
       };
     },

--- a/apps/store/src/features/products/presentation/components/ProductDetail/ImageGallery.tsx
+++ b/apps/store/src/features/products/presentation/components/ProductDetail/ImageGallery.tsx
@@ -49,8 +49,6 @@ export function ImageGallery({ product, theme }: ImageGalleryProps) {
     () => getProductImages(product.images),
     [product.images],
   );
-  const hasImages = images.length > 0;
-
   const activeImage = images[activeIndex];
 
   const thumbInactive =
@@ -63,7 +61,9 @@ export function ImageGallery({ product, theme }: ImageGalleryProps) {
   );
 
   // Placeholder for products with no images
-  if (!hasImages) {
+  // No active image means there are no images at all, or the selected index is
+  // stale after a product change -- both render the same empty state.
+  if (!activeImage) {
     return (
       <div
         className="w-full max-w-full shrink-0 lg:w-3/5"

--- a/apps/store/tsconfig.json
+++ b/apps/store/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
       "@/*": ["./src/*"],
       "ui": ["../../packages/ui/src"],
@@ -14,7 +18,8 @@
       "api/*": ["../../packages/api/src/*"],
       "@api/*": ["../../packages/api/src/*"]
     },
-    "noEmit": true
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary

Eleventh of twelve workspaces to get `noUncheckedIndexedAccess`. Four production sites needed real guards; the rest were test-side reads.

## Production fixes

| Site | What was wrong |
| --- | --- |
| `ImageGallery.tsx` | Dereferenced `images[activeIndex]` seven times behind a `hasImages` check the type checker cannot connect to the indexed read. Now guards on `activeImage` itself — same empty state, and it also survives a stale index after a product change. `hasImages` had no other use, so this *removes* a condition. |
| `buildGridOrder.ts` | `pull()` read `indices[ptr++]` and used it as a `Set` key and an array index; it also returned `products[idx]` typed `Product \| null` while the value could be `undefined`. |
| `useSellerProfiles.ts`, `useSellerInfo.ts` | Both fell back to `email.split("@")[0]`, which is only non-empty for a well-formed address. Same fix already landed for `UserProfilePage` in #351. |

Test-side reads use non-null assertions: type-only, erased at compile, so they cannot alter behaviour.

## One documented exemption

The pre-commit gate lints touched files at `--max-warnings=0`, which surfaced a pre-existing `page.waitForTimeout(500)` in `navbar-persistence.spec.ts`. It stays, with the reasoning recorded in place: the assertion is that the navbar does **not** re-render when permission responses resolve. A negative assertion has no positive event to await, and waiting only until the mutation counter goes quiet would stop watching before late flicker.

## Verification

`pnpm typecheck` · `pnpm lint` (0 errors) · 350 store tests across 48 files · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt