### PR TITLE
chore: hoist noUncheckedIndexedAccess into the base tsconfig [GH-000]

### DIFF
--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -14,8 +14,7 @@
       "api/*": ["../../packages/api/src/*"],
       "@api/*": ["../../packages/api/src/*"]
     },
-    "noEmit": true,
-    "noUncheckedIndexedAccess": true
+    "noEmit": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/auth/tsconfig.json
+++ b/apps/auth/tsconfig.json
@@ -20,8 +20,7 @@
       "auth": ["../../packages/auth/src"],
       "auth/*": ["../../packages/auth/src/*"]
     },
-    "noEmit": true,
-    "noUncheckedIndexedAccess": true
+    "noEmit": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules", "e2e"]

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -15,8 +15,7 @@
       "shared/*": ["../../packages/shared/src/*"],
       "@shared/*": ["../../packages/shared/src/*"]
     },
-    "noEmit": true,
-    "noUncheckedIndexedAccess": true
+    "noEmit": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/payments/tsconfig.json
+++ b/apps/payments/tsconfig.json
@@ -18,8 +18,7 @@
       "api/*": ["../../packages/api/src/*"],
       "@api/*": ["../../packages/api/src/*"]
     },
-    "noEmit": true,
-    "noUncheckedIndexedAccess": true
+    "noEmit": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/playground/tsconfig.json
+++ b/apps/playground/tsconfig.json
@@ -18,8 +18,7 @@
       "api/*": ["../../packages/api/src/*"],
       "@api/*": ["../../packages/api/src/*"]
     },
-    "noEmit": true,
-    "noUncheckedIndexedAccess": true
+    "noEmit": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/store/tsconfig.json
+++ b/apps/store/tsconfig.json
@@ -18,8 +18,7 @@
       "api/*": ["../../packages/api/src/*"],
       "@api/*": ["../../packages/api/src/*"]
     },
-    "noEmit": true,
-    "noUncheckedIndexedAccess": true
+    "noEmit": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -18,8 +18,7 @@
       "api/*": ["../../packages/api/src/*"],
       "@api/*": ["../../packages/api/src/*"]
     },
-    "noEmit": true,
-    "noUncheckedIndexedAccess": true
+    "noEmit": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -6,8 +6,7 @@
     "baseUrl": ".",
     "paths": {
       "@api/*": ["./src/*"]
-    },
-    "noUncheckedIndexedAccess": true
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"]

--- a/packages/app-components/tsconfig.json
+++ b/packages/app-components/tsconfig.json
@@ -8,8 +8,7 @@
       "@app-components/*": ["./src/*"],
       "@shared/*": ["../shared/src/*"],
       "@ui/*": ["../ui/src/*"]
-    },
-    "noUncheckedIndexedAccess": true
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"]

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -7,8 +7,7 @@
     "types": ["vitest/globals", "node"],
     "paths": {
       "@auth/*": ["./src/*"]
-    },
-    "noUncheckedIndexedAccess": true
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"]

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -6,8 +6,7 @@
     "baseUrl": ".",
     "paths": {
       "@shared/*": ["./src/*"]
-    },
-    "noUncheckedIndexedAccess": true
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"]

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -7,8 +7,7 @@
     "paths": {
       "@ui/*": ["./src/*"],
       "@shared/*": ["../shared/src/*"]
-    },
-    "noUncheckedIndexedAccess": true
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary

All twelve workspaces enabled `noUncheckedIndexedAccess` individually over the last several PRs. Left that way it is **opt-in**: a workspace added tomorrow inherits `tsconfig.base.json` and would silently build without index safety — and nothing would report it. The checks would all be green.

This moves the flag into the base config and deletes the twelve copies, so it becomes the default and new workspaces get it for free.

## Verification

Confirmed with `tsc --showConfig` in each workspace that the flag still resolves through inheritance:

| | |
| --- | --- |
| apps | admin, store, studio, payments, auth, landing, playground |
| packages | api, ui, shared, auth, app-components |

All twelve report the flag as effective.

`pnpm typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt