### PR TITLE
chore: delete eight superseded provider files, declare a missing dep [GH-000]

### DIFF
--- a/apps/admin/src/shared/infrastructure/providers/ApiAuthBootstrap.tsx
+++ b/apps/admin/src/shared/infrastructure/providers/ApiAuthBootstrap.tsx
@@ -1,3 +1,0 @@
-"use client";
-
-export { ApiAuthBootstrap } from "shared/providers";

--- a/apps/admin/src/shared/infrastructure/providers/QueryProvider.tsx
+++ b/apps/admin/src/shared/infrastructure/providers/QueryProvider.tsx
@@ -1,3 +1,0 @@
-"use client";
-
-export { QueryProvider } from "shared/providers";

--- a/apps/admin/src/shared/infrastructure/providers/index.ts
+++ b/apps/admin/src/shared/infrastructure/providers/index.ts
@@ -1,4 +1,2 @@
-export { QueryProvider } from "./QueryProvider";
 export { MSWProvider } from "./MSWProvider";
-export { ApiAuthBootstrap } from "./ApiAuthBootstrap";
 export { ThemeProvider } from "./ThemeProvider";

--- a/apps/auth/src/shared/infrastructure/providers/QueryProvider.tsx
+++ b/apps/auth/src/shared/infrastructure/providers/QueryProvider.tsx
@@ -1,3 +1,0 @@
-"use client";
-
-export { QueryProvider } from "shared/providers";

--- a/apps/auth/src/shared/infrastructure/providers/index.ts
+++ b/apps/auth/src/shared/infrastructure/providers/index.ts
@@ -1,2 +1,1 @@
-export { QueryProvider } from "./QueryProvider";
 export { ThemeProvider } from "./ThemeProvider";

--- a/apps/payments/src/shared/infrastructure/providers/ApiAuthBootstrap.tsx
+++ b/apps/payments/src/shared/infrastructure/providers/ApiAuthBootstrap.tsx
@@ -1,3 +1,0 @@
-"use client";
-
-export { ApiAuthBootstrap } from "shared/providers";

--- a/apps/payments/src/shared/infrastructure/providers/QueryProvider.tsx
+++ b/apps/payments/src/shared/infrastructure/providers/QueryProvider.tsx
@@ -1,3 +1,0 @@
-"use client";
-
-export { QueryProvider } from "shared/providers";

--- a/apps/payments/src/shared/infrastructure/providers/index.ts
+++ b/apps/payments/src/shared/infrastructure/providers/index.ts
@@ -1,4 +1,2 @@
-export { QueryProvider } from "./QueryProvider";
 export { MSWProvider } from "./MSWProvider";
-export { ApiAuthBootstrap } from "./ApiAuthBootstrap";
 export { ThemeProvider } from "./ThemeProvider";

--- a/apps/playground/src/shared/infrastructure/providers/QueryProvider.tsx
+++ b/apps/playground/src/shared/infrastructure/providers/QueryProvider.tsx
@@ -1,3 +1,0 @@
-"use client";
-
-export { QueryProvider } from "shared/providers";

--- a/apps/playground/src/shared/infrastructure/providers/index.ts
+++ b/apps/playground/src/shared/infrastructure/providers/index.ts
@@ -1,2 +1,1 @@
-export { QueryProvider } from "./QueryProvider";
 export { ThemeProvider } from "./ThemeProvider";

--- a/apps/studio/src/shared/infrastructure/providers/ApiAuthBootstrap.tsx
+++ b/apps/studio/src/shared/infrastructure/providers/ApiAuthBootstrap.tsx
@@ -1,3 +1,0 @@
-"use client";
-
-export { ApiAuthBootstrap } from "shared/providers";

--- a/apps/studio/src/shared/infrastructure/providers/QueryProvider.tsx
+++ b/apps/studio/src/shared/infrastructure/providers/QueryProvider.tsx
@@ -1,3 +1,0 @@
-"use client";
-
-export { QueryProvider } from "shared/providers";

--- a/apps/studio/src/shared/infrastructure/providers/index.ts
+++ b/apps/studio/src/shared/infrastructure/providers/index.ts
@@ -1,4 +1,2 @@
-export { QueryProvider } from "./QueryProvider";
 export { MSWProvider } from "./MSWProvider";
-export { ApiAuthBootstrap } from "./ApiAuthBootstrap";
 export { ThemeProvider } from "./ThemeProvider";

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
+    "@vitest/coverage-v8": "^4.1.5",
     "next": "16.2.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -870,6 +870,9 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
## Summary

Five apps moved to the shared providers factory and **kept their local copies**. Nothing imported them.

| App | Uses | Local files |
| --- | --- | --- |
| studio, payments, admin | `createAppRuntimeProviders` | `QueryProvider.tsx` + `ApiAuthBootstrap.tsx` — deleted |
| auth, playground | `QueryOnlyProviders` | `QueryProvider.tsx` — deleted |
| store, landing | hand-rolled | local `QueryProvider` genuinely used — **kept** |

Each deletion verified to have zero references outside its own file and the barrel that re-exported it.

`store` has a reason to hand-roll — `CartProvider`, `FlyToCartProvider` and the nuqs adapter. `landing` looks like it could adopt the shared factory, but that's a behaviour change rather than a deletion, so it isn't done here.

This was found by chasing what looked alarming in knip's output: *"`QueryProvider` unused in payments"* would mean TanStack Query has no provider mounted. It turned out the shared factory supplies it — and the local file was a leftover.

## A missing dependency declaration

knip's unlisted-dependency check caught `packages/api` using `@vitest/coverage-v8` in `vitest.config.mts` **without declaring it**. Every other workspace declares it; `packages/api` only worked because pnpm hoisted someone else's copy. Now declared.

## Deliberately not touched

86 of the remaining 160 unused exports are **barrel re-exports**, where consumers import deep paths instead of going through `index.ts`. That's the architecture-rule contradiction already recorded in `docs/standards/quality-gates.md` — the rule mandates feature barrels while its own examples show deep paths. Pruning them would pre-empt a decision that isn't mine to make.

## Verification

`typecheck` · `lint` · `format:check` · api tests · `sherif` · `syncpack` · **full build of all seven apps**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt