### PR TITLE
test(e2e): assert access-control invariants directly, re-arm the smoke test [GH-000]

### DIFF
--- a/apps/admin/e2e/reports.spec.ts
+++ b/apps/admin/e2e/reports.spec.ts
@@ -380,24 +380,19 @@ test.describe.serial("Reports page", () => {
 
     try {
       await injectSession(context, limitedUser);
-      const response = await page.goto(`${getAdminBaseUrl()}/en/reports`, {
+      await page.goto(`${getAdminBaseUrl()}/en/reports`, {
         waitUntil: "networkidle",
       });
 
-      // Either gets redirected away from reports or the API returns 403
-      // The page should NOT show the reports table with real data
-      const isOnReportsPage = page.url().includes("/reports");
-
-      if (isOnReportsPage) {
-        // If still on the page, the table should show an error state (API 403)
-        await page.waitForTimeout(MUTATION_WAIT_MS);
-        await expect(page.getByTestId("report-table")).toBeHidden({
-          timeout: ELEMENT_TIMEOUT_MS,
-        });
-      } else {
-        // Redirected — acceptable outcome
-        expect(response?.status()).not.toBe(200);
-      }
+      // The app may enforce this by redirecting or by returning 403 and
+      // rendering an error state. Either is fine; the invariant is the same
+      // and holds in both cases, so assert it directly rather than branching.
+      // Branching meant that if isOnReportsPage were ever computed wrongly the
+      // test would assert something unrelated and still pass -- on an access
+      // control check.
+      await expect(page.getByTestId("report-table")).toBeHidden({
+        timeout: ELEMENT_TIMEOUT_MS,
+      });
     } finally {
       await deleteTestUser(limitedUser).catch(() => {});
     }

--- a/apps/auth/e2e/smoke-all-apps.spec.ts
+++ b/apps/auth/e2e/smoke-all-apps.spec.ts
@@ -92,19 +92,17 @@ test.describe("Smoke test -- all apps", () => {
         );
       }
 
+      // This is the assertion the test exists for: the session injected once
+      // must be visible in every app's navbar. It used to be wrapped in
+      // `if (isVisible)` with an else branch that only logged, so the test
+      // passed when the navbar showed no user at all -- the exact symptom of
+      // session propagation being broken.
       const navEmail = page.getByTestId("nav-user-email");
-      const isVisible = await navEmail
-        .isVisible({ timeout: 5000 })
-        .catch(() => false);
-
-      if (isVisible) {
-        await expect(navEmail).not.toBeEmpty();
-        console.log(`[smoke] ${appName} (${url}) -- navbar shows user email`);
-      } else {
-        console.log(
-          `[smoke] ${appName} (${url}) -- navbar does NOT show user email`,
-        );
-      }
+      await expect(
+        navEmail,
+        `${appName} (${url}) navbar does not show the signed-in user`,
+      ).toBeVisible({ timeout: 5000 });
+      await expect(navEmail).not.toBeEmpty();
     }
   });
 

--- a/apps/payments/e2e/seller-reports.spec.ts
+++ b/apps/payments/e2e/seller-reports.spec.ts
@@ -367,20 +367,16 @@ test.describe.serial("Seller Reports page", () => {
     page,
   }) => {
     // No session injection
-    const response = await page.goto(`${getPaymentsBaseUrl()}/en/reports`, {
+    await page.goto(`${getPaymentsBaseUrl()}/en/reports`, {
       waitUntil: "networkidle",
     });
 
-    // Should redirect to login or return a non-200 status
-    const isOnReportsPage =
-      page.url().includes("/reports") && response?.status() === 200;
-    if (isOnReportsPage) {
-      // API call should fail with 401 and show error state
-      await page.waitForTimeout(MUTATION_WAIT_MS);
-      await expect(page.getByTestId("seller-report-table")).toBeHidden();
-    } else {
-      // Redirect happened — acceptable
-      expect(page.url()).not.toContain("/reports");
-    }
+    // The app may redirect to login or serve the page and fail the API with
+    // 401. Either is fine; an unauthenticated visitor must not see report data
+    // in either case, so assert that invariant directly instead of branching
+    // on which enforcement path ran.
+    await expect(page.getByTestId("seller-report-table")).toBeHidden({
+      timeout: ELEMENT_TIMEOUT_MS,
+    });
   });
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,7 @@ const playwrightConfig = {
     // warnings, so dropping them from the staged list below is not enough --
     // verified by planting a violation and watching it fail.
     "playwright/no-useless-not": "error",
+    "playwright/no-conditional-expect": "error",
     "playwright/consistent-spacing-between-blocks": "error",
     //
     // The rules below have real violations today and are warnings with their
@@ -78,7 +79,6 @@ const playwrightConfig = {
         ],
       },
     ],
-    "playwright/no-conditional-expect": "warn", // 5
     "playwright/no-skipped-test": "warn", // 5
     "playwright/no-force-option": "warn", // 4
   },


### PR DESCRIPTION
## Summary

Drives `no-conditional-expect` to zero and promotes it to an **error**. All five sites were assertions that might never run.

## Two access-control tests asserted different things in different branches

`admin/reports.spec.ts` (403) and `payments/seller-reports.spec.ts` (401) both branched on which enforcement path the app took:

```ts
const isOnReportsPage = page.url().includes("/reports");
if (isOnReportsPage) {
  await expect(page.getByTestId("report-table")).toBeHidden(…);
} else {
  expect(response?.status()).not.toBe(200);   // ← something else entirely
}
```

If the branch condition were ever computed wrongly, the test would assert something unrelated and still pass — **on an access-control check**.

The invariant is the same either way and holds in both branches: *a user without permission must not see report data.* Whether the app redirects or serves the page with a failed API call, the table must not be visible. Both tests now assert that directly, with no conditional. The `waitForTimeout` each used before its assertion is gone too — `toBeHidden` already polls.

## The smoke test could not fail for the thing it names

`smoke-all-apps.spec.ts` checks that one injected session is visible in every app's navbar. It read:

```ts
if (isVisible) {
  await expect(navEmail).not.toBeEmpty();
} else {
  console.log(`[smoke] ${appName} -- navbar does NOT show user email`);
}
```

So the test **passed when the navbar showed no user at all** — the exact symptom of session propagation being broken, which is the only thing that test exists to catch.

It now asserts visibility, with the app name and URL in the failure message.

## Verification

Planted conditional expect → `error  Avoid calling expect conditionally`. Suite → 0. `typecheck` · `lint` · `format:check`

Note: the smoke change makes a previously toothless assertion real across all seven apps. If any app does not surface the signed-in user, this PR's E2E run is where that shows up — which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt