### PR TITLE
chore(admin): enable noUncheckedIndexedAccess [GH-000]

### DIFF
--- a/apps/admin/src/features/dashboard/infrastructure/recentActivityQueries.test.ts
+++ b/apps/admin/src/features/dashboard/infrastructure/recentActivityQueries.test.ts
@@ -23,7 +23,7 @@ describe("fetchRecentActivity", () => {
 
   it("passes select param with expected fields", async () => {
     await fetchRecentActivity();
-    const params = mockAuditRestQuery.mock.calls[0][1] as URLSearchParams;
+    const params = mockAuditRestQuery.mock.calls[0]![1] as URLSearchParams;
     expect(params.get("select")).toContain("event_id");
     expect(params.get("select")).toContain("action_timestamp");
     expect(params.get("select")).toContain("user_email");
@@ -31,13 +31,13 @@ describe("fetchRecentActivity", () => {
 
   it("passes order param for descending timestamp", async () => {
     await fetchRecentActivity();
-    const params = mockAuditRestQuery.mock.calls[0][1] as URLSearchParams;
+    const params = mockAuditRestQuery.mock.calls[0]![1] as URLSearchParams;
     expect(params.get("order")).toBe("action_timestamp.desc");
   });
 
   it("passes limit of 5", async () => {
     await fetchRecentActivity();
-    const params = mockAuditRestQuery.mock.calls[0][1] as URLSearchParams;
+    const params = mockAuditRestQuery.mock.calls[0]![1] as URLSearchParams;
     expect(params.get("limit")).toBe("5");
   });
 

--- a/apps/admin/src/features/reports/infrastructure/reportsApi.test.ts
+++ b/apps/admin/src/features/reports/infrastructure/reportsApi.test.ts
@@ -64,7 +64,7 @@ describe("fetchReportOrders", () => {
       dateTo: "2024-01-31",
     });
 
-    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    const calledUrl = fetchMock.mock.calls[0]![0] as string;
     expect(calledUrl).toContain("dateFrom=2024-01-01");
     expect(calledUrl).toContain("dateTo=2024-01-31");
   });
@@ -75,7 +75,7 @@ describe("fetchReportOrders", () => {
 
     await fetchReportOrders({ ...emptyFilters, status: "approved" });
 
-    expect(fetchMock.mock.calls[0][0]).toContain("status=approved");
+    expect(fetchMock.mock.calls[0]![0]).toContain("status=approved");
   });
 
   it("appends sellerId filter", async () => {
@@ -84,7 +84,7 @@ describe("fetchReportOrders", () => {
 
     await fetchReportOrders({ ...emptyFilters, sellerId: "seller-1" });
 
-    expect(fetchMock.mock.calls[0][0]).toContain("sellerId=seller-1");
+    expect(fetchMock.mock.calls[0]![0]).toContain("sellerId=seller-1");
   });
 
   it("appends buyerId filter", async () => {
@@ -93,7 +93,7 @@ describe("fetchReportOrders", () => {
 
     await fetchReportOrders({ ...emptyFilters, buyerId: "buyer-1" });
 
-    expect(fetchMock.mock.calls[0][0]).toContain("buyerId=buyer-1");
+    expect(fetchMock.mock.calls[0]![0]).toContain("buyerId=buyer-1");
   });
 
   it("appends productId filter", async () => {
@@ -102,7 +102,7 @@ describe("fetchReportOrders", () => {
 
     await fetchReportOrders({ ...emptyFilters, productId: "prod-1" });
 
-    expect(fetchMock.mock.calls[0][0]).toContain("productId=prod-1");
+    expect(fetchMock.mock.calls[0]![0]).toContain("productId=prod-1");
   });
 
   it("appends currency filter", async () => {
@@ -111,7 +111,7 @@ describe("fetchReportOrders", () => {
 
     await fetchReportOrders({ ...emptyFilters, currency: "USD" });
 
-    expect(fetchMock.mock.calls[0][0]).toContain("currency=USD");
+    expect(fetchMock.mock.calls[0]![0]).toContain("currency=USD");
   });
 
   it("appends amountMin filter including zero", async () => {
@@ -120,7 +120,7 @@ describe("fetchReportOrders", () => {
 
     await fetchReportOrders({ ...emptyFilters, amountMin: 0 });
 
-    expect(fetchMock.mock.calls[0][0]).toContain("amountMin=0");
+    expect(fetchMock.mock.calls[0]![0]).toContain("amountMin=0");
   });
 
   it("appends amountMax filter", async () => {
@@ -129,7 +129,7 @@ describe("fetchReportOrders", () => {
 
     await fetchReportOrders({ ...emptyFilters, amountMax: 500 });
 
-    expect(fetchMock.mock.calls[0][0]).toContain("amountMax=500");
+    expect(fetchMock.mock.calls[0]![0]).toContain("amountMax=500");
   });
 
   it("omits null filters from query string", async () => {
@@ -138,7 +138,7 @@ describe("fetchReportOrders", () => {
 
     await fetchReportOrders(emptyFilters);
 
-    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    const calledUrl = fetchMock.mock.calls[0]![0] as string;
     expect(calledUrl).not.toContain("?");
   });
 
@@ -165,7 +165,7 @@ describe("fetchReportOrders", () => {
 
     await fetchReportOrders({ ...emptyFilters, status: "pending" });
 
-    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    const calledUrl = fetchMock.mock.calls[0]![0] as string;
     expect(calledUrl).toContain("?");
     expect(calledUrl).toMatch(/\/api\/admin\/reports\/orders\?/);
   });

--- a/apps/admin/src/features/reports/presentation/pages/ReportsPage.test.tsx
+++ b/apps/admin/src/features/reports/presentation/pages/ReportsPage.test.tsx
@@ -339,7 +339,7 @@ describe("ReportsPage", () => {
     render(<ReportsPage />);
     fireEvent.click(screen.getByTestId("reports-export-button"));
     await screen.findByTestId("reports-export-button");
-    const calledUrl: string = mockFetch.mock.calls[0][0] as string;
+    const calledUrl: string = mockFetch.mock.calls[0]![0] as string;
     expect(calledUrl).toContain("dateFrom=2026-01-01");
     expect(calledUrl).toContain("dateTo=2026-12-31");
     expect(calledUrl).toContain("status=approved");
@@ -400,7 +400,7 @@ describe("ReportsPage", () => {
     render(<ReportsPage />);
     fireEvent.click(screen.getByTestId("reports-export-button"));
     await screen.findByTestId("reports-export-button");
-    const calledUrl: string = mockFetch.mock.calls[0][0] as string;
+    const calledUrl: string = mockFetch.mock.calls[0]![0] as string;
     expect(calledUrl).toContain("amountMin=10");
     expect(calledUrl).toContain("amountMax=500");
     vi.unstubAllGlobals();

--- a/apps/admin/src/features/settings/infrastructure/settingsQueries.test.ts
+++ b/apps/admin/src/features/settings/infrastructure/settingsQueries.test.ts
@@ -77,7 +77,7 @@ describe("updatePaymentSetting", () => {
     await updatePaymentSetting(supabase, "timeout_awaiting_payment_hours", 48);
 
     const fromResult = (supabase.from as ReturnType<typeof vi.fn>).mock
-      .results[0].value;
+      .results[0]!.value;
     expect(fromResult.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         key: "timeout_awaiting_payment_hours",

--- a/apps/admin/src/features/templates/presentation/components/ItemRow.test.tsx
+++ b/apps/admin/src/features/templates/presentation/components/ItemRow.test.tsx
@@ -35,7 +35,7 @@ describe("ItemRow", () => {
     render(<ItemRow {...defaultProps} onUpdate={onUpdate} />);
 
     const inputs = screen.getAllByRole("textbox");
-    fireEvent.change(inputs[0], { target: { value: "New Title" } });
+    fireEvent.change(inputs[0]!, { target: { value: "New Title" } });
     expect(onUpdate).toHaveBeenCalledWith({ title_en: "New Title" });
   });
 
@@ -51,7 +51,7 @@ describe("ItemRow", () => {
     const onUpdate = vi.fn();
     render(<ItemRow {...defaultProps} onUpdate={onUpdate} />);
     const inputs = screen.getAllByRole("textbox");
-    fireEvent.change(inputs[1], { target: { value: "Nuevo" } });
+    fireEvent.change(inputs[1]!, { target: { value: "Nuevo" } });
     expect(onUpdate).toHaveBeenCalledWith({ title_es: "Nuevo" });
   });
 
@@ -59,7 +59,7 @@ describe("ItemRow", () => {
     const onUpdate = vi.fn();
     render(<ItemRow {...defaultProps} onUpdate={onUpdate} />);
     const inputs = screen.getAllByRole("textbox");
-    fireEvent.change(inputs[2], { target: { value: "New Desc" } });
+    fireEvent.change(inputs[2]!, { target: { value: "New Desc" } });
     expect(onUpdate).toHaveBeenCalledWith({ description_en: "New Desc" });
   });
 
@@ -77,7 +77,7 @@ describe("ItemRow", () => {
     const onUpdate = vi.fn();
     render(<ItemRow {...defaultProps} onUpdate={onUpdate} />);
     const inputs = screen.getAllByRole("textbox");
-    fireEvent.change(inputs[3], { target: { value: "Nueva Desc" } });
+    fireEvent.change(inputs[3]!, { target: { value: "Nueva Desc" } });
     expect(onUpdate).toHaveBeenCalledWith({ description_es: "Nueva Desc" });
   });
 
@@ -85,7 +85,7 @@ describe("ItemRow", () => {
     const onUpdate = vi.fn();
     render(<ItemRow {...defaultProps} onUpdate={onUpdate} />);
     const inputs = screen.getAllByRole("textbox");
-    fireEvent.change(inputs[4], { target: { value: "Heart" } });
+    fireEvent.change(inputs[4]!, { target: { value: "Heart" } });
     expect(onUpdate).toHaveBeenCalledWith({ icon: "Heart" });
   });
 });

--- a/apps/admin/src/features/templates/presentation/components/SectionBlock.test.tsx
+++ b/apps/admin/src/features/templates/presentation/components/SectionBlock.test.tsx
@@ -77,7 +77,7 @@ describe("SectionBlock", () => {
     render(<SectionBlock {...defaultProps} onUpdate={onUpdate} />);
 
     const inputs = screen.getAllByRole("textbox");
-    fireEvent.change(inputs[0], { target: { value: "New Name" } });
+    fireEvent.change(inputs[0]!, { target: { value: "New Name" } });
     expect(onUpdate).toHaveBeenCalledWith({ name_en: "New Name" });
   });
 
@@ -127,7 +127,7 @@ describe("SectionBlock", () => {
     render(<SectionBlock {...defaultProps} onUpdate={onUpdate} />);
 
     const inputs = screen.getAllByRole("textbox");
-    fireEvent.change(inputs[1], { target: { value: "Nuevo Nombre" } });
+    fireEvent.change(inputs[1]!, { target: { value: "Nuevo Nombre" } });
     expect(onUpdate).toHaveBeenCalledWith({ name_es: "Nuevo Nombre" });
   });
 

--- a/apps/admin/src/features/templates/presentation/components/TemplateEditor.test.tsx
+++ b/apps/admin/src/features/templates/presentation/components/TemplateEditor.test.tsx
@@ -100,7 +100,7 @@ describe("TemplateEditor", () => {
 
     fireEvent.click(screen.getByTestId("template-save"));
     expect(onSave).toHaveBeenCalledTimes(1);
-    expect(onSave.mock.calls[0][0].name_en).toBe("My Template");
+    expect(onSave.mock.calls[0]![0]!.name_en).toBe("My Template");
   });
 
   it("calls onCancel when cancel button is clicked", () => {
@@ -148,10 +148,10 @@ describe("TemplateEditor", () => {
     });
 
     fireEvent.click(screen.getByTestId("template-save"));
-    const saved = onSave.mock.calls[0][0] as {
+    const saved = onSave.mock.calls[0]![0] as {
       sections: Array<{ name_en: string }>;
     };
-    expect(saved.sections[0].name_en).toBe("Updated Section");
+    expect(saved.sections[0]!.name_en).toBe("Updated Section");
   });
 
   it("removeSection removes the section via onRemove callback", () => {
@@ -178,10 +178,10 @@ describe("TemplateEditor", () => {
     });
 
     fireEvent.click(screen.getByTestId("template-save"));
-    const saved = onSave.mock.calls[0][0] as {
+    const saved = onSave.mock.calls[0]![0] as {
       sections: Array<{ items: Array<{ title_en: string }> }>;
     };
-    expect(saved.sections[0].items).toHaveLength(1);
+    expect(saved.sections[0]!.items).toHaveLength(1);
   });
 
   it("updateItem updates an item in the section via onUpdateItem callback", () => {
@@ -197,10 +197,10 @@ describe("TemplateEditor", () => {
     });
 
     fireEvent.click(screen.getByTestId("template-save"));
-    const saved = onSave.mock.calls[0][0] as {
+    const saved = onSave.mock.calls[0]![0] as {
       sections: Array<{ items: Array<{ title_en: string }> }>;
     };
-    expect(saved.sections[0].items[0].title_en).toBe("My Item");
+    expect(saved.sections[0]!.items[0]!.title_en).toBe("My Item");
   });
 
   it("removeItem removes an item from the section via onRemoveItem callback", () => {
@@ -216,9 +216,9 @@ describe("TemplateEditor", () => {
     });
 
     fireEvent.click(screen.getByTestId("template-save"));
-    const saved = onSave.mock.calls[0][0] as {
+    const saved = onSave.mock.calls[0]![0] as {
       sections: Array<{ items: unknown[] }>;
     };
-    expect(saved.sections[0].items).toHaveLength(0);
+    expect(saved.sections[0]!.items).toHaveLength(0);
   });
 });

--- a/apps/admin/src/features/templates/presentation/components/TemplateEditor.tsx
+++ b/apps/admin/src/features/templates/presentation/components/TemplateEditor.tsx
@@ -64,8 +64,10 @@ export function TemplateEditor({
   const updateSection = useCallback(
     (index: number, partial: Partial<ProductSection>) => {
       setForm((prev) => {
+        const target = prev.sections[index];
+        if (!target) return prev;
         const sections = [...prev.sections];
-        sections[index] = { ...sections[index], ...partial };
+        sections[index] = { ...target, ...partial };
         return { ...prev, sections };
       });
     },
@@ -86,10 +88,13 @@ export function TemplateEditor({
       partial: Partial<ProductSectionItem>,
     ) => {
       setForm((prev) => {
+        const section = prev.sections[sectionIndex];
+        const target = section?.items[itemIndex];
+        if (!section || !target) return prev;
+        const items = [...section.items];
+        items[itemIndex] = { ...target, ...partial };
         const sections = [...prev.sections];
-        const items = [...sections[sectionIndex].items];
-        items[itemIndex] = { ...items[itemIndex], ...partial };
-        sections[sectionIndex] = { ...sections[sectionIndex], items };
+        sections[sectionIndex] = { ...section, items };
         return { ...prev, sections };
       });
     },
@@ -98,23 +103,25 @@ export function TemplateEditor({
 
   const addItem = useCallback((sectionIndex: number) => {
     setForm((prev) => {
-      const sections = [...prev.sections];
+      const section = prev.sections[sectionIndex];
+      if (!section) return prev;
       const items = [
-        ...sections[sectionIndex].items,
-        createEmptyItem(sections[sectionIndex].items.length + 1),
+        ...section.items,
+        createEmptyItem(section.items.length + 1),
       ];
-      sections[sectionIndex] = { ...sections[sectionIndex], items };
+      const sections = [...prev.sections];
+      sections[sectionIndex] = { ...section, items };
       return { ...prev, sections };
     });
   }, []);
 
   const removeItem = useCallback((sectionIndex: number, itemIndex: number) => {
     setForm((prev) => {
+      const section = prev.sections[sectionIndex];
+      if (!section) return prev;
+      const items = section.items.filter((_, i) => i !== itemIndex);
       const sections = [...prev.sections];
-      const items = sections[sectionIndex].items.filter(
-        (_, i) => i !== itemIndex,
-      );
-      sections[sectionIndex] = { ...sections[sectionIndex], items };
+      sections[sectionIndex] = { ...section, items };
       return { ...prev, sections };
     });
   }, []);

--- a/apps/admin/src/features/users/application/utils/getInitials.ts
+++ b/apps/admin/src/features/users/application/utils/getInitials.ts
@@ -12,5 +12,5 @@ export function getInitials(name: string | null, email: string): string {
       .slice(0, MAX_INITIALS_LENGTH);
   }
   if (!email) return "?";
-  return email[0].toUpperCase();
+  return email.charAt(0).toUpperCase();
 }

--- a/apps/admin/src/features/users/domain/constants.ts
+++ b/apps/admin/src/features/users/domain/constants.ts
@@ -116,7 +116,7 @@ export const ALL_PERMISSION_KEYS: string[] = PERMISSION_GROUPS.flatMap(
   (group) => group.permissions,
 );
 
-export const PERMISSION_TEMPLATES: Record<string, string[]> = {
+export const PERMISSION_TEMPLATES = {
   buyer: [
     "products.read",
     "product_reviews.create",
@@ -159,7 +159,7 @@ export const PERMISSION_TEMPLATES: Record<string, string[]> = {
     "check_ins.update",
   ],
   none: [],
-};
+} satisfies Record<string, string[]>;
 
 /** @deprecated Import from `@/shared/domain/constants` instead */
 export { ADMIN_APP_ACCESS_KEYS } from "@/shared/domain/constants";

--- a/apps/admin/src/features/users/presentation/components/PermissionGroupCard.test.tsx
+++ b/apps/admin/src/features/users/presentation/components/PermissionGroupCard.test.tsx
@@ -48,7 +48,7 @@ describe("PermissionGroupCard", () => {
     render(<PermissionGroupCard {...defaultProps} onToggle={onToggle} />);
     const checkboxes = screen.getAllByRole("checkbox");
     // Click unchecked "orders.edit" → should grant it
-    fireEvent.click(checkboxes[1]);
+    fireEvent.click(checkboxes[1]!);
     expect(onToggle).toHaveBeenCalledWith("orders.edit", true);
   });
 
@@ -57,7 +57,7 @@ describe("PermissionGroupCard", () => {
     render(<PermissionGroupCard {...defaultProps} onToggle={onToggle} />);
     const checkboxes = screen.getAllByRole("checkbox");
     // Click checked "orders.view" → should revoke it
-    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[0]!);
     expect(onToggle).toHaveBeenCalledWith("orders.view", false);
   });
 

--- a/apps/admin/src/features/users/presentation/components/UserHeader.test.tsx
+++ b/apps/admin/src/features/users/presentation/components/UserHeader.test.tsx
@@ -45,7 +45,7 @@ vi.mock("@/features/users/application/utils", () => ({
   formatLastSeen: (ts: string | null) =>
     ts ? { key: "minutesAgo", params: { count: 5 } } : null,
   getInitials: (name: string | null, email: string) =>
-    name ? name[0].toUpperCase() : email[0].toUpperCase(),
+    name ? name[0]!.toUpperCase() : email[0]!.toUpperCase(),
 }));
 
 import { UserHeader } from "./UserHeader";

--- a/apps/admin/src/features/users/presentation/components/UserTable.test.tsx
+++ b/apps/admin/src/features/users/presentation/components/UserTable.test.tsx
@@ -116,7 +116,7 @@ describe("UserTable", () => {
       <UserTable {...defaultProps} onRoleFilterChange={onRoleFilterChange} />,
     );
     const selects = screen.getAllByRole("combobox");
-    fireEvent.change(selects[0], { target: { value: "buyer" } });
+    fireEvent.change(selects[0]!, { target: { value: "buyer" } });
     expect(onRoleFilterChange).toHaveBeenCalledWith("buyer");
   });
 
@@ -126,7 +126,7 @@ describe("UserTable", () => {
       <UserTable {...defaultProps} onItemFilterChange={onItemFilterChange} />,
     );
     const selects = screen.getAllByRole("combobox");
-    fireEvent.change(selects[1], { target: { value: "has_items" } });
+    fireEvent.change(selects[1]!, { target: { value: "has_items" } });
     expect(onItemFilterChange).toHaveBeenCalledWith("has_items");
   });
 
@@ -137,8 +137,8 @@ describe("UserTable", () => {
     );
     const checkboxes = screen.getAllByRole("checkbox");
     // First checkbox is the select-all header checkbox
-    fireEvent.click(checkboxes[0]);
-    const called = onSelectUsersChange.mock.calls[0][0] as Set<string>;
+    fireEvent.click(checkboxes[0]!);
+    const called = onSelectUsersChange.mock.calls[0]![0] as Set<string>;
     expect(called.has("1")).toBe(true);
     expect(called.has("2")).toBe(true);
   });
@@ -153,8 +153,8 @@ describe("UserTable", () => {
       />,
     );
     const checkboxes = screen.getAllByRole("checkbox");
-    fireEvent.click(checkboxes[0]);
-    const called = onSelectUsersChange.mock.calls[0][0] as Set<string>;
+    fireEvent.click(checkboxes[0]!);
+    const called = onSelectUsersChange.mock.calls[0]![0] as Set<string>;
     expect(called.size).toBe(0);
   });
 

--- a/apps/admin/src/features/users/presentation/components/delegates/RemoveButton.test.tsx
+++ b/apps/admin/src/features/users/presentation/components/delegates/RemoveButton.test.tsx
@@ -86,7 +86,7 @@ describe("RemoveButton", () => {
     render(<RemoveButton rowId="r1" userId="u1" canDelete={true} />);
     fireEvent.click(screen.getByTestId("remove-delegate-r1"));
     fireEvent.click(screen.getByTestId("confirm-remove-delegate-r1"));
-    const { onSettled } = mockMutate.mock.calls[0][1] as {
+    const { onSettled } = mockMutate.mock.calls[0]![1] as {
       onSettled: () => void;
     };
     expect(typeof onSettled).toBe("function");

--- a/apps/admin/src/features/users/presentation/pages/UsersPageContent.test.tsx
+++ b/apps/admin/src/features/users/presentation/pages/UsersPageContent.test.tsx
@@ -173,7 +173,7 @@ describe("UsersPageContent", () => {
   it("passes users from useUsers to UserTable", () => {
     render(<UsersPageContent />);
     expect(capturedUsers).toHaveLength(2);
-    expect(capturedUsers[0].id).toBe("u1");
+    expect(capturedUsers[0]!.id).toBe("u1");
   });
 
   it("passes isLoading=false to UserTable when data is ready", () => {

--- a/apps/admin/src/shared/presentation/components/AppTopNavigation.test.tsx
+++ b/apps/admin/src/shared/presentation/components/AppTopNavigation.test.tsx
@@ -40,7 +40,7 @@ describe("AppTopNavigation", () => {
 
   it("passes permissionState with grantedKeys and isAuthenticated from hook", () => {
     render(<AppTopNavigation {...defaultProps} />);
-    const call = mockAppNavigation.mock.calls[0][0] as {
+    const call = mockAppNavigation.mock.calls[0]![0] as {
       permissionState: { grantedKeys: string[]; isAuthenticated: boolean };
     };
     expect(call.permissionState.grantedKeys).toEqual(mockGrantedKeys);
@@ -49,7 +49,7 @@ describe("AppTopNavigation", () => {
 
   it("passes through all original props to AppNavigation", () => {
     render(<AppTopNavigation {...defaultProps} />);
-    const call = mockAppNavigation.mock.calls[0][0] as Record<string, unknown>;
+    const call = mockAppNavigation.mock.calls[0]![0] as Record<string, unknown>;
     expect(call.currentApp).toBe("admin");
     expect(call.userEmail).toBe("user@example.com");
   });

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -14,7 +14,8 @@
       "api/*": ["../../packages/api/src/*"],
       "@api/*": ["../../packages/api/src/*"]
     },
-    "noEmit": true
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary

The twelfth and last workspace. **Every workspace in the monorepo now builds with `noUncheckedIndexedAccess`.**

Two real findings in production code.

### `PERMISSION_TEMPLATES` was erasing its own key type

It was annotated `Record<string, string[]>`, which discards the literal keys. That made

```ts
export type TemplateKey = Exclude<keyof typeof PERMISSION_TEMPLATES, "none">;
```

resolve to plain `string` — so every function taking a `TemplateKey` accepted **any string at all**, and the toggle/permission machinery had no key safety despite looking like it did.

Switching to `satisfies Record<string, string[]>` keeps the same shape check, preserves the keys, restores `TemplateKey` to a real union, and fixed five of the six remaining errors by itself.

### `TemplateEditor`'s four updaters could persist malformed state

`updateSection`, `updateItem`, `addItem`, and `removeItem` each take an index from the caller and index into state without checking it. With a stale index — a closure captured before a concurrent removal — the spread became `{ ...undefined, ...partial }`: a section or item missing every required field, written straight into form state. That is precisely what TS2322 was reporting. Each updater now returns the previous state unchanged when the index does not resolve.

### `getInitials`

Used `email[0]` behind an `if (!email)` guard the checker cannot connect to the read. `charAt(0)` has identical behaviour with no `undefined`.

Test-side reads use non-null assertions: type-only, erased at compile, so they cannot alter behaviour.

## Verification

`pnpm typecheck` · `pnpm lint` (0 errors) · 531 admin tests across 70 files · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt