### PR TITLE
test(e2e): make expect-expect truthful and promote it to an error [GH-000]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,7 @@ If any fail, keep in app's `shared/` folder instead.
 - [Testing](.claude/rules/testing.md)
 - [Checkout Stock Integrity](.claude/rules/checkout-stock-integrity.md)
 - [Checkout Stock Integrity Standard](docs/standards/checkout-stock-integrity.md)
+- [Quality Gates](docs/standards/quality-gates.md) — what the checks verify, what is staged, and the gates that were found not to work
 - [E2E Selectors](.claude/rules/e2e-selectors.md)
 - [Build Checks](.claude/rules/build-checks.md)
 - [Code Review Standards](.claude/rules/code-review-standards.md)

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -1,0 +1,93 @@
+# Quality Gates
+
+> What the automated checks actually verify, which ones are staged, and the
+> gates that were found not to work.
+
+This document exists because of a recurring defect found across this codebase:
+**checks that exist, report green, and structurally cannot detect the thing
+they are named after.** A gate nobody has tried to make fail is not yet a gate.
+
+---
+
+## The rule
+
+When you add or promote a check, prove it can fail. Write the violation,
+watch the check reject it, then delete the violation. Record here what you
+proved.
+
+---
+
+## TypeScript
+
+`noUncheckedIndexedAccess` is set in `tsconfig.base.json`, so every workspace
+inherits it and a new workspace gets it without opting in.
+
+It was enabled workspace by workspace and found real defects, not just noise:
+
+| Defect                                                                                                                                   | Where                                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| A `finally` block whose `return` discarded any in-flight exception                                                                       | store cart context                                              |
+| The same drag-reorder `splice` bug three times: the removed element was inserted back without checking it existed                        | studio product table, payments display and form section editors |
+| Four state updaters that would write `{ ...undefined, ...partial }` — a record missing every required field — when handed a stale index  | admin template editor                                           |
+| `email.split("@")[0]` used as a display name, which is only non-empty for a well-formed address                                          | four call sites across store and admin                          |
+| `PERMISSION_TEMPLATES` annotated `Record<string, string[]>`, which erased its literal keys and collapsed `TemplateKey` to plain `string` | admin user permissions                                          |
+
+---
+
+## ESLint — Playwright rules
+
+The `eslint-plugin-playwright` recommended set applies to `apps/*/e2e/**`.
+Before this was configured the plugin matched only `apps/*/src`, so 26 spec
+files had no rules applied at all.
+
+`playwright/expect-expect` is an **error**, not a warning. A test that asserts
+nothing passes no matter how the product behaves, which makes it the one
+defect a test suite cannot detect on its own.
+
+Making it truthful took configuration. It reported 11 violations and **all 11
+were false**: three were Playwright setup/teardown projects that use `test()`
+for fixture work, and eight were tests whose assertions live in a helper the
+rule cannot see through. Every helper listed in `assertFunctionNames` was
+checked to contain real assertions. A rule with no true positives is noise
+that trains people to ignore it — and would hide the first real case.
+
+Proved it fires: an assertion-free spec is rejected as an error, and the same
+file named `*.setup.ts` is correctly exempt.
+
+The remaining rules are staged as warnings with their counts recorded in
+`eslint.config.mjs`, to be driven to zero and promoted one at a time. Do not
+run `eslint --fix` blindly over them: `prefer-web-first-assertions` rewrote
+`const href = await link.getAttribute("href")` into `const href = link`,
+silently turning a string into a Locator and breaking three assertions below
+it. Typecheck caught it. Review every hunk.
+
+---
+
+## Known gaps
+
+### An E2E test that disables itself
+
+`apps/store/e2e/product-detail-seller-card.spec.ts` reads:
+
+```ts
+const supabase = await getSupabaseAdmin();
+if (!supabase) return test.skip();
+const { data: product } = await supabase.from("products")…;
+if (!product) return test.skip();
+```
+
+Both branches turn a missing precondition into a skip. If the E2E database
+holds no product with a `seller_id`, the seller-card assertion never runs and
+the suite still reports green.
+
+The durable fix is for the test to seed its own product instead of querying
+for one that may not exist. That needs a store-side seeding helper — the auth
+suite's `createProduct` drives the studio UI and is not reusable here.
+
+### Permanently skipped OAuth tests
+
+`discord-login.spec.ts` and `google-login.spec.ts` call `test.skip(true, …)`
+unconditionally. The reason is real: both providers block automated browsers
+and the tests need a pre-seeded profile. They are manual-only by design, but
+they are also coverage the suite does not have — treat the OAuth paths as
+untested by CI.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,11 +49,45 @@ const playwrightConfig = {
     "playwright/no-conditional-in-test": "warn", // 31
     "playwright/no-useless-not": "warn", // 19 (auto-fixable, safe)
     "playwright/prefer-web-first-assertions": "warn", // 15 (auto-fix is NOT safe here)
-    "playwright/expect-expect": "warn", // 11 — tests that assert nothing
+    // expect-expect is an ERROR, not a warning: a test that asserts nothing
+    // passes no matter how the product behaves, so it is the one defect a test
+    // suite cannot detect on its own. It reported 11 violations before this
+    // configuration and all 11 were false: 3 were Playwright setup/teardown
+    // projects (excluded below) and 8 were tests whose assertions live in a
+    // helper the rule cannot see through. Each helper named here was checked to
+    // contain real assertions. With the rule reading correctly it reports zero,
+    // so it can block CI and a genuinely assertion-free test gets caught.
+    "playwright/expect-expect": [
+      "error",
+      {
+        assertFunctionNames: [
+          "expectVisible",
+          "expectHidden",
+          "expectAuthenticatedAcrossApps",
+          "createProduct",
+          "createPaymentMethod",
+          "setPermissions",
+        ],
+      },
+    ],
     "playwright/no-conditional-expect": "warn", // 5
     "playwright/no-skipped-test": "warn", // 5
     "playwright/no-force-option": "warn", // 4
     "playwright/consistent-spacing-between-blocks": "warn", // 1
+  },
+};
+
+// Playwright "setup" and "teardown" projects use test() to run fixture work
+// (seeding a session, cleaning up users). They legitimately assert nothing, so
+// expect-expect does not apply to them.
+const playwrightSetupConfig = {
+  files: [
+    "apps/*/e2e/**/*.setup.ts",
+    "apps/*/e2e/**/*.teardown.ts",
+    "apps/*/e2e/**/setup-*.ts",
+  ],
+  rules: {
+    "playwright/expect-expect": "off",
   },
 };
 
@@ -1678,6 +1712,7 @@ const eslintConfig = defineConfig([
     },
   },
   playwrightConfig,
+  playwrightSetupConfig,
 ]);
 
 export default eslintConfig;


### PR DESCRIPTION
## Summary

A test that asserts nothing passes no matter how the product behaves — the one defect a test suite cannot detect on its own. Worth blocking CI, but only once the rule reports the truth.

## It reported 11 violations. All 11 were false.

| | |
| --- | --- |
| 3 | Playwright **setup/teardown projects** that use `test()` to run fixture work (seeding a session, cleaning up users). They legitimately assert nothing — now excluded by a scoped config. |
| 8 | Tests whose assertions live in a **helper the rule cannot see through**. |

Every helper named in `assertFunctionNames` was checked to contain real assertions before being listed:

| Helper | Assertions in body |
| --- | --- |
| `createProduct` | 19 |
| `createPaymentMethod` | 16 |
| `expectAuthenticatedAcrossApps` | 13 |
| `setPermissions` | 6 |
| `expectVisible`, `expectHidden` | ✓ |

A rule with no true positives is noise that trains people to ignore it — and would have hidden the first real case.

## Proved the gate fires

Rather than assuming it works, I wrote a violation and watched it get rejected:

```
2:1  error  Test has no assertions  playwright/expect-expect
```

…and confirmed the identical file named `*.setup.ts` is correctly exempt (0 hits).

## New: `docs/standards/quality-gates.md`

Records what each check actually verifies, which are staged, and **two gaps found on the way**:

- `product-detail-seller-card.spec.ts` turns a missing fixture into `test.skip()` — if the E2E database holds no product with a `seller_id`, the assertion never runs and the suite still reports green.
- The Discord and Google OAuth tests are `test.skip(true, …)` unconditionally. The reason is real (both providers block automated browsers), but the OAuth paths should be understood as untested by CI.

These findings were living in git-ignored scratch. They belong in the repo.

## Verification

`pnpm lint` (0 errors) · `pnpm typecheck` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt