### PR TITLE
refactor(ui): rename Label to StatusLabel [GH-000]

### DIFF
--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -334,15 +334,19 @@ computed colour contrast against the real theme, focus order across a whole
 page, or a heading hierarchy that only exists once a layout composes.
 `@axe-core/playwright` against each app's main routes is the missing piece.
 
-### A naming hazard, deliberately left in place
+### A naming hazard, now removed
 
-`Label` in `packages/ui` is a **status badge that renders a `<span>`**, not a
-form label. The name collides with the shadcn convention, where `label.tsx`
+`Label` in `packages/ui` was a **status badge that rendered a `<span>`**, not a
+form label. The name collided with the shadcn convention, where `label.tsx`
 _is_ the form label — so anyone importing `Label` to label an input would
 silently get no association at all, which is the exact defect the `label` axe
-rule exists to catch. Nothing imports it today, and a test now pins the
-behaviour so the trap is at least written down. Renaming it to `StatusLabel`
-would be safe (no consumers) and is worth doing.
+rule exists to catch. That is how it was found: the first draft of the
+accessibility suite assumed `Label` was a form label, and axe failed.
+
+It is now `StatusLabel` in `StatusLabel.tsx`. Nothing imported it, so the
+rename cost nothing, and it frees `label.tsx` for a real form label — there
+isn't one in this package yet, which is worth knowing before building a form
+against `ui`. A test pins the shape so the trap cannot come back.
 
 ---
 

--- a/packages/ui/src/components/StatusLabel.test.tsx
+++ b/packages/ui/src/components/StatusLabel.test.tsx
@@ -1,72 +1,78 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 
-import { Label } from "./label";
+import { StatusLabel } from "./StatusLabel";
 
-describe("Label", () => {
+describe("StatusLabel", () => {
   it("renders children", () => {
-    render(<Label>Healthy</Label>);
+    render(<StatusLabel>Healthy</StatusLabel>);
     expect(screen.getByText("Healthy")).toBeInTheDocument();
   });
 
   it("renders as a span element", () => {
-    render(<Label>Status</Label>);
+    render(<StatusLabel>Status</StatusLabel>);
     expect(screen.getByText("Status").tagName).toBe("SPAN");
   });
 
   it("applies healthy variant by default", () => {
-    render(<Label>OK</Label>);
+    render(<StatusLabel>OK</StatusLabel>);
     expect(screen.getByText("OK").className).toContain("bg-success");
   });
 
   it("applies attention variant", () => {
-    render(<Label variant="attention">Warn</Label>);
+    render(<StatusLabel variant="attention">Warn</StatusLabel>);
     expect(screen.getByText("Warn").className).toContain("bg-warning");
   });
 
   it("applies critical variant", () => {
-    render(<Label variant="critical">Fail</Label>);
+    render(<StatusLabel variant="critical">Fail</StatusLabel>);
     expect(screen.getByText("Fail").className).toContain("bg-destructive");
   });
 
   it("applies info variant", () => {
-    render(<Label variant="info">Note</Label>);
+    render(<StatusLabel variant="info">Note</StatusLabel>);
     expect(screen.getByText("Note").className).toContain("bg-info");
   });
 
   it("applies brand variant", () => {
-    render(<Label variant="brand">Brand</Label>);
+    render(<StatusLabel variant="brand">Brand</StatusLabel>);
     expect(screen.getByText("Brand").className).toContain("bg-brand");
   });
 
   it("shows icon by default", () => {
-    const { container } = render(<Label>With Icon</Label>);
+    const { container } = render(<StatusLabel>With Icon</StatusLabel>);
     const svg = container.querySelector("svg");
     expect(svg).toBeInTheDocument();
     expect(svg).toHaveAttribute("aria-hidden", "true");
   });
 
   it("hides icon when showIcon is false", () => {
-    const { container } = render(<Label showIcon={false}>No Icon</Label>);
+    const { container } = render(
+      <StatusLabel showIcon={false}>No Icon</StatusLabel>,
+    );
     expect(container.querySelector("svg")).toBeNull();
   });
 
   it("shows icon wrapper for healthy variant", () => {
-    const { container } = render(<Label variant="healthy">OK</Label>);
+    const { container } = render(
+      <StatusLabel variant="healthy">OK</StatusLabel>,
+    );
     // healthy variant has showWrapper: true, so there's a wrapping span around the icon
     const wrapper = container.querySelector("span.rounded-full.border");
     expect(wrapper).toBeInTheDocument();
   });
 
   it("does not show icon wrapper for attention variant", () => {
-    const { container } = render(<Label variant="attention">Warn</Label>);
+    const { container } = render(
+      <StatusLabel variant="attention">Warn</StatusLabel>,
+    );
     // attention variant has showWrapper: false, no wrapping span
     const wrapper = container.querySelector("span.rounded-full.border");
     expect(wrapper).toBeNull();
   });
 
   it("applies custom className", () => {
-    render(<Label className="my-class">Test</Label>);
+    render(<StatusLabel className="my-class">Test</StatusLabel>);
     expect(screen.getByText("Test").className).toContain("my-class");
   });
 });

--- a/packages/ui/src/components/StatusLabel.tsx
+++ b/packages/ui/src/components/StatusLabel.tsx
@@ -6,10 +6,16 @@ import * as React from "react";
 import { cn } from "@ui/utils/cn";
 
 /**
- * Label - Status label with solid colors and icons.
+ * StatusLabel - Status badge with solid colours and icons.
  * For process statuses like "Healthy", "Attention", "Critical".
+ *
+ * Renamed from `Label`. It renders a <span> and has no htmlFor, so under the
+ * old name it collided with the shadcn convention where label.tsx IS the form
+ * label -- importing `Label` to label an input gave no association at all, the
+ * exact defect axe's `label` rule exists to catch. Nothing imported it, so the
+ * rename cost nothing; it also frees `label.tsx` for a real form label.
  */
-const labelVariants = cva(
+const statusLabelVariants = cva(
   "inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium",
   {
     variants: {
@@ -33,7 +39,7 @@ const labelVariants = cva(
  * Maps variant to default icon and whether to show icon wrapper (circle border).
  */
 const STATUS_ICONS: Record<
-  NonNullable<VariantProps<typeof labelVariants>["variant"]>,
+  NonNullable<VariantProps<typeof statusLabelVariants>["variant"]>,
   { icon: LucideIcon; showWrapper: boolean }
 > = {
   healthy: { icon: Check, showWrapper: true },
@@ -44,10 +50,10 @@ const STATUS_ICONS: Record<
   "brand-soft": { icon: Check, showWrapper: true },
 };
 
-export interface LabelProps
+export interface StatusLabelProps
   extends
     React.HTMLAttributes<HTMLSpanElement>,
-    VariantProps<typeof labelVariants> {
+    VariantProps<typeof statusLabelVariants> {
   /** Show the default icon for this variant */
   showIcon?: boolean;
   /** Custom icon to override the default */
@@ -56,7 +62,7 @@ export interface LabelProps
   showIconWrapper?: boolean;
 }
 
-function Label({
+function StatusLabel({
   className,
   variant = "healthy",
   showIcon = true,
@@ -64,13 +70,16 @@ function Label({
   showIconWrapper,
   children,
   ...props
-}: LabelProps) {
+}: StatusLabelProps) {
   const iconConfig = variant ? STATUS_ICONS[variant] : STATUS_ICONS.healthy;
   const Icon = icon ?? iconConfig.icon;
   const shouldShowWrapper = showIconWrapper ?? iconConfig.showWrapper;
 
   return (
-    <span className={cn(labelVariants({ variant }), className)} {...props}>
+    <span
+      className={cn(statusLabelVariants({ variant }), className)}
+      {...props}
+    >
       {showIcon && (
         <>
           {shouldShowWrapper ? (
@@ -87,4 +96,4 @@ function Label({
   );
 }
 
-export { Label, labelVariants };
+export { StatusLabel, statusLabelVariants };

--- a/packages/ui/src/components/accessibility.test.tsx
+++ b/packages/ui/src/components/accessibility.test.tsx
@@ -27,11 +27,11 @@ import { Chip } from "@ui/components/chip";
 import { CircularProgress } from "@ui/components/CircularProgress";
 import { InfoBadge } from "@ui/components/InfoBadge";
 import { Input } from "@ui/components/input";
-import { Label } from "@ui/components/label";
 import { ProgressBar } from "@ui/components/ProgressBar";
 import { Separator } from "@ui/components/separator";
 import { Skeleton } from "@ui/components/skeleton";
 import { StatusCard } from "@ui/components/StatusCard";
+import { StatusLabel } from "@ui/components/StatusLabel";
 
 async function expectNoViolations(ui: React.ReactElement) {
   const { container } = render(ui);
@@ -71,16 +71,16 @@ describe("shared UI primitives — accessibility", () => {
     expect(results.violations.map((v) => v.id)).toContain("label");
   });
 
-  it("Label is a status badge, not a form label", async () => {
-    // `Label` in this package renders a <span> and carries no htmlFor. The
-    // name collides with the shadcn convention, where label.tsx IS the form
-    // label -- so anyone importing `Label` expecting to label an input would
-    // silently get no association at all. Nothing imports it today.
-    const { container } = render(<Label>Healthy</Label>);
+  it("StatusLabel is a badge, not a form label", async () => {
+    // It renders a <span> and carries no htmlFor. Under its old name, `Label`,
+    // it collided with the shadcn convention where label.tsx IS the form label
+    // -- importing it to label an input gave no association at all. The name
+    // is fixed; this pins the shape so the trap cannot come back.
+    const { container } = render(<StatusLabel>Healthy</StatusLabel>);
 
     expect(container.querySelector("label")).toBeNull();
     expect(container.querySelector("span")).not.toBeNull();
-    await expectNoViolations(<Label>Healthy</Label>);
+    await expectNoViolations(<StatusLabel>Healthy</StatusLabel>);
   });
 
   it("Badge carries its text", async () => {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,7 +16,7 @@ export * from "./components/dropdown-menu";
 export * from "./components/icon-showcase";
 export * from "./components/InfoBadge";
 export * from "./components/input";
-export * from "./components/label";
+export * from "./components/StatusLabel";
 export * from "./components/MiniAreaChart";
 export * from "./components/popover";
 export * from "./components/ProgressBar";


### PR DESCRIPTION
## Summary

`Label` in `packages/ui` rendered a `<span>` and carried no `htmlFor` — a **status badge** for "Healthy", "Attention", "Critical". Not a form label.

The name collided with the shadcn convention, where `label.tsx` **is** the form label. Anyone importing `Label` from `ui` to label an input would have got **no association at all** — exactly the defect axe's `label` rule exists to catch, and one no static check would flag, because the code looks correct:

```tsx
<Label htmlFor="email">Email</Label>   // renders <span>, htmlFor goes nowhere
<Input id="email" />                   // unlabelled
```

That is how I found it: my first draft of the accessibility suite in #371 assumed `Label` was a form label, and axe failed with the `label` rule.

## Why now

Nothing imports it, so the rename costs nothing and isn't a breaking change in practice. Deferring it only widens the window in which someone reaches for the obvious name and gets a silent accessibility bug.

It also frees `label.tsx` for a real form label — which this package **doesn't have**, worth knowing before building a form against `ui`.

## What moved

| Before | After |
| --- | --- |
| `label.tsx` | `StatusLabel.tsx` |
| `Label` | `StatusLabel` |
| `labelVariants` | `statusLabelVariants` |
| `LabelProps` | `StatusLabelProps` |

The accessibility test that pinned the old shape now pins the new one, so the trap can't come back under either name.

## Verification

`typecheck` · `lint` · `format:check` · **228 ui tests** · `cspell` · full build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt