### PR TITLE
chore: stop jscpd and CI's change filter from lying [GH-000]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,24 @@ jobs:
               - 'knip.json'
               - 'stylelint.config.*'
               - 'vitest.config.*'
+              # Each of these changes how the code is built, checked or resolved,
+              # and each was previously treated as docs-only. This PR is the
+              # proof: it edits .jscpd.json, and CI skipped the quality,
+              # unit-test, build and E2E jobs entirely.
+              - '.jscpd.json'
+              - '.secretlintrc.*'
+              - '.secretlintignore'
+              - '.syncpackrc.*'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
+              - '.nvmrc'
+              - 'orval.config.*'
+              - '.prettierrc*'
+              - '.prettierignore'
+              - '.gitattributes'
+              - '.env.ci'
+              - '.husky/**'
+              - 'config/**'
             code:
               - 'apps/**'
               - 'packages/**'
@@ -93,6 +111,24 @@ jobs:
               - 'knip.json'
               - 'stylelint.config.*'
               - 'vitest.config.*'
+              # Each of these changes how the code is built, checked or resolved,
+              # and each was previously treated as docs-only. This PR is the
+              # proof: it edits .jscpd.json, and CI skipped the quality,
+              # unit-test, build and E2E jobs entirely.
+              - '.jscpd.json'
+              - '.secretlintrc.*'
+              - '.secretlintignore'
+              - '.syncpackrc.*'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
+              - '.nvmrc'
+              - 'orval.config.*'
+              - '.prettierrc*'
+              - '.prettierignore'
+              - '.gitattributes'
+              - '.env.ci'
+              - '.husky/**'
+              - 'config/**'
               # CI could not previously validate changes to itself: a workflow
               # edit counted as docs-only, so every quality/test/build job
               # skipped. Same for schema and container changes.

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -17,7 +17,13 @@
     "**/*.test.*",
     "**/*.spec.*",
     "**/mocks/**",
-    "**/test/**"
+    "**/test/**",
+    "**/src/app/**/layout.tsx",
+    "**/src/app/**/error.tsx",
+    "**/src/app/**/global-error.tsx",
+    "**/src/app/**/not-found.tsx",
+    "**/src/app/**/loading.tsx",
+    "**/src/app/**/template.tsx"
   ],
   "format": ["typescript", "tsx", "javascript", "jsx"],
   "absolute": true,

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -267,3 +267,29 @@ knows where those screens are heading.
 
 The Excel exporters are the strongest candidate: three copies of worksheet
 construction is knowledge duplication, not coincidence.
+
+---
+
+## CI's change filter had holes
+
+`ci.yml` skips the quality, unit-test, build and E2E jobs for docs-only PRs,
+decided by a path filter. The filter listed some tool configs and not others,
+so a change to an unlisted one was treated as documentation and went
+completely unverified.
+
+This was found the way these things should be: the PR that edited
+`.jscpd.json` had every check skipped.
+
+Added to the filter: `.jscpd.json`, `.secretlintrc.*`, `.secretlintignore`,
+`.syncpackrc.*`, `pnpm-workspace.yaml`, `.npmrc`, `.nvmrc`, `orval.config.*`,
+`.prettierrc*`, `.prettierignore`, `.gitattributes`, `.env.ci`, `.husky/**`
+and `config/**`.
+
+Two of those matter beyond tidiness. `pnpm-workspace.yaml` defines which
+workspaces exist, so adding or removing one would have skipped CI entirely.
+`.secretlintrc.*` and `.secretlintignore` configure secret scanning: weakening
+them was a docs-only change.
+
+If you add a root-level config file, add it to **both** the `tooling` and
+`code` filters in `.github/workflows/ci.yml`. A config that changes behaviour
+but not the filter is invisible to CI.

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -230,3 +230,40 @@ and the failure mode for wait-condition changes is _intermittent_ flakiness,
 which one green CI run does not disprove. Rewriting 70 wait conditions on the
 strength of a single pipeline would trade a visible problem for an invisible
 one. Do these per app, with someone able to run the suite repeatedly.
+
+---
+
+## jscpd
+
+Configured, and still **not enforced in CI**, but its number is now honest.
+
+It reported 7.75% duplication against a 5% threshold. A chunk of that was the
+framework, not the codebase: Next.js requires `layout.tsx`, `error.tsx`,
+`global-error.tsx`, `not-found.tsx`, `loading.tsx` and `template.tsx` to exist
+as real files at specific paths in every app. Seven apps means seven
+near-identical copies of each, and they cannot be deduplicated -- the shared
+part is already extracted (`GlobalErrorFallback` lives in
+`packages/app-components`; what remains is the `"use client"` directive, a
+Sentry `useEffect`, and a default export). Measuring those as duplication
+measures Next.js.
+
+Excluding them takes the figure from **7.75% to 6%**.
+
+The remaining 6% is real, and is concentrated in four places:
+
+| Where                                                                                                                  | Clones | What it is                                                   |
+| ---------------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------ |
+| `studio` `SectionItems{Accordion,Cards,Gallery,TwoColumn}.tsx`                                                         | 21     | four renderers of the same section data in different layouts |
+| `admin` / `payments` report UI (`ReportTable`, `ReportFiltersBar`, `SellerReportFiltersBar`)                           | 10     | two apps with near-identical report screens                  |
+| `admin` / `payments` Excel export (`exportOrdersToExcel`, `exportDelegatedOrdersToExcel`, `exportSellerOrdersToExcel`) | 8      | the same worksheet-building code three times                 |
+| `packages/ui` (`status-card`, `mini-area-chart`)                                                                       | 4      | variant components                                           |
+
+Driving this under 5% needs component-extraction decisions that are product
+calls, not mechanical cleanup -- whether admin's and payments' report screens
+_should_ share a component, or are expected to diverge. This repo's own rules
+say to favour KISS over DRY and to treat coincidental duplication as something
+to leave alone, so the extraction should be a deliberate choice by someone who
+knows where those screens are heading.
+
+The Excel exporters are the strongest candidate: three copies of worksheet
+construction is knowledge duplication, not coincidence.


### PR DESCRIPTION
## Two related fixes, both about a check reporting something other than the truth.

---

## 1. jscpd was measuring Next.js, not this repo

It reported **7.75%** duplication against a 5% threshold. Part of that was the framework.

Next.js requires `layout.tsx`, `error.tsx`, `global-error.tsx`, `not-found.tsx`, `loading.tsx` and `template.tsx` to exist as **real files at specific paths in every app**. Seven apps means seven near-identical copies of each, and they cannot be deduplicated — the shared part is already extracted (`GlobalErrorFallback` lives in `packages/app-components`), and what remains is a `"use client"` directive, a Sentry `useEffect`, and a default export. All seven `global-error.tsx` files are byte-identical for exactly that reason.

**Excluding them: 7.75% → 6%.**

### The remaining 6% is real

| Where | Clones | What it is |
| --- | --- | --- |
| `studio` `SectionItems{Accordion,Cards,Gallery,TwoColumn}.tsx` | 21 | four renderers of the same data in different layouts |
| `admin` / `payments` report UI | 10 | two apps with near-identical report screens |
| `admin` / `payments` Excel export | 8 | the same worksheet code three times |
| `packages/ui` (`status-card`, `mini-area-chart`) | 4 | variant components |

Not refactored here — driving it under 5% needs product calls about whether admin's and payments' report screens *should* share a component. This repo's rules say to favour KISS over DRY and leave coincidental duplication alone.

*(The Excel exporters — named as the strongest candidate — are extracted in #370.)*

---

## 2. CI treated root tool configs as docs-only

`ci.yml` skips the quality, unit-test, build and E2E jobs for docs-only PRs, decided by a path filter. That filter listed *some* root configs and not others, so a change to an unlisted one went **completely unverified**.

Found the way these things should be: **this PR edits `.jscpd.json`, and every check on it was skipped.**

Added to both the `tooling` and `code` filters:

`.jscpd.json` · `.secretlintrc.*` · `.secretlintignore` · `.syncpackrc.*` · `pnpm-workspace.yaml` · `.npmrc` · `.nvmrc` · `orval.config.*` · `.prettierrc*` · `.prettierignore` · `.gitattributes` · `.env.ci` · `.husky/**` · `config/**`

Two matter beyond tidiness:

- **`pnpm-workspace.yaml`** defines which workspaces exist — adding or removing one would have skipped CI entirely.
- **`.secretlintrc.*` / `.secretlintignore`** configure secret scanning. Weakening them was, until now, a docs-only change.

Both recorded in `docs/standards/quality-gates.md`, with a note to add future root configs to both filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt