### PR TITLE
test(e2e): stop forcing cart clicks in the purchase flows [GH-000]

### DIFF
--- a/apps/auth/e2e/delegated-admin-flow.spec.ts
+++ b/apps/auth/e2e/delegated-admin-flow.spec.ts
@@ -263,10 +263,13 @@ test.describe.serial("Delegated admin purchase flow", () => {
     await snap(page, "buyer-added-to-cart");
 
     // Open cart and checkout
-    await page
-      .getByTestId("cart-drawer-trigger")
-      .first()
-      .click({ force: true });
+    // No `force: true` here. Forcing the click skips Playwright's actionability
+    // checks, so this passed even if the trigger were covered or disabled --
+    // i.e. even if a real buyer could not open their cart. Assert it is
+    // actually clickable, then click it normally.
+    const cartTrigger = page.getByTestId("cart-drawer-trigger").first();
+    await expect(cartTrigger).toBeVisible();
+    await cartTrigger.click();
     await expect(page.getByTestId("cart-drawer-items")).toBeVisible();
     await snap(page, "buyer-cart-open");
 

--- a/apps/auth/e2e/full-purchase-flow.spec.ts
+++ b/apps/auth/e2e/full-purchase-flow.spec.ts
@@ -392,10 +392,13 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
     await snap(page, "store-added-beta");
 
     // ── Open cart and verify both items ────────────────────────
-    await page
-      .getByTestId("cart-drawer-trigger")
-      .first()
-      .click({ force: true });
+    // No `force: true` here. Forcing the click skips Playwright's actionability
+    // checks, so this passed even if the trigger were covered or disabled --
+    // i.e. even if a real buyer could not open their cart. Assert it is
+    // actually clickable, then click it normally.
+    const cartTrigger = page.getByTestId("cart-drawer-trigger").first();
+    await expect(cartTrigger).toBeVisible();
+    await cartTrigger.click();
     await expect(page.getByTestId("cart-drawer-items")).toBeVisible();
 
     // Should see two seller groups

--- a/apps/auth/e2e/receipt-delegate-flow.spec.ts
+++ b/apps/auth/e2e/receipt-delegate-flow.spec.ts
@@ -212,10 +212,13 @@ test.describe.serial("Delegate sees buyer receipt", () => {
     await page.getByTestId("hero-add-to-cart").click();
     await page.waitForTimeout(MUTATION_WAIT_MS);
 
-    await page
-      .getByTestId("cart-drawer-trigger")
-      .first()
-      .click({ force: true });
+    // No `force: true` here. Forcing the click skips Playwright's actionability
+    // checks, so this passed even if the trigger were covered or disabled --
+    // i.e. even if a real buyer could not open their cart. Assert it is
+    // actually clickable, then click it normally.
+    const cartTrigger = page.getByTestId("cart-drawer-trigger").first();
+    await expect(cartTrigger).toBeVisible();
+    await cartTrigger.click();
     await expect(page.getByTestId("cart-drawer-items")).toBeVisible();
     await page.getByTestId("cart-checkout").click();
     await page.waitForURL(

--- a/apps/auth/e2e/receipt-reference-flow.spec.ts
+++ b/apps/auth/e2e/receipt-reference-flow.spec.ts
@@ -180,10 +180,13 @@ test.describe.serial("Receipt + reference number payment flow", () => {
     await snap(page, "buyer-product-added");
 
     // Open cart and proceed to checkout
-    await page
-      .getByTestId("cart-drawer-trigger")
-      .first()
-      .click({ force: true });
+    // No `force: true` here. Forcing the click skips Playwright's actionability
+    // checks, so this passed even if the trigger were covered or disabled --
+    // i.e. even if a real buyer could not open their cart. Assert it is
+    // actually clickable, then click it normally.
+    const cartTrigger = page.getByTestId("cart-drawer-trigger").first();
+    await expect(cartTrigger).toBeVisible();
+    await cartTrigger.click();
     await expect(page.getByTestId("cart-drawer-items")).toBeVisible();
     await page.getByTestId("cart-checkout").click();
     await page.waitForURL(

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,7 @@ const playwrightConfig = {
     // verified by planting a violation and watching it fail.
     "playwright/no-useless-not": "error",
     "playwright/no-conditional-expect": "error",
+    "playwright/no-force-option": "error",
     "playwright/consistent-spacing-between-blocks": "error",
     //
     // The rules below have real violations today and are warnings with their
@@ -80,7 +81,6 @@ const playwrightConfig = {
       },
     ],
     "playwright/no-skipped-test": "warn", // 5
-    "playwright/no-force-option": "warn", // 4
   },
 };
 


### PR DESCRIPTION
## Summary

Drives `no-force-option` to zero and promotes it to an **error**.

All four sites were the same call, in a purchase flow:

```ts
await page.getByTestId("cart-drawer-trigger").first().click({ force: true });
```

`force: true` skips Playwright's actionability checks. These tests passed even if the cart trigger were covered by an overlay, disabled, or off-screen — that is, **even if a real buyer could not open their cart**. Bypassing actionability is a poor trade anywhere; in the checkout path it defeats the test's purpose.

Each now asserts the trigger is visible and clicks it normally, so an obstruction fails the test instead of being stepped over.

| File | |
| --- | --- |
| `delegated-admin-flow.spec.ts` | ✓ |
| `full-purchase-flow.spec.ts` | ✓ |
| `receipt-delegate-flow.spec.ts` | ✓ |
| `receipt-reference-flow.spec.ts` | ✓ |

## Verification

Planted forced click → `error  Unexpected use of { force: true } option`. Suite → 0. `typecheck` · `lint` · `format:check`

If the trigger genuinely is obstructed in any of these flows, this PR's E2E run is where it surfaces — which is the point of removing the bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt