### PR TITLE
chore(lint): lint the whole repo and replace timing waits with real conditions [GH-000]

### DIFF
--- a/apps/admin/e2e/audit-log.spec.ts
+++ b/apps/admin/e2e/audit-log.spec.ts
@@ -1,9 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import {
-  ELEMENT_TIMEOUT_MS,
-  MUTATION_WAIT_MS,
-} from "../../auth/e2e/helpers/constants";
+import { ELEMENT_TIMEOUT_MS } from "../../auth/e2e/helpers/constants";
 import {
   ADMIN_PERMISSIONS,
   createTestUser,
@@ -67,31 +64,21 @@ test.describe.serial("Audit Log page", () => {
     page,
   }) => {
     await injectSession(context, adminUser);
-    // Kept deliberately. The assertion below is negative -- it checks that
-    // something is NOT there. Without a settle window it would pass simply
-    // because the page had not rendered yet, which is a false pass rather
-    // than a flake. Only a positive, retrying assertion makes a wait
-    // redundant.
-    await page.goto(`${getAdminBaseUrl()}/en/audit`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${getAdminBaseUrl()}/en/audit`);
 
-    // Kept deliberately. The assertion below is negative -- it checks that
-    // something is NOT there. Without a settle window it would pass simply
-    // because the page had not rendered yet, which is a false pass rather
-    // than a flake. Only a positive, retrying assertion makes a wait
-    // redundant.
-    await page.waitForTimeout(MUTATION_WAIT_MS);
+    // Anchor on a positive, retrying assertion first: the page has loaded once
+    // it shows either rows or the empty state. That replaces both the
+    // networkidle wait and the fixed sleep, and it is a stronger claim -- it
+    // proves the page rendered rather than assuming a time window sufficed.
+    // It also replaces a pair of one-shot isVisible() reads, which do not
+    // retry and so raced the render they were meant to observe.
+    await expect(
+      page.getByTestId("audit-table").or(page.getByTestId("audit-empty")),
+    ).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
 
-    // The error state must NOT be visible (which would indicate a 406 or network error)
+    // Only now does the negative assertion mean anything: the page is up, so
+    // the error state being absent is a fact rather than a race.
     await expect(page.getByTestId("audit-error")).toBeHidden();
-
-    // Either the table or the empty state must be visible
-    const table = page.getByTestId("audit-table");
-    const empty = page.getByTestId("audit-empty");
-    const tableVisible = await table.isVisible();
-    const emptyVisible = await empty.isVisible();
-    expect(tableVisible || emptyVisible).toBe(true);
   });
 
   test("action type filters update the view without errors", async ({
@@ -107,24 +94,26 @@ test.describe.serial("Audit Log page", () => {
 
     // Click INSERT filter
     await page.getByTestId("audit-filter-insert").click();
-    // Kept deliberately. The assertion below is negative -- it checks that
-    // something is NOT there. Without a settle window it would pass simply
-    // because the page had not rendered yet, which is a false pass rather
-    // than a flake. Only a positive, retrying assertion makes a wait
-    // redundant.
-    await page.waitForTimeout(MUTATION_WAIT_MS);
+
+    // The pill reports its own state through aria-pressed, so the test can
+    // wait for the filter to actually apply instead of sleeping and hoping.
+    // That attribute was added for this: the active pill used to be
+    // distinguishable only by a CSS class, which is exactly what the
+    // e2e-selectors rule forbids asserting on.
+    await expect(page.getByTestId("audit-filter-insert")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
 
     // Error state must not appear after filtering
     await expect(page.getByTestId("audit-error")).toBeHidden();
 
     // Reset to all
     await page.getByTestId("audit-filter-all").click();
-    // Kept deliberately. The assertion below is negative -- it checks that
-    // something is NOT there. Without a settle window it would pass simply
-    // because the page had not rendered yet, which is a false pass rather
-    // than a flake. Only a positive, retrying assertion makes a wait
-    // redundant.
-    await page.waitForTimeout(MUTATION_WAIT_MS);
+    await expect(page.getByTestId("audit-filter-all")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
 
     await expect(page.getByTestId("audit-error")).toBeHidden();
   });
@@ -156,19 +145,19 @@ test.describe.serial("Audit Log page", () => {
 
     try {
       await injectSession(context, limitedUser);
-      // Kept deliberately. The assertion below is negative -- it checks that
-      // something is NOT there. Without a settle window it would pass simply
-      // because the page had not rendered yet, which is a false pass rather
-      // than a flake. Only a positive, retrying assertion makes a wait
-      // redundant.
-      await page.goto(`${getAdminBaseUrl()}/en/audit`, {
-        waitUntil: "networkidle",
-      });
+      await page.goto(`${getAdminBaseUrl()}/en/audit`);
 
-      // Should NOT show the audit log page content
-      await expect(page.getByTestId("audit-log-page")).toBeHidden({
+      // A user without audit.read gets the access-denied state, so there is a
+      // positive thing to wait for. Asserting that it appears is also a
+      // stronger claim than the absence below: absence alone is satisfied by a
+      // page that never rendered, which is why this used to need a
+      // networkidle wait to mean anything.
+      await expect(page.getByTestId("access-denied")).toBeVisible({
         timeout: ELEMENT_TIMEOUT_MS,
       });
+
+      // And the audit content itself must not be there.
+      await expect(page.getByTestId("audit-log-page")).toBeHidden();
     } finally {
       await deleteTestUser(limitedUser).catch(() => {});
     }

--- a/apps/admin/e2e/reports.spec.ts
+++ b/apps/admin/e2e/reports.spec.ts
@@ -347,14 +347,17 @@ test.describe.serial("Reports page", () => {
 
     try {
       await injectSession(context, limitedUser);
-      // Kept deliberately. The assertion below is negative -- it checks that
-      // something is NOT there. Without a settle window it would pass simply
-      // because the page had not rendered yet, which is a false pass rather
-      // than a flake. Only a positive, retrying assertion makes a wait
-      // redundant.
-      await page.goto(`${getAdminBaseUrl()}/en/reports`, {
-        waitUntil: "networkidle",
-      });
+      await page.goto(`${getAdminBaseUrl()}/en/reports`);
+
+      // Anchor on something positive before asserting an absence. The page
+      // shell renders for any signed-in user and the data layer is what
+      // refuses, so `reports-page` is the normal outcome; `access-denied`
+      // covers a guard that short-circuits instead. Waiting for either means
+      // the absence below is measured against a rendered page rather than
+      // against a page that had not started.
+      await expect(
+        page.getByTestId("reports-page").or(page.getByTestId("access-denied")),
+      ).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
 
       // The app may enforce this by redirecting or by returning 403 and
       // rendering an error state. Either is fine; the invariant is the same

--- a/apps/admin/src/features/audit/presentation/components/AuditFilters.tsx
+++ b/apps/admin/src/features/audit/presentation/components/AuditFilters.tsx
@@ -56,6 +56,7 @@ export function AuditFilters({
         <button
           type="button"
           onClick={() => onActionChange("")}
+          aria-pressed={actionType === ""}
           className={getActionButtonClass(actionType === "")}
           {...tid("audit-filter-all")}
         >
@@ -66,6 +67,7 @@ export function AuditFilters({
             type="button"
             key={type}
             onClick={() => onActionChange(type)}
+            aria-pressed={actionType === type}
             className={getActionButtonClass(actionType === type)}
             {...tid(`audit-filter-${type.toLowerCase()}`)}
           >

--- a/apps/admin/test/e2e/users.spec.ts
+++ b/apps/admin/test/e2e/users.spec.ts
@@ -9,6 +9,15 @@ import {
   type TestUser,
 } from "../../../auth/e2e/helpers/session";
 
+// Read at module scope, not inside the test. A missing base URL is a broken
+// run configuration, not a case the test is meant to branch on -- hoisting it
+// makes the whole file fail at collection instead of part-way through a test,
+// and keeps the test body free of the conditional the linter objects to.
+const ADMIN_BASE_URL = process.env.NEXT_PUBLIC_ADMIN_URL;
+if (!ADMIN_BASE_URL) {
+  throw new Error("NEXT_PUBLIC_ADMIN_URL is required for this e2e test.");
+}
+
 test.describe("Users Page", () => {
   let adminUser: TestUser;
 
@@ -27,14 +36,9 @@ test.describe("Users Page", () => {
     context,
     page,
   }) => {
-    const adminBaseUrl = process.env.NEXT_PUBLIC_ADMIN_URL;
-    if (!adminBaseUrl) {
-      throw new Error("NEXT_PUBLIC_ADMIN_URL is required for this e2e test.");
-    }
-
     await injectSession(context, adminUser);
 
-    await page.goto(`${adminBaseUrl}/en/users`, { waitUntil: "networkidle" });
+    await page.goto(`${ADMIN_BASE_URL}/en/users`, { waitUntil: "networkidle" });
 
     await expect(page.getByTestId("users-page")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,

--- a/apps/admin/test/e2e/users.spec.ts
+++ b/apps/admin/test/e2e/users.spec.ts
@@ -38,7 +38,9 @@ test.describe("Users Page", () => {
   }) => {
     await injectSession(context, adminUser);
 
-    await page.goto(`${ADMIN_BASE_URL}/en/users`, { waitUntil: "networkidle" });
+    // No wait needed: the next assertion is positive and retrying, so it
+    // already waits for the page to render.
+    await page.goto(`${ADMIN_BASE_URL}/en/users`);
 
     await expect(page.getByTestId("users-page")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,

--- a/apps/admin/tests/AuditFilters.test.tsx
+++ b/apps/admin/tests/AuditFilters.test.tsx
@@ -100,4 +100,38 @@ describe("AuditFilters", () => {
     fireEvent.click(screen.getByTestId("audit-filter-all"));
     expect(onActionChange).toHaveBeenCalledWith("");
   });
+
+  // Which pill is active was expressed only through a CSS class, so nothing
+  // outside the component could see it. An e2e test that filtered had no way
+  // to know the filter had applied and slept instead, which the project's own
+  // e2e-selectors rule exists to prevent.
+  it("marks the active action pill with aria-pressed", () => {
+    render(<AuditFilters {...defaultProps} actionType="INSERT" />);
+
+    expect(screen.getByTestId("audit-filter-insert")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByTestId("audit-filter-update")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByTestId("audit-filter-all")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("marks the 'all' pill as pressed when no action type is selected", () => {
+    render(<AuditFilters {...defaultProps} actionType="" />);
+
+    expect(screen.getByTestId("audit-filter-all")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByTestId("audit-filter-insert")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
 });

--- a/apps/auth/e2e/admin-users-export-receipts.spec.ts
+++ b/apps/auth/e2e/admin-users-export-receipts.spec.ts
@@ -174,9 +174,7 @@ test.describe.serial("admin users export with receipts backup", () => {
   }) => {
     await injectSession(context, adminUser);
 
-    await page.goto(resolveAdminUsersUrl(), {
-      waitUntil: "networkidle",
-    });
+    await page.goto(resolveAdminUsersUrl());
     await expect(page.getByTestId("users-page")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });

--- a/apps/auth/e2e/checkout-stock-integrity.spec.ts
+++ b/apps/auth/e2e/checkout-stock-integrity.spec.ts
@@ -106,7 +106,6 @@ test.describe.serial("Checkout stock integrity", () => {
     ]);
 
     await page.goto(`${APP_URLS.PAYMENTS}/en/checkout`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId(/^seller-checkout-/).first()).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,

--- a/apps/auth/e2e/delegated-admin-flow.spec.ts
+++ b/apps/auth/e2e/delegated-admin-flow.spec.ts
@@ -101,7 +101,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
   ): Promise<string> {
     await injectSession(context, user);
     await page.goto(`${APP_URLS.STUDIO}/en`);
-    await page.waitForLoadState("networkidle");
     // Wait for permissions to load — page renders null while isLoading=true
     await expect(page.getByTestId("new-product-button")).toBeVisible({
       timeout: LONG_OPERATION_TIMEOUT_MS,
@@ -109,7 +108,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
     await snap(page, `${snapPrefix}-product-list`);
 
     await page.getByTestId("new-product-button").click();
-    await page.waitForLoadState("networkidle");
 
     const nameField = page.getByTestId("inline-text-en-name_en");
     await nameField.click();
@@ -149,7 +147,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
   ) {
     await injectSession(context, user);
     await page.goto(`${APP_URLS.PAYMENTS}/en/payment-methods`);
-    await page.waitForLoadState("networkidle");
 
     await page.getByTestId("add-payment-method-button").click();
 
@@ -199,7 +196,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
 
     // Save the payment method and wait for the mutation to complete
     await page.getByTestId("payment-method-save").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     await expect(page.getByTestId("payment-methods-page")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -243,23 +239,19 @@ test.describe.serial("Delegated admin purchase flow", () => {
     await injectSession(context, buyer);
 
     await page.goto(`${APP_URLS.STORE}/en`);
-    await page.waitForLoadState("networkidle");
 
     // Search for the product
     await expect(page.getByTestId("search-bar-input")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
     await page.getByTestId("search-bar-input").fill("E2E Delegated Product");
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
     await snap(page, "buyer-search-product");
 
     const card = page.getByTestId("product-card-link").first();
     await expect(card).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await card.click();
-    await page.waitForLoadState("networkidle");
 
     await page.getByTestId("hero-add-to-cart").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "buyer-added-to-cart");
 
     // Open cart and checkout
@@ -289,7 +281,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
       )
       .toBeGreaterThan(1);
     await methodSelect.selectOption({ index: 1 });
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "buyer-method-selected");
 
     // Fill form field
@@ -311,7 +302,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
 
     const fileInput = page.getByTestId("receipt-file-input");
     await fileInput.setInputFiles(RECEIPT_FIXTURE);
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     const receiptPreview = page.getByTestId("receipt-preview");
     await expect(receiptPreview).toBeVisible({
@@ -331,7 +321,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
 
     // Verify order is pending on purchases page
     await page.goto(`${APP_URLS.PAYMENTS}/en/purchases`);
-    await page.waitForLoadState("networkidle");
 
     const pendingBadge = page.getByTestId("order-status-pending_verification");
     await expect(pendingBadge.first()).toBeVisible({
@@ -348,7 +337,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
   }) => {
     await injectSession(context, seller);
     await page.goto(`${APP_URLS.STUDIO}/en/products/${productId}/delegates`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("product-delegates-page")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -358,7 +346,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
     // Search for delegate by email
     const searchInput = page.getByTestId("delegate-search-input");
     await searchInput.fill(delegate.email);
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
     await snap(page, "seller-delegate-search");
 
     // Select the delegate from search results
@@ -374,12 +361,10 @@ test.describe.serial("Delegated admin purchase flow", () => {
 
     // Submit
     await page.getByTestId("delegate-add-submit").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "seller-delegate-added");
 
     // Verify delegate appears in the list
     await page.reload();
-    await page.waitForLoadState("networkidle");
 
     const delegateItem = page.getByTestId(`delegate-item-${delegate.userId}`);
     await expect(delegateItem).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
@@ -394,7 +379,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
   }) => {
     await injectSession(context, delegate);
     await page.goto(`${APP_URLS.PAYMENTS}/en/assigned`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("assigned-orders-page")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -436,12 +420,10 @@ test.describe.serial("Delegated admin purchase flow", () => {
 
     // Submit the note
     await page.getByTestId("seller-note-submit").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "delegate-proof-requested");
 
     // Reload and verify the order is still visible (evidence_requested is actionable)
     await page.reload();
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("assigned-orders-list")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -460,7 +442,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
   }) => {
     await injectSession(context, buyer);
     await page.goto(`${APP_URLS.PAYMENTS}/en/purchases`);
-    await page.waitForLoadState("networkidle");
 
     // Verify order shows evidence_requested status
     const evidenceBadge = page.getByTestId("order-status-evidence_requested");
@@ -485,17 +466,14 @@ test.describe.serial("Delegated admin purchase flow", () => {
     // Upload a new receipt
     const resubmitFileInput = resubmitForm.locator('input[type="file"]');
     await resubmitFileInput.setInputFiles(RECEIPT_FIXTURE);
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "buyer-resubmit-filled");
 
     // Submit resubmission
     await page.getByTestId(`resubmit-submit-${orderId}`).click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "buyer-resubmit-submitted");
 
     // Reload and verify order returns to pending_verification
     await page.reload();
-    await page.waitForLoadState("networkidle");
 
     const pendingBadge = page.getByTestId("order-status-pending_verification");
     await expect(pendingBadge.first()).toBeVisible({
@@ -512,7 +490,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
   }) => {
     await injectSession(context, delegate);
     await page.goto(`${APP_URLS.PAYMENTS}/en/assigned`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("assigned-orders-page")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -548,13 +525,11 @@ test.describe.serial("Delegated admin purchase flow", () => {
     await expect(page.getByTestId("confirm-action-panel")).toBeVisible();
     await page.getByTestId("confirm-checkbox").check();
     await page.getByTestId("confirm-action-submit").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "delegate-order-approved");
 
     // Reload and verify order is no longer in the assigned list
     // (assigned only shows pending_verification / evidence_requested)
     await page.reload();
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("assigned-orders-empty")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -567,7 +542,6 @@ test.describe.serial("Delegated admin purchase flow", () => {
   test("Phase 8: buyer sees order approved", async ({ context, page }) => {
     await injectSession(context, buyer);
     await page.goto(`${APP_URLS.PAYMENTS}/en/purchases`);
-    await page.waitForLoadState("networkidle");
 
     const approvedBadge = page.getByTestId("order-status-approved");
     await expect(approvedBadge.first()).toBeVisible({

--- a/apps/auth/e2e/delegated-admin-flow.spec.ts
+++ b/apps/auth/e2e/delegated-admin-flow.spec.ts
@@ -247,7 +247,15 @@ test.describe.serial("Delegated admin purchase flow", () => {
     await page.getByTestId("search-bar-input").fill("E2E Delegated Product");
     await snap(page, "buyer-search-product");
 
-    const card = page.getByTestId("product-card-link").first();
+    // Filter by the product just searched for rather than taking whatever is
+    // first. The search is debounced, so straight after fill() the grid can
+    // still be showing the previous results, and .first() would click a stale
+    // card. This bit full-purchase-flow, which added the same product twice
+    // and then found one seller group where it expected two.
+    const card = page
+      .getByTestId("product-card-link")
+      .filter({ hasText: "E2E Delegated Product" })
+      .first();
     await expect(card).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await card.click();
 

--- a/apps/auth/e2e/delegated-admin-flow.spec.ts
+++ b/apps/auth/e2e/delegated-admin-flow.spec.ts
@@ -361,12 +361,20 @@ test.describe.serial("Delegated admin purchase flow", () => {
 
     // Submit
     await page.getByTestId("delegate-add-submit").click();
+
+    // Wait for the mutation's own refetch before reloading. The mutation
+    // invalidates its query on success, so this is the point at which the
+    // server is known to have accepted the write; reloading before it races
+    // the commit and reads stale data. This replaces a fixed sleep -- removing
+    // that sleep without putting this in its place is what broke the
+    // two-seller cart assertion in full-purchase-flow.
+    const delegateItem = page.getByTestId(`delegate-item-${delegate.userId}`);
+    await expect(delegateItem).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await snap(page, "seller-delegate-added");
 
-    // Verify delegate appears in the list
+    // Reload to prove it persisted rather than merely leaving the cache.
     await page.reload();
 
-    const delegateItem = page.getByTestId(`delegate-item-${delegate.userId}`);
     await expect(delegateItem).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await snap(page, "seller-delegate-in-list");
   });
@@ -420,6 +428,16 @@ test.describe.serial("Delegated admin purchase flow", () => {
 
     // Submit the note
     await page.getByTestId("seller-note-submit").click();
+
+    // Wait for the mutation's own refetch before reloading. The mutation
+    // invalidates its query on success, so this is the point at which the
+    // server is known to have accepted the write; reloading before it races
+    // the commit and reads stale data. This replaces a fixed sleep -- removing
+    // that sleep without putting this in its place is what broke the
+    // two-seller cart assertion in full-purchase-flow.
+    await expect(page.getByTestId("assigned-orders-list")).toBeVisible({
+      timeout: ELEMENT_TIMEOUT_MS,
+    });
     await snap(page, "delegate-proof-requested");
 
     // Reload and verify the order is still visible (evidence_requested is actionable)
@@ -470,12 +488,19 @@ test.describe.serial("Delegated admin purchase flow", () => {
 
     // Submit resubmission
     await page.getByTestId(`resubmit-submit-${orderId}`).click();
+
+    // Wait for the mutation's own refetch before reloading -- the status badge
+    // flipping is the point at which the server is known to have accepted the
+    // resubmission. Reloading first races the commit.
+    const pendingBadge = page.getByTestId("order-status-pending_verification");
+    await expect(pendingBadge.first()).toBeVisible({
+      timeout: ELEMENT_TIMEOUT_MS,
+    });
     await snap(page, "buyer-resubmit-submitted");
 
-    // Reload and verify order returns to pending_verification
+    // Reload to prove it persisted rather than merely leaving the cache.
     await page.reload();
 
-    const pendingBadge = page.getByTestId("order-status-pending_verification");
     await expect(pendingBadge.first()).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
@@ -525,6 +550,16 @@ test.describe.serial("Delegated admin purchase flow", () => {
     await expect(page.getByTestId("confirm-action-panel")).toBeVisible();
     await page.getByTestId("confirm-checkbox").check();
     await page.getByTestId("confirm-action-submit").click();
+
+    // Wait for the mutation's own refetch before reloading. The mutation
+    // invalidates its query on success, so this is the point at which the
+    // server is known to have accepted the write; reloading before it races
+    // the commit and reads stale data. This replaces a fixed sleep -- removing
+    // that sleep without putting this in its place is what broke the
+    // two-seller cart assertion in full-purchase-flow.
+    await expect(page.getByTestId("assigned-orders-empty")).toBeVisible({
+      timeout: ELEMENT_TIMEOUT_MS,
+    });
     await snap(page, "delegate-order-approved");
 
     // Reload and verify order is no longer in the assigned list

--- a/apps/auth/e2e/discord-login.spec.ts
+++ b/apps/auth/e2e/discord-login.spec.ts
@@ -83,7 +83,6 @@ test("Discord OAuth login flow", async () => {
       // On authorize page — scroll down to reveal the accept button
       console.log("[e2e] On authorize page, scrolling to reveal button...");
       await page.mouse.wheel(0, 500);
-      await page.waitForTimeout(1000);
       // Also try scrolling inside the modal
       const modal = page
         .locator('[class*="modal"], [class*="oauth2"], [role="dialog"]')
@@ -92,7 +91,6 @@ test("Discord OAuth login flow", async () => {
         await modal.evaluate((el) => el.scrollTo(0, el.scrollHeight));
       }
       await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
-      await page.waitForTimeout(1000);
       await page.screenshot({ path: "e2e/screenshots/discord-scrolled.png" });
       await authorizeBtn.waitFor({ state: "visible", timeout: 15000 });
       firstVisible = "authorize";
@@ -134,9 +132,8 @@ test("Discord OAuth login flow", async () => {
 
     console.log("[e2e] ✓ Back on app:", page.url());
 
-    // 5. Wait for page to settle
-    await page.waitForLoadState("networkidle", { timeout: 15000 });
-    await page.waitForTimeout(2000);
+    // The account-card check below waits on its own (isVisible has a
+    // timeout), so settling here was redundant.
     await page.screenshot({ path: "e2e/screenshots/final-page.png" });
     console.log("[e2e] Final URL:", page.url());
 

--- a/apps/auth/e2e/discord-login.spec.ts
+++ b/apps/auth/e2e/discord-login.spec.ts
@@ -70,6 +70,12 @@ test("Discord OAuth login flow", async () => {
       .first();
 
     console.log("[e2e] Waiting for Discord page to load...");
+    // Discord's page can settle into any of three states (login form,
+    // authorize prompt, or straight back to the app), and the branch below
+    // reads the URL to find out which. There is no single element to wait for
+    // without first knowing the answer, and the markup belongs to a third
+    // party.
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- see above
     await page.waitForTimeout(5000);
 
     // Determine what Discord is showing

--- a/apps/auth/e2e/full-purchase-flow.spec.ts
+++ b/apps/auth/e2e/full-purchase-flow.spec.ts
@@ -8,7 +8,6 @@ import {
   APP_URLS,
   ELEMENT_TIMEOUT_MS,
   LONG_OPERATION_TIMEOUT_MS,
-  MUTATION_WAIT_MS,
   NAVIGATION_TIMEOUT_MS,
 } from "./helpers/constants";
 import {
@@ -372,19 +371,11 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
 
     await page.getByTestId("hero-add-to-cart").click();
 
-    // The indicator proves React took the item, which is worth asserting on
-    // its own -- but it is not sufficient here. The cart also persists to a
-    // cookie from a useEffect, and it is the cookie, not the DOM, that
-    // survives the navigation below. Two attempts at replacing the sleep
-    // failed in CI: waiting on the indicator alone still lost the item, and
-    // polling the cookie for an exact count failed too, most likely because
-    // the count is not what I assumed. Diagnosing that needs the suite run
-    // locally against a real store, so the sleep stays until someone can.
+    // The in-cart indicator only renders once the cart holds this product, so
+    // it is a real signal the add landed before we navigate away.
     await expect(page.getByTestId("hero-in-cart")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
-    // eslint-disable-next-line playwright/no-wait-for-timeout -- see above
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "store-added-alpha");
 
     // ── Add Seller B's product ──────────────────────────────────
@@ -413,19 +404,11 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
 
     await page.getByTestId("hero-add-to-cart").click();
 
-    // The indicator proves React took the item, which is worth asserting on
-    // its own -- but it is not sufficient here. The cart also persists to a
-    // cookie from a useEffect, and it is the cookie, not the DOM, that
-    // survives the navigation below. Two attempts at replacing the sleep
-    // failed in CI: waiting on the indicator alone still lost the item, and
-    // polling the cookie for an exact count failed too, most likely because
-    // the count is not what I assumed. Diagnosing that needs the suite run
-    // locally against a real store, so the sleep stays until someone can.
+    // The in-cart indicator only renders once the cart holds this product, so
+    // it is a real signal the add landed before we navigate away.
     await expect(page.getByTestId("hero-in-cart")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
-    // eslint-disable-next-line playwright/no-wait-for-timeout -- see above
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "store-added-beta");
 
     // ── Open cart and verify both items ────────────────────────

--- a/apps/auth/e2e/full-purchase-flow.spec.ts
+++ b/apps/auth/e2e/full-purchase-flow.spec.ts
@@ -6,11 +6,8 @@ import { cleanupTestData } from "./helpers/cleanup";
 import { dragAndDrop } from "./helpers/drag";
 import {
   APP_URLS,
-  BULK_MUTATION_WAIT_MS,
-  DEBOUNCE_WAIT_MS,
   ELEMENT_TIMEOUT_MS,
   LONG_OPERATION_TIMEOUT_MS,
-  MUTATION_WAIT_MS,
   NAVIGATION_TIMEOUT_MS,
 } from "./helpers/constants";
 import {
@@ -83,11 +80,9 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
   ) {
     await injectSession(context, seller);
     await page.goto(`${APP_URLS.STUDIO}/en`);
-    await page.waitForLoadState("networkidle");
     await snap(page, `${snapPrefix}-product-list`);
 
     await page.getByTestId("new-product-button").click();
-    await page.waitForLoadState("networkidle");
 
     const nameField = page.getByTestId("inline-text-en-name_en");
     await nameField.click();
@@ -121,7 +116,6 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
   ) {
     await injectSession(context, seller);
     await page.goto(`${APP_URLS.PAYMENTS}/en/payment-methods`);
-    await page.waitForLoadState("networkidle");
 
     // New builder UX: "Add Method" instantly creates and expands inline
     await page.getByTestId("add-payment-method-button").click();
@@ -173,7 +167,6 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
 
     // Save the payment method and wait for the mutation to complete
     await page.getByTestId("payment-method-save").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     await expect(page.getByTestId("payment-methods-page")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -255,7 +248,6 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
     async ({ context, page }) => {
       await injectSession(context, sellerA);
       await page.goto(`${APP_URLS.PAYMENTS}/en/payment-methods`);
-      await page.waitForLoadState("networkidle");
 
       // Expand the first payment method
       await page.getByTestId("payment-method-name").first().click();
@@ -353,7 +345,6 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
     await injectSession(context, buyer);
 
     await page.goto(`${APP_URLS.STORE}/en`);
-    await page.waitForLoadState("networkidle");
     await snap(page, "store-catalog");
 
     // ── Add Seller A's product ──────────────────────────────────
@@ -361,38 +352,31 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
       timeout: ELEMENT_TIMEOUT_MS,
     });
     await page.getByTestId("search-bar-input").fill(PRODUCT_ALPHA);
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
     await snap(page, "store-search-alpha");
 
     const cardA = page.getByTestId("product-card-link").first();
     await expect(cardA).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await cardA.click();
-    await page.waitForLoadState("networkidle");
     await snap(page, "store-product-alpha");
 
     await page.getByTestId("hero-add-to-cart").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "store-added-alpha");
 
     // ── Add Seller B's product ──────────────────────────────────
     await page.goto(`${APP_URLS.STORE}/en`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("search-bar-input")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
     await page.getByTestId("search-bar-input").fill(PRODUCT_BETA);
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
     await snap(page, "store-search-beta");
 
     const cardB = page.getByTestId("product-card-link").first();
     await expect(cardB).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await cardB.click();
-    await page.waitForLoadState("networkidle");
     await snap(page, "store-product-beta");
 
     await page.getByTestId("hero-add-to-cart").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "store-added-beta");
 
     // ── Open cart and verify both items ────────────────────────
@@ -442,7 +426,6 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
       )
       .toBeGreaterThan(1);
     await cardASelect.selectOption({ index: 1 });
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "checkout-sellerA-method-selected");
 
     await expect(firstCard.getByTestId(/^display-block-/).first()).toBeVisible({
@@ -466,7 +449,6 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
 
     const fileInputA = firstCard.getByTestId("receipt-file-input");
     await fileInputA.setInputFiles(RECEIPT_FIXTURE);
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     const receiptPreviewA = firstCard.getByTestId("receipt-preview");
     await expect(receiptPreviewA).toBeVisible({
@@ -490,7 +472,6 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
       )
       .toBeGreaterThan(1);
     await cardBSelect.selectOption({ index: 1 });
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "checkout-sellerB-method-selected");
 
     await expect(secondCard.getByTestId(/^dynamic-field-/).first()).toBeVisible(
@@ -511,7 +492,6 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
 
     const fileInputB = secondCard.getByTestId("receipt-file-input");
     await fileInputB.setInputFiles(RECEIPT_FIXTURE);
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     const receiptPreviewB = secondCard.getByTestId("receipt-preview");
     await expect(receiptPreviewB).toBeVisible({
@@ -539,7 +519,6 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
   }) => {
     await injectSession(context, buyer);
     await page.goto(`${APP_URLS.PAYMENTS}/en/purchases`);
-    await page.waitForLoadState("networkidle");
 
     const pendingBadges = page.getByTestId("order-status-pending_verification");
     await expect(pendingBadges.first()).toBeVisible({
@@ -554,7 +533,6 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
   test("Phase 5a: seller A approves their order", async ({ context, page }) => {
     await injectSession(context, sellerA);
     await page.goto(`${APP_URLS.PAYMENTS}/en/sales`);
-    await page.waitForLoadState("networkidle");
 
     const approveBtn = page.getByTestId(/^order-approve-/).first();
     await expect(approveBtn).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
@@ -580,9 +558,24 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
     await page.getByTestId("confirm-checkbox").check();
     await page.getByTestId("confirm-action-submit").click();
 
-    await page.waitForTimeout(BULK_MUTATION_WAIT_MS);
+    // The approve mutation invalidates the received-orders query on success,
+    // so the row's approve button disappears once the refetch lands. Waiting
+    // for that is a real signal the server accepted the write; the fixed sleep
+    // it replaces was guessing how long the write takes.
+    await expect(page.getByTestId(/^order-approve-/).first()).toBeHidden({
+      timeout: NAVIGATION_TIMEOUT_MS,
+    });
+
+    // Reload anyway, to prove it persisted rather than merely leaving the
+    // client cache -- and wait for the list to come back before asserting an
+    // absence against it, since an absence also holds on a page that has not
+    // rendered. Either the list or its empty state means the page is up.
     await page.reload();
-    await page.waitForLoadState("networkidle");
+    await expect(
+      page
+        .getByTestId("received-orders-list")
+        .or(page.getByTestId("received-orders-empty")),
+    ).toBeVisible({ timeout: NAVIGATION_TIMEOUT_MS });
 
     await expect(page.getByTestId(/^order-approve-/).first()).toBeHidden({
       timeout: NAVIGATION_TIMEOUT_MS,
@@ -595,7 +588,6 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
   test("Phase 5b: seller B approves their order", async ({ context, page }) => {
     await injectSession(context, sellerB);
     await page.goto(`${APP_URLS.PAYMENTS}/en/sales`);
-    await page.waitForLoadState("networkidle");
 
     const approveBtn = page.getByTestId(/^order-approve-/).first();
     await expect(approveBtn).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
@@ -621,9 +613,24 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
     await page.getByTestId("confirm-checkbox").check();
     await page.getByTestId("confirm-action-submit").click();
 
-    await page.waitForTimeout(BULK_MUTATION_WAIT_MS);
+    // The approve mutation invalidates the received-orders query on success,
+    // so the row's approve button disappears once the refetch lands. Waiting
+    // for that is a real signal the server accepted the write; the fixed sleep
+    // it replaces was guessing how long the write takes.
+    await expect(page.getByTestId(/^order-approve-/).first()).toBeHidden({
+      timeout: NAVIGATION_TIMEOUT_MS,
+    });
+
+    // Reload anyway, to prove it persisted rather than merely leaving the
+    // client cache -- and wait for the list to come back before asserting an
+    // absence against it, since an absence also holds on a page that has not
+    // rendered. Either the list or its empty state means the page is up.
     await page.reload();
-    await page.waitForLoadState("networkidle");
+    await expect(
+      page
+        .getByTestId("received-orders-list")
+        .or(page.getByTestId("received-orders-empty")),
+    ).toBeVisible({ timeout: NAVIGATION_TIMEOUT_MS });
 
     await expect(page.getByTestId(/^order-approve-/).first()).toBeHidden({
       timeout: NAVIGATION_TIMEOUT_MS,
@@ -639,7 +646,6 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
   }) => {
     await injectSession(context, buyer);
     await page.goto(`${APP_URLS.PAYMENTS}/en/purchases`);
-    await page.waitForLoadState("networkidle");
 
     const approvedBadges = page.getByTestId("order-status-approved");
     await expect(approvedBadges.first()).toBeVisible({

--- a/apps/auth/e2e/full-purchase-flow.spec.ts
+++ b/apps/auth/e2e/full-purchase-flow.spec.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 
-import type { BrowserContext } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 import { cleanupTestData } from "./helpers/cleanup";
@@ -9,6 +8,7 @@ import {
   APP_URLS,
   ELEMENT_TIMEOUT_MS,
   LONG_OPERATION_TIMEOUT_MS,
+  MUTATION_WAIT_MS,
   NAVIGATION_TIMEOUT_MS,
 } from "./helpers/constants";
 import {
@@ -43,42 +43,6 @@ const { snap, resetCounter } = createSnapHelper(
  *
  * Requires: supabase start + pnpm dev (all apps)
  */
-/**
- * Wait until the cart cookie holds `count` items.
- *
- * The cart persists to a cookie from a useEffect on the item list, so the
- * write lands a tick after React has already rendered the "in cart" state.
- * Navigating in that gap loses the item -- which is what a fixed sleep used to
- * paper over here, and what an assertion on the rendered indicator failed to
- * catch: the DOM was right and the cookie had not been written yet. The
- * cookie is what survives the navigation, so the cookie is what to wait for.
- */
-async function expectCartCookieToHold(
-  context: BrowserContext,
-  count: number,
-): Promise<void> {
-  await expect
-    .poll(
-      async () => {
-        const cookie = (await context.cookies()).find(
-          (c) => c.name === "libra-cart",
-        );
-        if (!cookie) return 0;
-        try {
-          const items: unknown = JSON.parse(decodeURIComponent(cookie.value));
-          return Array.isArray(items) ? items.length : 0;
-        } catch {
-          return 0;
-        }
-      },
-      {
-        timeout: ELEMENT_TIMEOUT_MS,
-        message: `cart cookie never reached ${count} item(s)`,
-      },
-    )
-    .toBe(count);
-}
-
 test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
   let sellerA: TestUser;
   let sellerB: TestUser;
@@ -398,12 +362,19 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
 
     await page.getByTestId("hero-add-to-cart").click();
 
-    // Rendered state first, then persisted state. The indicator proves React
-    // took the item; the cookie is what the navigation below actually needs.
+    // The indicator proves React took the item, which is worth asserting on
+    // its own -- but it is not sufficient here. The cart also persists to a
+    // cookie from a useEffect, and it is the cookie, not the DOM, that
+    // survives the navigation below. Two attempts at replacing the sleep
+    // failed in CI: waiting on the indicator alone still lost the item, and
+    // polling the cookie for an exact count failed too, most likely because
+    // the count is not what I assumed. Diagnosing that needs the suite run
+    // locally against a real store, so the sleep stays until someone can.
     await expect(page.getByTestId("hero-in-cart")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
-    await expectCartCookieToHold(context, 1);
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- see above
+    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "store-added-alpha");
 
     // ── Add Seller B's product ──────────────────────────────────
@@ -422,12 +393,19 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
 
     await page.getByTestId("hero-add-to-cart").click();
 
-    // Rendered state first, then persisted state. The indicator proves React
-    // took the item; the cookie is what the navigation below actually needs.
+    // The indicator proves React took the item, which is worth asserting on
+    // its own -- but it is not sufficient here. The cart also persists to a
+    // cookie from a useEffect, and it is the cookie, not the DOM, that
+    // survives the navigation below. Two attempts at replacing the sleep
+    // failed in CI: waiting on the indicator alone still lost the item, and
+    // polling the cookie for an exact count failed too, most likely because
+    // the count is not what I assumed. Diagnosing that needs the suite run
+    // locally against a real store, so the sleep stays until someone can.
     await expect(page.getByTestId("hero-in-cart")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
-    await expectCartCookieToHold(context, 2);
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- see above
+    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "store-added-beta");
 
     // ── Open cart and verify both items ────────────────────────

--- a/apps/auth/e2e/full-purchase-flow.spec.ts
+++ b/apps/auth/e2e/full-purchase-flow.spec.ts
@@ -360,6 +360,15 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
     await snap(page, "store-product-alpha");
 
     await page.getByTestId("hero-add-to-cart").click();
+
+    // Wait for the item to be in the cart before navigating away. The hero's
+    // in-cart indicator only renders once the cart holds this product, so it
+    // is a real signal the write landed. Removing the sleep that used to sit
+    // here without adding this is what broke the two-seller assertion below:
+    // the next page-load assertion said nothing about the cart.
+    await expect(page.getByTestId("hero-in-cart")).toBeVisible({
+      timeout: ELEMENT_TIMEOUT_MS,
+    });
     await snap(page, "store-added-alpha");
 
     // ── Add Seller B's product ──────────────────────────────────
@@ -377,6 +386,15 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
     await snap(page, "store-product-beta");
 
     await page.getByTestId("hero-add-to-cart").click();
+
+    // Wait for the item to be in the cart before navigating away. The hero's
+    // in-cart indicator only renders once the cart holds this product, so it
+    // is a real signal the write landed. Removing the sleep that used to sit
+    // here without adding this is what broke the two-seller assertion below:
+    // the next page-load assertion said nothing about the cart.
+    await expect(page.getByTestId("hero-in-cart")).toBeVisible({
+      timeout: ELEMENT_TIMEOUT_MS,
+    });
     await snap(page, "store-added-beta");
 
     // ── Open cart and verify both items ────────────────────────

--- a/apps/auth/e2e/full-purchase-flow.spec.ts
+++ b/apps/auth/e2e/full-purchase-flow.spec.ts
@@ -355,7 +355,17 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
     await page.getByTestId("search-bar-input").fill(PRODUCT_ALPHA);
     await snap(page, "store-search-alpha");
 
-    const cardA = page.getByTestId("product-card-link").first();
+    // Match the product being searched for rather than "whatever is first".
+    // The search is debounced, so straight after fill() the grid still shows
+    // the previous results -- .first() then clicks a stale card, and picking
+    // the same card twice is exactly how this test came to find one seller
+    // group where it expected two. Filtering makes the locator wait for the
+    // debounced result *and* click the right thing; the sleep it replaces did
+    // the first and never checked the second.
+    const cardA = page
+      .getByTestId("product-card-link")
+      .filter({ hasText: PRODUCT_ALPHA })
+      .first();
     await expect(cardA).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await cardA.click();
     await snap(page, "store-product-alpha");
@@ -386,7 +396,17 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
     await page.getByTestId("search-bar-input").fill(PRODUCT_BETA);
     await snap(page, "store-search-beta");
 
-    const cardB = page.getByTestId("product-card-link").first();
+    // Match the product being searched for rather than "whatever is first".
+    // The search is debounced, so straight after fill() the grid still shows
+    // the previous results -- .first() then clicks a stale card, and picking
+    // the same card twice is exactly how this test came to find one seller
+    // group where it expected two. Filtering makes the locator wait for the
+    // debounced result *and* click the right thing; the sleep it replaces did
+    // the first and never checked the second.
+    const cardB = page
+      .getByTestId("product-card-link")
+      .filter({ hasText: PRODUCT_BETA })
+      .first();
     await expect(cardB).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await cardB.click();
     await snap(page, "store-product-beta");

--- a/apps/auth/e2e/full-purchase-flow.spec.ts
+++ b/apps/auth/e2e/full-purchase-flow.spec.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 
+import type { BrowserContext } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 import { cleanupTestData } from "./helpers/cleanup";
@@ -42,6 +43,42 @@ const { snap, resetCounter } = createSnapHelper(
  *
  * Requires: supabase start + pnpm dev (all apps)
  */
+/**
+ * Wait until the cart cookie holds `count` items.
+ *
+ * The cart persists to a cookie from a useEffect on the item list, so the
+ * write lands a tick after React has already rendered the "in cart" state.
+ * Navigating in that gap loses the item -- which is what a fixed sleep used to
+ * paper over here, and what an assertion on the rendered indicator failed to
+ * catch: the DOM was right and the cookie had not been written yet. The
+ * cookie is what survives the navigation, so the cookie is what to wait for.
+ */
+async function expectCartCookieToHold(
+  context: BrowserContext,
+  count: number,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const cookie = (await context.cookies()).find(
+          (c) => c.name === "libra-cart",
+        );
+        if (!cookie) return 0;
+        try {
+          const items: unknown = JSON.parse(decodeURIComponent(cookie.value));
+          return Array.isArray(items) ? items.length : 0;
+        } catch {
+          return 0;
+        }
+      },
+      {
+        timeout: ELEMENT_TIMEOUT_MS,
+        message: `cart cookie never reached ${count} item(s)`,
+      },
+    )
+    .toBe(count);
+}
+
 test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
   let sellerA: TestUser;
   let sellerB: TestUser;
@@ -361,14 +398,12 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
 
     await page.getByTestId("hero-add-to-cart").click();
 
-    // Wait for the item to be in the cart before navigating away. The hero's
-    // in-cart indicator only renders once the cart holds this product, so it
-    // is a real signal the write landed. Removing the sleep that used to sit
-    // here without adding this is what broke the two-seller assertion below:
-    // the next page-load assertion said nothing about the cart.
+    // Rendered state first, then persisted state. The indicator proves React
+    // took the item; the cookie is what the navigation below actually needs.
     await expect(page.getByTestId("hero-in-cart")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
+    await expectCartCookieToHold(context, 1);
     await snap(page, "store-added-alpha");
 
     // ── Add Seller B's product ──────────────────────────────────
@@ -387,14 +422,12 @@ test.describe.serial("Full purchase flow: two sellers, one buyer", () => {
 
     await page.getByTestId("hero-add-to-cart").click();
 
-    // Wait for the item to be in the cart before navigating away. The hero's
-    // in-cart indicator only renders once the cart holds this product, so it
-    // is a real signal the write landed. Removing the sleep that used to sit
-    // here without adding this is what broke the two-seller assertion below:
-    // the next page-load assertion said nothing about the cart.
+    // Rendered state first, then persisted state. The indicator proves React
+    // took the item; the cookie is what the navigation below actually needs.
     await expect(page.getByTestId("hero-in-cart")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
+    await expectCartCookieToHold(context, 2);
     await snap(page, "store-added-beta");
 
     // ── Open cart and verify both items ────────────────────────

--- a/apps/auth/e2e/google-login.spec.ts
+++ b/apps/auth/e2e/google-login.spec.ts
@@ -119,7 +119,6 @@ async function expectAuthenticatedAcrossApps(
 ) {
   for (const app of APP_CHECKS) {
     await page.goto(app.url);
-    await page.waitForLoadState("networkidle", { timeout: 20000 });
     await expect(
       page,
       `${app.name} should not bounce back to login`,
@@ -166,7 +165,6 @@ test("Google OAuth login flow", async ({ page }) => {
   await expect(page.getByTestId("login-google")).toBeVisible();
   console.log("[e2e] Login page loaded");
 
-  await page.waitForTimeout(1000);
   await page.getByTestId("login-google").click();
   console.log("[e2e] Clicked Google");
 
@@ -207,7 +205,6 @@ test("Google OAuth login flow", async ({ page }) => {
       .first();
     await nextBtn.click();
     console.log("[e2e] Submitted password");
-    await page.waitForTimeout(3000);
   }
 
   await page.waitForURL(

--- a/apps/auth/e2e/google-login.spec.ts
+++ b/apps/auth/e2e/google-login.spec.ts
@@ -108,6 +108,11 @@ async function waitForAnyVisible(
       }
     }
 
+    // The poll interval of a hand-rolled race across Google's own markup,
+    // which varies by account state and locale. Playwright's .or() would
+    // express it natively, but rewriting a flow that can only be exercised
+    // against the live provider is not something a lint sweep should do blind.
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- see above
     await page.waitForTimeout(500);
   }
 
@@ -214,9 +219,8 @@ test("Google OAuth login flow", async ({ page }) => {
   );
   console.log("[e2e] Back on app:", page.url());
 
-  await page.waitForLoadState("networkidle", { timeout: 15000 });
-  await page.waitForTimeout(2000);
-
+  // The account-page check below waits on its own (isVisible has a timeout),
+  // so settling here was redundant.
   const isAccountPage = await page
     .getByTestId("account-settings-page")
     .isVisible({ timeout: 5000 })

--- a/apps/auth/e2e/helpers/drag.ts
+++ b/apps/auth/e2e/helpers/drag.ts
@@ -17,7 +17,23 @@ import type { Locator, Page } from "@playwright/test";
  * @param direction - Direction to move: "up"/"down" for vertical droppables,
  *                    "left"/"right" for horizontal droppables (e.g. cards section)
  * @param positions - Number of positions to move (default: 1)
+ *
+ * The waits below are deliberate and are not the usual "wait for the network"
+ * anti-pattern this repo removes elsewhere. @hello-pangea/dnd drives a
+ * state machine of its own between keystrokes -- lift, move, drop each run an
+ * animation and a screen-reader announcement -- and it drops keystrokes that
+ * arrive mid-transition. There is no assertion to anchor on here: the helper
+ * has no idea what the caller expects to change, so it cannot wait for it.
+ * The caller asserts the outcome instead.
+ *
+ * Replacing these with the library's own drag signals (the placeholder node
+ * it mounts while a drag is live) is plausible but unverified -- it needs the
+ * e2e suite to confirm, and a wrong guess here breaks reordering coverage
+ * silently rather than loudly. Left as-is on purpose, disabled with a reason
+ * rather than left to sit in a warning list where it reads as unexamined.
  */
+/* eslint-disable playwright/no-wait-for-timeout -- see the note above:
+   these pace a third-party drag state machine, not a network operation. */
 export async function dragAndDrop(
   page: Page,
   handle: Locator,

--- a/apps/auth/e2e/mobile-layout.spec.ts
+++ b/apps/auth/e2e/mobile-layout.spec.ts
@@ -70,7 +70,7 @@ test(
       await injectSession(context, buyer);
 
       // Verify session landed (not redirected to login)
-      await page.goto(`${STORE_URL}/en`, { waitUntil: "networkidle" });
+      await page.goto(`${STORE_URL}/en`);
       expect(page.url(), "Store should not redirect to login").not.toContain(
         "/login",
       );
@@ -96,7 +96,6 @@ test(
       });
 
       await page.getByTestId("product-card-link").first().click();
-      await page.waitForLoadState("networkidle");
       await expect(page.getByTestId("product-detail-page")).toBeVisible();
       await expect(page.getByTestId("hero-section")).toBeVisible();
 

--- a/apps/auth/e2e/mobile-layout.spec.ts
+++ b/apps/auth/e2e/mobile-layout.spec.ts
@@ -130,8 +130,12 @@ test(
       // Then persisted state, which is what the navigation below actually
       // needs. The cart writes its cookie from a useEffect, so the write lands
       // a tick after React has already rendered the indicator above -- and it
-      // is the cookie, not the DOM, that survives the goto. Asserting only the
-      // rendered state here left the same race the sleep was covering.
+      // is the cookie, not the DOM, that survives the goto.
+      //
+      // Kept as a presence check rather than a count. full-purchase-flow tried
+      // asserting an exact item count here and CI rejected it, so the count is
+      // not what I assumed; presence is the part I can stand behind without
+      // running the suite.
       await expect
         .poll(
           async () =>

--- a/apps/auth/e2e/mobile-layout.spec.ts
+++ b/apps/auth/e2e/mobile-layout.spec.ts
@@ -118,16 +118,21 @@ test(
       });
 
       await page.getByTestId("product-detail-mobile-add-to-cart").click();
-      await page.waitForTimeout(500);
 
-      await page.goto(`${PAYMENTS_URL}/en/checkout`, {
-        waitUntil: "networkidle",
-      });
+      // Wait for the item to actually be in the cart before navigating away.
+      // The bar's in-cart indicator only renders once quantityInCart > 0, and
+      // unlike the button's "added" state it does not time out after a moment,
+      // so it is safe to assert against. It had no test id until now, which is
+      // why this was a fixed 500ms sleep -- there was nothing to wait for.
+      await expect(
+        page.getByTestId("product-detail-mobile-in-cart"),
+      ).toBeVisible();
 
-      // Verify we landed on checkout, not redirected to login
-      expect(page.url(), "Checkout should not redirect to login").not.toContain(
-        "/login",
-      );
+      await page.goto(`${PAYMENTS_URL}/en/checkout`);
+
+      // Verify we landed on checkout, not redirected to login. toHaveURL
+      // retries, so it waits and asserts in one step.
+      await expect(page).not.toHaveURL(/\/login/);
 
       await expect(
         page.getByTestId("payments-mobile-sidebar-trigger"),

--- a/apps/auth/e2e/mobile-layout.spec.ts
+++ b/apps/auth/e2e/mobile-layout.spec.ts
@@ -119,14 +119,26 @@ test(
 
       await page.getByTestId("product-detail-mobile-add-to-cart").click();
 
-      // Wait for the item to actually be in the cart before navigating away.
-      // The bar's in-cart indicator only renders once quantityInCart > 0, and
-      // unlike the button's "added" state it does not time out after a moment,
-      // so it is safe to assert against. It had no test id until now, which is
-      // why this was a fixed 500ms sleep -- there was nothing to wait for.
+      // Rendered state first: the bar's in-cart indicator renders once
+      // quantityInCart > 0. Unlike the button's "added" state it does not time
+      // out after a moment, so it is safe to assert against. It had no test id
+      // until now, which is why this was a fixed 500ms sleep.
       await expect(
         page.getByTestId("product-detail-mobile-in-cart"),
       ).toBeVisible();
+
+      // Then persisted state, which is what the navigation below actually
+      // needs. The cart writes its cookie from a useEffect, so the write lands
+      // a tick after React has already rendered the indicator above -- and it
+      // is the cookie, not the DOM, that survives the goto. Asserting only the
+      // rendered state here left the same race the sleep was covering.
+      await expect
+        .poll(
+          async () =>
+            (await context.cookies()).some((c) => c.name === "libra-cart"),
+          { message: "cart cookie was never written" },
+        )
+        .toBe(true);
 
       await page.goto(`${PAYMENTS_URL}/en/checkout`);
 

--- a/apps/auth/e2e/permission-management.spec.ts
+++ b/apps/auth/e2e/permission-management.spec.ts
@@ -67,7 +67,6 @@ async function navigateToUserDetail(
   targetUserId: string,
 ): Promise<void> {
   await page.goto(`${APP_URLS.ADMIN}/en/users/${targetUserId}`, {
-    waitUntil: "networkidle",
     timeout: NAVIGATION_TIMEOUT_MS,
   });
   await expect(page.getByTestId("user-detail-page")).toBeVisible({
@@ -144,7 +143,6 @@ async function setPermissions(
     const current = await checkbox.isChecked();
     if (current !== desired) {
       await checkbox.click();
-      await page.waitForTimeout(MUTATION_WAIT_MS);
       await waitForPermissionState(target.userId, { [permissionKey]: desired });
     }
 
@@ -493,7 +491,6 @@ test.describe.serial("Permission management", () => {
     await injectSession(context, admin);
     await navigateToUserDetail(page, target.userId);
     await page.getByTestId("template-btn-none").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     await expect(
       page.getByTestId("permission-toggle-products.read"),
@@ -524,7 +521,6 @@ test.describe.serial("Permission management", () => {
     await injectSession(context, admin);
     await navigateToUserDetail(page, target.userId);
     await page.getByTestId("template-btn-admin").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     await expect(
       page.getByTestId("permission-toggle-products.read"),

--- a/apps/auth/e2e/receipt-delegate-flow.spec.ts
+++ b/apps/auth/e2e/receipt-delegate-flow.spec.ts
@@ -206,7 +206,15 @@ test.describe.serial("Delegate sees buyer receipt", () => {
     });
     await page.getByTestId("search-bar-input").fill(PRODUCT_NAME);
 
-    const productCard = page.getByTestId("product-card-link").first();
+    // Filter by the product just searched for rather than taking whatever is
+    // first. The search is debounced, so straight after fill() the grid can
+    // still be showing the previous results, and .first() would click a stale
+    // card. This bit full-purchase-flow, which added the same product twice
+    // and then found one seller group where it expected two.
+    const productCard = page
+      .getByTestId("product-card-link")
+      .filter({ hasText: PRODUCT_NAME })
+      .first();
     await expect(productCard).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await productCard.click();
 

--- a/apps/auth/e2e/receipt-delegate-flow.spec.ts
+++ b/apps/auth/e2e/receipt-delegate-flow.spec.ts
@@ -288,8 +288,16 @@ test.describe.serial("Delegate sees buyer receipt", () => {
     await snap(page, "seller-delegate-configured");
 
     await page.getByTestId("delegate-add-submit").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
+    // The mutation invalidates the seller-admins query on success, so the new
+    // delegate shows up once the refetch lands. That is a real signal the
+    // server accepted the write, which is what the fixed sleep was standing in
+    // for -- the reload after it would otherwise have raced the commit.
+    await expect(
+      page.getByTestId(`delegate-item-${delegate.userId}`),
+    ).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
+
+    // Reload to prove it persisted rather than merely leaving the cache.
     await page.reload();
 
     await expect(

--- a/apps/auth/e2e/receipt-delegate-flow.spec.ts
+++ b/apps/auth/e2e/receipt-delegate-flow.spec.ts
@@ -372,6 +372,16 @@ test.describe.serial("Delegate sees buyer receipt", () => {
     await expect(page.getByTestId("confirm-action-panel")).toBeVisible();
     await page.getByTestId("confirm-checkbox").check();
     await page.getByTestId("confirm-action-submit").click();
+
+    // Wait for the mutation's own refetch before reloading. The mutation
+    // invalidates its query on success, so this is the point at which the
+    // server is known to have accepted the write; reloading before it races
+    // the commit and reads stale data. This replaces a fixed sleep -- removing
+    // that sleep without putting this in its place is what broke the
+    // two-seller cart assertion in full-purchase-flow.
+    await expect(page.getByTestId("assigned-orders-empty")).toBeVisible({
+      timeout: ELEMENT_TIMEOUT_MS,
+    });
     await snap(page, "delegate-order-approved");
 
     // After approval the order leaves the assigned list (only pending/evidence

--- a/apps/auth/e2e/receipt-delegate-flow.spec.ts
+++ b/apps/auth/e2e/receipt-delegate-flow.spec.ts
@@ -98,13 +98,11 @@ test.describe.serial("Delegate sees buyer receipt", () => {
   }) => {
     await injectSession(context, seller);
     await page.goto(`${APP_URLS.STUDIO}/en`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("new-product-button")).toBeVisible({
       timeout: LONG_OPERATION_TIMEOUT_MS,
     });
     await page.getByTestId("new-product-button").click();
-    await page.waitForLoadState("networkidle");
 
     const nameField = page.getByTestId("inline-text-en-name_en");
     await nameField.click();
@@ -139,7 +137,6 @@ test.describe.serial("Delegate sees buyer receipt", () => {
   }) => {
     await injectSession(context, seller);
     await page.goto(`${APP_URLS.PAYMENTS}/en/payment-methods`);
-    await page.waitForLoadState("networkidle");
 
     await page.getByTestId("add-payment-method-button").click();
 
@@ -188,7 +185,6 @@ test.describe.serial("Delegate sees buyer receipt", () => {
     await snap(page, "seller-method-configured");
 
     await page.getByTestId("payment-method-save").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     await expect(page.getByTestId("payment-methods-page")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -204,21 +200,17 @@ test.describe.serial("Delegate sees buyer receipt", () => {
   }) => {
     await injectSession(context, buyer);
     await page.goto(`${APP_URLS.STORE}/en`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("search-bar-input")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
     await page.getByTestId("search-bar-input").fill(PRODUCT_NAME);
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
 
     const productCard = page.getByTestId("product-card-link").first();
     await expect(productCard).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await productCard.click();
-    await page.waitForLoadState("networkidle");
 
     await page.getByTestId("hero-add-to-cart").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     // No `force: true` here. Forcing the click skips Playwright's actionability
     // checks, so this passed even if the trigger were covered or disabled --
@@ -248,7 +240,6 @@ test.describe.serial("Delegate sees buyer receipt", () => {
       )
       .toBeGreaterThan(1);
     await methodSelect.selectOption({ index: 1 });
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     const transferInput = sellerCard.getByTestId("transfer-number-input");
     await expect(transferInput).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
@@ -256,7 +247,6 @@ test.describe.serial("Delegate sees buyer receipt", () => {
 
     const fileInput = sellerCard.getByTestId("receipt-file-input");
     await fileInput.setInputFiles(RECEIPT_FIXTURE);
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     const receiptPreview = sellerCard.getByTestId("receipt-preview");
     await expect(receiptPreview).toBeVisible({
@@ -282,7 +272,6 @@ test.describe.serial("Delegate sees buyer receipt", () => {
   }) => {
     await injectSession(context, seller);
     await page.goto(`${APP_URLS.STUDIO}/en/products/${productId}/delegates`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("product-delegates-page")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -290,7 +279,6 @@ test.describe.serial("Delegate sees buyer receipt", () => {
 
     const searchInput = page.getByTestId("delegate-search-input");
     await searchInput.fill(delegate.email);
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
 
     const searchResult = page.locator("ul li button").first();
     await expect(searchResult).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
@@ -303,7 +291,6 @@ test.describe.serial("Delegate sees buyer receipt", () => {
     await page.waitForTimeout(MUTATION_WAIT_MS);
 
     await page.reload();
-    await page.waitForLoadState("networkidle");
 
     await expect(
       page.getByTestId(`delegate-item-${delegate.userId}`),
@@ -319,7 +306,6 @@ test.describe.serial("Delegate sees buyer receipt", () => {
   }) => {
     await injectSession(context, delegate);
     await page.goto(`${APP_URLS.PAYMENTS}/en/assigned`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("assigned-orders-page")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -378,13 +364,11 @@ test.describe.serial("Delegate sees buyer receipt", () => {
     await expect(page.getByTestId("confirm-action-panel")).toBeVisible();
     await page.getByTestId("confirm-checkbox").check();
     await page.getByTestId("confirm-action-submit").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "delegate-order-approved");
 
     // After approval the order leaves the assigned list (only pending/evidence
     // orders are shown there).
     await page.reload();
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("assigned-orders-empty")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -397,7 +381,6 @@ test.describe.serial("Delegate sees buyer receipt", () => {
   test("Phase 6: buyer sees order approved", async ({ context, page }) => {
     await injectSession(context, buyer);
     await page.goto(`${APP_URLS.PAYMENTS}/en/purchases`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("order-status-approved").first()).toBeVisible(
       { timeout: ELEMENT_TIMEOUT_MS },

--- a/apps/auth/e2e/receipt-reference-flow.spec.ts
+++ b/apps/auth/e2e/receipt-reference-flow.spec.ts
@@ -170,7 +170,15 @@ test.describe.serial("Receipt + reference number payment flow", () => {
     });
     await page.getByTestId("search-bar-input").fill(PRODUCT_NAME);
 
-    const productCard = page.getByTestId("product-card-link").first();
+    // Filter by the product just searched for rather than taking whatever is
+    // first. The search is debounced, so straight after fill() the grid can
+    // still be showing the previous results, and .first() would click a stale
+    // card. This bit full-purchase-flow, which added the same product twice
+    // and then found one seller group where it expected two.
+    const productCard = page
+      .getByTestId("product-card-link")
+      .filter({ hasText: PRODUCT_NAME })
+      .first();
     await expect(productCard).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await productCard.click();
 

--- a/apps/auth/e2e/receipt-reference-flow.spec.ts
+++ b/apps/auth/e2e/receipt-reference-flow.spec.ts
@@ -7,10 +7,8 @@ import { expect, test } from "@playwright/test";
 import { cleanupTestData } from "./helpers/cleanup";
 import {
   APP_URLS,
-  DEBOUNCE_WAIT_MS,
   ELEMENT_TIMEOUT_MS,
   LONG_OPERATION_TIMEOUT_MS,
-  MUTATION_WAIT_MS,
   NAVIGATION_TIMEOUT_MS,
 } from "./helpers/constants";
 import {
@@ -69,10 +67,8 @@ test.describe.serial("Receipt + reference number payment flow", () => {
   }) => {
     await injectSession(context, seller);
     await page.goto(`${APP_URLS.STUDIO}/en`);
-    await page.waitForLoadState("networkidle");
 
     await page.getByTestId("new-product-button").click();
-    await page.waitForLoadState("networkidle");
 
     const nameField = page.getByTestId("inline-text-en-name_en");
     await nameField.click();
@@ -100,7 +96,6 @@ test.describe.serial("Receipt + reference number payment flow", () => {
   }) => {
     await injectSession(context, seller);
     await page.goto(`${APP_URLS.PAYMENTS}/en/payment-methods`);
-    await page.waitForLoadState("networkidle");
 
     await page.getByTestId("add-payment-method-button").click();
 
@@ -152,7 +147,6 @@ test.describe.serial("Receipt + reference number payment flow", () => {
     await snap(page, "seller-method-configured");
 
     await page.getByTestId("payment-method-save").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     await expect(page.getByTestId("payment-methods-page")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -170,21 +164,17 @@ test.describe.serial("Receipt + reference number payment flow", () => {
 
     // Find and add product to cart
     await page.goto(`${APP_URLS.STORE}/en`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("search-bar-input")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
     await page.getByTestId("search-bar-input").fill(PRODUCT_NAME);
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
 
     const productCard = page.getByTestId("product-card-link").first();
     await expect(productCard).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await productCard.click();
-    await page.waitForLoadState("networkidle");
 
     await page.getByTestId("hero-add-to-cart").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "buyer-product-added");
 
     // Open cart and proceed to checkout
@@ -218,7 +208,6 @@ test.describe.serial("Receipt + reference number payment flow", () => {
       )
       .toBeGreaterThan(1);
     await methodSelect.selectOption({ index: 1 });
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "buyer-method-selected");
 
     // Enter the bank reference / transfer number
@@ -230,7 +219,6 @@ test.describe.serial("Receipt + reference number payment flow", () => {
     // Upload the receipt image via the hidden file input
     const fileInput = sellerCard.getByTestId("receipt-file-input");
     await fileInput.setInputFiles(RECEIPT_FIXTURE);
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     // Verify receipt preview is visible — confirms the image was selected
     const receiptPreview = sellerCard.getByTestId("receipt-preview");
@@ -260,7 +248,6 @@ test.describe.serial("Receipt + reference number payment flow", () => {
   }) => {
     await injectSession(context, buyer);
     await page.goto(`${APP_URLS.PAYMENTS}/en/purchases`);
-    await page.waitForLoadState("networkidle");
 
     await expect(
       page.getByTestId("order-status-pending_verification").first(),
@@ -276,7 +263,6 @@ test.describe.serial("Receipt + reference number payment flow", () => {
   }) => {
     await injectSession(context, seller);
     await page.goto(`${APP_URLS.PAYMENTS}/en/sales`);
-    await page.waitForLoadState("networkidle");
 
     // Receipt viewer container must be present on the order card
     const receiptViewer = page.getByTestId("receipt-viewer").first();
@@ -332,9 +318,24 @@ test.describe.serial("Receipt + reference number payment flow", () => {
     await page.getByTestId("confirm-checkbox").check();
     await page.getByTestId("confirm-action-submit").click();
 
-    await page.waitForTimeout(MUTATION_WAIT_MS);
+    // The approve mutation invalidates the received-orders query on success,
+    // so the row's approve button disappears once the refetch lands. Waiting
+    // for that is a real signal the server accepted the write; the fixed sleep
+    // it replaces was guessing how long the write takes.
+    await expect(page.getByTestId(/^order-approve-/).first()).toBeHidden({
+      timeout: NAVIGATION_TIMEOUT_MS,
+    });
+
+    // Reload anyway, to prove it persisted rather than merely leaving the
+    // client cache -- and wait for the list to come back before asserting an
+    // absence against it, since an absence also holds on a page that has not
+    // rendered. Either the list or its empty state means the page is up.
     await page.reload();
-    await page.waitForLoadState("networkidle");
+    await expect(
+      page
+        .getByTestId("received-orders-list")
+        .or(page.getByTestId("received-orders-empty")),
+    ).toBeVisible({ timeout: NAVIGATION_TIMEOUT_MS });
 
     await expect(page.getByTestId(/^order-approve-/).first()).toBeHidden({
       timeout: NAVIGATION_TIMEOUT_MS,
@@ -347,7 +348,6 @@ test.describe.serial("Receipt + reference number payment flow", () => {
   test("Phase 6: buyer sees order approved", async ({ context, page }) => {
     await injectSession(context, buyer);
     await page.goto(`${APP_URLS.PAYMENTS}/en/purchases`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("order-status-approved").first()).toBeVisible(
       { timeout: ELEMENT_TIMEOUT_MS },

--- a/apps/auth/e2e/smoke-all-apps.spec.ts
+++ b/apps/auth/e2e/smoke-all-apps.spec.ts
@@ -133,7 +133,8 @@ test.describe("Smoke test -- all apps", () => {
 
       expect(response, `${appName} did not respond at ${url}`).not.toBeNull();
 
-      await page.waitForLoadState("networkidle");
+      // The status comes off the response object captured above, so it does
+      // not need the page to have settled at all.
       const status = response?.status() ?? 0;
 
       expect(

--- a/apps/auth/e2e/smoke-all-apps.spec.ts
+++ b/apps/auth/e2e/smoke-all-apps.spec.ts
@@ -25,7 +25,6 @@ test.describe("Smoke test -- all apps", () => {
   }) => {
     expect(authenticatedPage.email).toBeTruthy();
     await page.goto(`${APPS.auth}/en`);
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("account-settings-page")).toBeVisible({
       timeout: 10000,
@@ -41,7 +40,6 @@ test.describe("Smoke test -- all apps", () => {
   test("auth app: sign out works", async ({ page, authenticatedPage }) => {
     expect(authenticatedPage.email).toBeTruthy();
     await page.goto(`${APPS.auth}/en`);
-    await page.waitForLoadState("networkidle");
 
     // Verify we are actually on the authenticated page before signing out
     await expect(page.getByTestId("account-settings-page")).toBeVisible({
@@ -68,7 +66,6 @@ test.describe("Smoke test -- all apps", () => {
 
     // First verify the session is actually working on the auth app
     await page.goto(`${APPS.auth}/en`);
-    await page.waitForLoadState("networkidle");
     await expect(page.getByTestId("nav-user-email")).toBeVisible({
       timeout: 10000,
     });
@@ -85,10 +82,13 @@ test.describe("Smoke test -- all apps", () => {
         `${appName} returned ${response?.status()} at ${url}`,
       ).toBeLessThan(400);
 
-      await page.waitForLoadState("networkidle");
-
       // Verify we actually landed on the app and didn't get redirected
-      // to a login page (which would mean the session didn't carry over)
+      // to a login page (which would mean the session didn't carry over).
+      // toHaveURL retries, so it both waits and asserts -- the settle wait
+      // it replaces was only ever making a single later snapshot likelier
+      // to be right.
+      await expect(page).not.toHaveURL(/\/login/);
+
       const currentUrl = page.url();
       expect(
         currentUrl,

--- a/apps/auth/e2e/studio-product-ui.spec.ts
+++ b/apps/auth/e2e/studio-product-ui.spec.ts
@@ -242,8 +242,6 @@ test.describe.serial(
 
       // Open the pre-seeded product in edit mode
       await page.goto(`${APP_URLS.STUDIO}/en/products/${productId}`);
-      await page.waitForLoadState("networkidle");
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       // Verify the initial seeded section order: cards(0), accordion(1), two-column(2), gallery(3)
       await expect(page.getByTestId("section-type-0")).toHaveValue("cards");
@@ -261,7 +259,6 @@ test.describe.serial(
         .locator("[data-rfd-drag-handle-draggable-id]")
         .first();
       await dragAndDrop(page, sectionHandle0, "down", 1);
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       await expect(page.getByTestId("section-type-0")).toHaveValue("accordion");
       await expect(page.getByTestId("section-type-1")).toHaveValue("cards");
@@ -276,8 +273,6 @@ test.describe.serial(
 
       // Re-open and verify the new order persisted
       await page.goto(`${APP_URLS.STUDIO}/en/products/${productId}`);
-      await page.waitForLoadState("networkidle");
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       await snap(page, "sections-persistence-check");
 
@@ -302,8 +297,6 @@ test.describe.serial(
       await injectSession(context, seller);
 
       await page.goto(`${APP_URLS.STUDIO}/en/products/${productId}`);
-      await page.waitForLoadState("networkidle");
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       // Scope to desktop gallery to avoid strict-mode collision with mobile gallery
       const gallery = page.getByTestId("image-gallery-thumbs");
@@ -327,7 +320,6 @@ test.describe.serial(
 
       // Change cover to image 1
       await gallery.getByTestId("image-thumb-cover-1").click();
-      await page.waitForTimeout(DEBOUNCE_WAIT_MS);
       await snap(page, "cover-changed-to-1");
 
       await expect(gallery.getByTestId("image-thumb-cover-1")).toHaveAttribute(
@@ -341,7 +333,6 @@ test.describe.serial(
 
       // Revert cover back to image 0
       await gallery.getByTestId("image-thumb-cover-0").click();
-      await page.waitForTimeout(DEBOUNCE_WAIT_MS);
       await snap(page, "cover-reverted-to-0");
 
       await expect(gallery.getByTestId("image-thumb-cover-0")).toHaveAttribute(
@@ -373,7 +364,6 @@ test.describe.serial(
       await injectSession(context, seller);
 
       await page.goto(`${APP_URLS.STUDIO}/en`);
-      await page.waitForLoadState("networkidle");
 
       const rows = page.locator(`[data-testid^="product-row-"]`);
       await rows
@@ -390,7 +380,6 @@ test.describe.serial(
         .locator("[data-rfd-drag-handle-draggable-id]")
         .first();
       await dragAndDrop(page, handle, "down", 1);
-      await page.waitForTimeout(MUTATION_WAIT_MS);
       await snap(page, "product-list-after-reorder");
 
       const newFirstRowId = await rows.first().getAttribute("data-testid");
@@ -429,8 +418,6 @@ test.describe.serial(
       // ── Phase 1: open editor, confirm current order, drag-reorder ─────────────
 
       await page.goto(`${APP_URLS.STUDIO}/en/products/${productId}`);
-      await page.waitForLoadState("networkidle");
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       // Post-test-1 section layout: accordion(0), cards(1), two-column(2), gallery(3)
       await expect(page.getByTestId("section-item-title-0-0")).toHaveValue(
@@ -462,19 +449,15 @@ test.describe.serial(
 
       // Accordion (slot 0) — vertical droppable: move item 0 → position 1
       await dragAndDrop(page, itemDragHandle(page, 0, 0), "down", 1);
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       // Cards (slot 1) — horizontal droppable: move item 0 → position 1
       await dragAndDrop(page, itemDragHandle(page, 1, 0), "right", 1);
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       // Two-column (slot 2) — vertical droppable: move item 0 → position 1
       await dragAndDrop(page, itemDragHandle(page, 2, 0), "down", 1);
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       // Gallery (slot 3) — vertical droppable: move item 0 → position 1
       await dragAndDrop(page, itemDragHandle(page, 3, 0), "down", 1);
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       await snap(page, "section-items-after-reorder");
 
@@ -514,8 +497,6 @@ test.describe.serial(
       // ── Phase 2: re-open and verify the order persisted ───────────────────────
 
       await page.goto(`${APP_URLS.STUDIO}/en/products/${productId}`);
-      await page.waitForLoadState("networkidle");
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       await snap(page, "section-items-persistence-check");
 
@@ -564,8 +545,6 @@ test.describe.serial(
       // ── Phase 1: open editor, capture initial srcs, drag-reorder ─────────────
 
       await page.goto(`${APP_URLS.STUDIO}/en/products/${productId}`);
-      await page.waitForLoadState("networkidle");
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       const gallery = page.getByTestId("image-gallery-thumbs");
 
@@ -597,7 +576,6 @@ test.describe.serial(
         .locator("[data-rfd-drag-handle-draggable-id]")
         .first();
       await dragAndDrop(page, thumbHandle, "down", 1);
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       await snap(page, "carousel-after-reorder");
 

--- a/apps/auth/e2e/studio-product-ui.spec.ts
+++ b/apps/auth/e2e/studio-product-ui.spec.ts
@@ -605,10 +605,12 @@ test.describe.serial(
       // ── Phase 2: re-open and verify the order persisted ───────────────────────
 
       await page.goto(`${APP_URLS.STUDIO}/en/products/${productId}`);
-      await page.waitForLoadState("networkidle");
-      await page.waitForTimeout(MUTATION_WAIT_MS);
 
       const galleryReload = page.getByTestId("image-gallery-thumbs");
+      // Reading src attributes below is a one-shot read, so the gallery has to
+      // be there first. Waiting for it replaces both a settle wait and a fixed
+      // sleep, and says what it is waiting for.
+      await expect(galleryReload).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
 
       await snap(page, "carousel-persistence-check");
 

--- a/apps/auth/e2e/studio-ux-improvements.spec.ts
+++ b/apps/auth/e2e/studio-ux-improvements.spec.ts
@@ -102,7 +102,6 @@ test.describe.serial("Studio UX Improvements", { tag: "@ux" }, () => {
     const desktopThumbs = page.getByTestId("image-gallery-thumbs");
     const addImageBtn = desktopThumbs.getByTestId("image-thumb-add");
     await addImageBtn.click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     // Fill first image URL
     const urlInput = page.getByTestId("image-edit-url");
@@ -117,7 +116,6 @@ test.describe.serial("Studio UX Improvements", { tag: "@ux" }, () => {
 
     // Add second image
     await addImageBtn.click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     const urlInput2 = page.getByTestId("image-edit-url");
     await expect(urlInput2).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
@@ -156,7 +154,6 @@ test.describe.serial("Studio UX Improvements", { tag: "@ux" }, () => {
 
     // Navigate to edit the product
     await page.goto(`${APP_URLS.STUDIO}/en/products/${productId}`);
-    await page.waitForLoadState("networkidle");
     await expect(page.getByTestId("inline-image-carousel")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
@@ -177,7 +174,6 @@ test.describe.serial("Studio UX Improvements", { tag: "@ux" }, () => {
     const coverBtn1 = desktopThumbs.getByTestId("image-thumb-cover-1");
     await expect(coverBtn1).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await coverBtn1.click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "cover-set-on-second-image");
 
     // Verify the star on the second thumbnail is filled (yellow)
@@ -215,7 +211,6 @@ test.describe.serial("Studio UX Improvements", { tag: "@ux" }, () => {
   }) => {
     await injectSession(context, seller);
     await page.goto(`${APP_URLS.STUDIO}/en`);
-    await page.waitForLoadState("networkidle");
     await expect(page.getByTestId("product-table")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
@@ -251,7 +246,6 @@ test.describe.serial("Studio UX Improvements", { tag: "@ux" }, () => {
     // Search for the delegate user by email
     const searchInput = page.getByTestId("delegate-search-input");
     await searchInput.fill(delegate.email);
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
     await snap(page, "delegate-search");
 
     // Select the delegate from search results
@@ -267,7 +261,6 @@ test.describe.serial("Studio UX Improvements", { tag: "@ux" }, () => {
 
     // Submit
     await page.getByTestId("delegate-add-submit").click();
-    await page.waitForTimeout(MUTATION_WAIT_MS);
     await snap(page, "delegate-added");
 
     // Wait for the delegate to appear in the list (query invalidation)
@@ -279,7 +272,6 @@ test.describe.serial("Studio UX Improvements", { tag: "@ux" }, () => {
 
     // Navigate back to product table
     await page.goto(`${APP_URLS.STUDIO}/en`);
-    await page.waitForLoadState("networkidle");
     await expect(page.getByTestId("product-table")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
@@ -309,7 +301,6 @@ test.describe.serial("Studio UX Improvements", { tag: "@ux" }, () => {
 
     // Navigate to edit the product
     await page.goto(`${APP_URLS.STUDIO}/en/products/${productId}`);
-    await page.waitForLoadState("networkidle");
     await expect(page.getByTestId("inline-image-carousel")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });

--- a/apps/auth/e2e/studio-ux-improvements.spec.ts
+++ b/apps/auth/e2e/studio-ux-improvements.spec.ts
@@ -80,15 +80,21 @@ test.describe.serial("Studio UX Improvements", { tag: "@ux" }, () => {
   }) => {
     await injectSession(context, seller);
     await page.goto(`${APP_URLS.STUDIO}/en`);
-    await page.waitForLoadState("networkidle");
+
+    // The screenshot below wants a rendered page, and the click after it wants
+    // this button, so waiting for the button covers both -- and unlike a
+    // settle wait it fails with a useful message when the page does not load.
+    await expect(page.getByTestId("new-product-button")).toBeVisible({
+      timeout: ELEMENT_TIMEOUT_MS,
+    });
     await snap(page, "studio-product-list");
 
     // Create a new product
     await page.getByTestId("new-product-button").click();
-    await page.waitForLoadState("networkidle");
 
     // Fill product name
     const nameField = page.getByTestId("inline-text-en-name_en");
+    await expect(nameField).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
     await nameField.click();
     await nameField.fill("E2E Studio UX Product");
 

--- a/apps/payments/e2e/checkout-order-integrity.spec.ts
+++ b/apps/payments/e2e/checkout-order-integrity.spec.ts
@@ -2,11 +2,7 @@ import type { BrowserContext } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 import { cleanupTestData } from "../../auth/e2e/helpers/cleanup";
-import {
-  APP_URLS,
-  DEBOUNCE_WAIT_MS,
-  ELEMENT_TIMEOUT_MS,
-} from "../../auth/e2e/helpers/constants";
+import { APP_URLS, ELEMENT_TIMEOUT_MS } from "../../auth/e2e/helpers/constants";
 import {
   BUYER_PERMISSIONS,
   SELLER_PERMISSIONS,
@@ -145,9 +141,7 @@ test.describe.serial("Checkout order creation integrity", () => {
     await injectSession(context, buyer);
     await injectCartCookie(context, seller.userId, productId);
 
-    await page.goto(`${PAYMENTS_URL}/en/checkout`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${PAYMENTS_URL}/en/checkout`);
 
     await expect(
       page.getByTestId(`seller-checkout-${seller.userId}`),
@@ -166,9 +160,7 @@ test.describe.serial("Checkout order creation integrity", () => {
     await injectSession(context, buyer);
     await injectCartCookie(context, seller.userId, productId);
 
-    await page.goto(`${PAYMENTS_URL}/en/checkout`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${PAYMENTS_URL}/en/checkout`);
 
     const sellerCard = page.getByTestId(`seller-checkout-${seller.userId}`);
     await expect(sellerCard).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
@@ -177,7 +169,6 @@ test.describe.serial("Checkout order creation integrity", () => {
     await sellerCard
       .getByTestId("payment-method-select")
       .selectOption({ index: 1 });
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
 
     // Fill the transfer reference field
     await expect(
@@ -202,9 +193,7 @@ test.describe.serial("Checkout order creation integrity", () => {
     await injectSession(context, buyer);
     await injectCartCookie(context, seller.userId, productId);
 
-    await page.goto(`${PAYMENTS_URL}/en/checkout`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${PAYMENTS_URL}/en/checkout`);
 
     const sellerCard = page.getByTestId(`seller-checkout-${seller.userId}`);
     await expect(sellerCard).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
@@ -213,7 +202,6 @@ test.describe.serial("Checkout order creation integrity", () => {
     await sellerCard
       .getByTestId("payment-method-select")
       .selectOption({ index: 1 });
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
 
     // Fill the transfer reference field
     await expect(

--- a/apps/payments/e2e/delegated-reports.spec.ts
+++ b/apps/payments/e2e/delegated-reports.spec.ts
@@ -138,9 +138,7 @@ test.describe.serial("Delegated Reports page", () => {
     page,
   }) => {
     await injectSession(context, delegateUser);
-    await page.goto(`${getPaymentsBaseUrl()}/en/delegated-reports`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${getPaymentsBaseUrl()}/en/delegated-reports`);
     await expect(page.getByTestId("sidebar-delegatedReports")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
     });
@@ -158,7 +156,6 @@ test.describe.serial("Delegated Reports page", () => {
     await injectSession(context, delegateUser);
     await page.goto(
       `${getPaymentsBaseUrl()}/en/delegated-reports?status=approved`,
-      { waitUntil: "networkidle" },
     );
 
     await expect(page.getByTestId("delegated-report-table")).toBeVisible({
@@ -187,7 +184,6 @@ test.describe.serial("Delegated Reports page", () => {
     await injectSession(context, delegateUser);
     await page.goto(
       `${getPaymentsBaseUrl()}/en/delegated-reports?status=approved`,
-      { waitUntil: "networkidle" },
     );
 
     const table = page.getByTestId("delegated-report-table");
@@ -214,7 +210,6 @@ test.describe.serial("Delegated Reports page", () => {
     await injectSession(context, delegateUser);
     await page.goto(
       `${getPaymentsBaseUrl()}/en/delegated-reports?status=approved`,
-      { waitUntil: "networkidle" },
     );
     await expect(page.getByTestId("delegated-report-table")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -247,10 +242,16 @@ test.describe.serial("Delegated Reports page", () => {
     });
     try {
       await injectSession(context, noReportDelegate);
-      await page.goto(`${getPaymentsBaseUrl()}/en/delegated-reports`, {
-        waitUntil: "networkidle",
+      await page.goto(`${getPaymentsBaseUrl()}/en/delegated-reports`);
+
+      // This user is signed in, so the app shell renders for them -- the
+      // sidebar is there, just without the delegated-reports entry. Waiting
+      // for the shell is what makes the two absences below mean something:
+      // on a page that had not rendered they would both hold trivially.
+      await expect(page.getByTestId("sidebar-collapse-toggle")).toBeVisible({
+        timeout: ELEMENT_TIMEOUT_MS,
       });
-      await page.waitForTimeout(MUTATION_WAIT_MS);
+
       await expect(page.getByTestId("sidebar-delegatedReports")).toHaveCount(0);
       await expect(page.getByTestId("delegated-reports-page")).toHaveCount(0);
     } finally {

--- a/apps/payments/e2e/seller-reports.spec.ts
+++ b/apps/payments/e2e/seller-reports.spec.ts
@@ -2,7 +2,6 @@ import path from "node:path";
 import { expect, test } from "@playwright/test";
 
 import {
-  DEBOUNCE_WAIT_MS,
   ELEMENT_TIMEOUT_MS,
   MUTATION_WAIT_MS,
 } from "../../auth/e2e/helpers/constants";
@@ -117,9 +116,7 @@ test.describe.serial("Seller Reports page", () => {
     page,
   }) => {
     await injectSession(context, sellerUser);
-    await page.goto(`${getPaymentsBaseUrl()}/en/reports`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${getPaymentsBaseUrl()}/en/reports`);
 
     await expect(page.getByTestId("seller-reports-filters-bar")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -133,9 +130,7 @@ test.describe.serial("Seller Reports page", () => {
 
   test("status filter updates URL query param", async ({ context, page }) => {
     await injectSession(context, sellerUser);
-    await page.goto(`${getPaymentsBaseUrl()}/en/reports`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${getPaymentsBaseUrl()}/en/reports`);
 
     await expect(page.getByTestId("seller-reports-filters-bar")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -144,10 +139,13 @@ test.describe.serial("Seller Reports page", () => {
     await page
       .getByTestId("seller-reports-filter-status")
       .selectOption("approved");
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
-
-    const url = new URL(page.url());
-    expect(url.searchParams.get("status")).toBe("approved");
+    // Poll the URL instead of sleeping for the debounce and reading it once.
+    // The old shape asserted against a single snapshot taken after a fixed
+    // delay: too short and it fails, too long and every run pays for it.
+    // expect.poll retries until the debounced update lands.
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("status"))
+      .toBe("approved");
   });
 
   test("date range filters update URL query params", async ({
@@ -155,9 +153,7 @@ test.describe.serial("Seller Reports page", () => {
     page,
   }) => {
     await injectSession(context, sellerUser);
-    await page.goto(`${getPaymentsBaseUrl()}/en/reports`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${getPaymentsBaseUrl()}/en/reports`);
 
     await expect(page.getByTestId("seller-reports-filters-bar")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -167,11 +163,16 @@ test.describe.serial("Seller Reports page", () => {
       .getByTestId("seller-reports-filter-date-from")
       .fill("2024-01-01");
     await page.getByTestId("seller-reports-filter-date-to").fill("2099-12-31");
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
-
-    const url = new URL(page.url());
-    expect(url.searchParams.get("dateFrom")).toBe("2024-01-01");
-    expect(url.searchParams.get("dateTo")).toBe("2099-12-31");
+    // Poll the URL instead of sleeping for the debounce and reading it once.
+    // The old shape asserted against a single snapshot taken after a fixed
+    // delay: too short and it fails, too long and every run pays for it.
+    // expect.poll retries until the debounced update lands.
+    await expect
+      .poll(() => {
+        const params = new URL(page.url()).searchParams;
+        return { from: params.get("dateFrom"), to: params.get("dateTo") };
+      })
+      .toEqual({ from: "2024-01-01", to: "2099-12-31" });
   });
 
   test("amount min/max filters update URL query params", async ({
@@ -179,9 +180,7 @@ test.describe.serial("Seller Reports page", () => {
     page,
   }) => {
     await injectSession(context, sellerUser);
-    await page.goto(`${getPaymentsBaseUrl()}/en/reports`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${getPaymentsBaseUrl()}/en/reports`);
 
     await expect(page.getByTestId("seller-reports-filters-bar")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -189,18 +188,22 @@ test.describe.serial("Seller Reports page", () => {
 
     await page.getByTestId("seller-reports-filter-amount-min").fill("1000");
     await page.getByTestId("seller-reports-filter-amount-max").fill("999999");
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
-
-    const url = new URL(page.url());
-    expect(url.searchParams.get("amountMin")).toBe("1000");
-    expect(url.searchParams.get("amountMax")).toBe("999999");
+    // Poll the URL instead of sleeping for the debounce and reading it once.
+    // The old shape asserted against a single snapshot taken after a fixed
+    // delay: too short and it fails, too long and every run pays for it.
+    // expect.poll retries until the debounced update lands.
+    await expect
+      .poll(() => {
+        const params = new URL(page.url()).searchParams;
+        return { min: params.get("amountMin"), max: params.get("amountMax") };
+      })
+      .toEqual({ min: "1000", max: "999999" });
   });
 
   test("clear button removes all active filters", async ({ context, page }) => {
     await injectSession(context, sellerUser);
     await page.goto(
       `${getPaymentsBaseUrl()}/en/reports?status=approved&amountMin=100`,
-      { waitUntil: "networkidle" },
     );
 
     await expect(page.getByTestId("seller-reports-filters-bar")).toBeVisible({
@@ -211,11 +214,16 @@ test.describe.serial("Seller Reports page", () => {
     });
 
     await page.getByTestId("seller-reports-filter-clear").click();
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
-
-    const url = new URL(page.url());
-    expect(url.searchParams.get("status")).toBeNull();
-    expect(url.searchParams.get("amountMin")).toBeNull();
+    // Poll the URL instead of sleeping for the debounce and reading it once.
+    // The old shape asserted against a single snapshot taken after a fixed
+    // delay: too short and it fails, too long and every run pays for it.
+    // expect.poll retries until the debounced update lands.
+    await expect
+      .poll(() => {
+        const params = new URL(page.url()).searchParams;
+        return { status: params.get("status"), min: params.get("amountMin") };
+      })
+      .toEqual({ status: null, min: null });
   });
 
   test("URL filter params are respected on page load", async ({
@@ -223,9 +231,7 @@ test.describe.serial("Seller Reports page", () => {
     page,
   }) => {
     await injectSession(context, sellerUser);
-    await page.goto(`${getPaymentsBaseUrl()}/en/reports?status=approved`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${getPaymentsBaseUrl()}/en/reports?status=approved`);
 
     await expect(page.getByTestId("seller-reports-filters-bar")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -240,9 +246,7 @@ test.describe.serial("Seller Reports page", () => {
 
   test("shows the seeded order in the table", async ({ context, page }) => {
     await injectSession(context, sellerUser);
-    await page.goto(`${getPaymentsBaseUrl()}/en/reports?status=approved`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${getPaymentsBaseUrl()}/en/reports?status=approved`);
 
     await expect(page.getByTestId("seller-report-table")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -260,9 +264,7 @@ test.describe.serial("Seller Reports page", () => {
     page,
   }) => {
     await injectSession(context, sellerUser);
-    await page.goto(`${getPaymentsBaseUrl()}/en/reports?status=approved`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${getPaymentsBaseUrl()}/en/reports?status=approved`);
 
     await expect(page.getByTestId("seller-report-table")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -279,11 +281,17 @@ test.describe.serial("Seller Reports page", () => {
     page,
   }) => {
     await injectSession(context, sellerUser);
-    await page.goto(`${getPaymentsBaseUrl()}/en/reports?status=pending`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${getPaymentsBaseUrl()}/en/reports?status=pending`);
 
-    await page.waitForTimeout(MUTATION_WAIT_MS);
+    // The table renders either rows or an empty state, so waiting for one of
+    // them proves the filtered page finished rendering. The assertion below is
+    // an absence, and an absence is also satisfied by a page that never
+    // rendered -- that is what the sleep was covering for.
+    await expect(
+      page
+        .getByTestId("seller-report-table")
+        .or(page.getByTestId("seller-report-empty")),
+    ).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
 
     await expect(
       page
@@ -302,11 +310,17 @@ test.describe.serial("Seller Reports page", () => {
     );
     try {
       await injectSession(context, otherSeller);
-      await page.goto(`${getPaymentsBaseUrl()}/en/reports`, {
-        waitUntil: "networkidle",
-      });
+      await page.goto(`${getPaymentsBaseUrl()}/en/reports`);
 
-      await page.waitForTimeout(MUTATION_WAIT_MS);
+      // The table renders either rows or an empty state, so waiting for one of
+      // them proves the filtered page finished rendering. The assertion below is
+      // an absence, and an absence is also satisfied by a page that never
+      // rendered -- that is what the sleep was covering for.
+      await expect(
+        page
+          .getByTestId("seller-report-table")
+          .or(page.getByTestId("seller-report-empty")),
+      ).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
 
       // The seeded order belongs to sellerUser, not otherSeller — must not be visible
       await expect(
@@ -328,10 +342,7 @@ test.describe.serial("Seller Reports page", () => {
     await injectSession(context, sellerUser);
     await page.goto(
       `${getPaymentsBaseUrl()}/en/reports?status=pending&amountMin=9999999`,
-      { waitUntil: "networkidle" },
     );
-
-    await page.waitForTimeout(MUTATION_WAIT_MS);
 
     const exportButton = page.getByTestId("seller-reports-export-button");
     await expect(exportButton).toBeVisible({ timeout: ELEMENT_TIMEOUT_MS });
@@ -343,9 +354,7 @@ test.describe.serial("Seller Reports page", () => {
     page,
   }) => {
     await injectSession(context, sellerUser);
-    await page.goto(`${getPaymentsBaseUrl()}/en/reports?status=approved`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${getPaymentsBaseUrl()}/en/reports?status=approved`);
 
     await expect(page.getByTestId("seller-report-table")).toBeVisible({
       timeout: ELEMENT_TIMEOUT_MS,
@@ -367,14 +376,30 @@ test.describe.serial("Seller Reports page", () => {
     page,
   }) => {
     // No session injection
-    await page.goto(`${getPaymentsBaseUrl()}/en/reports`, {
-      waitUntil: "networkidle",
-    });
+    await page.goto(`${getPaymentsBaseUrl()}/en/reports`);
 
     // The app may redirect to login or serve the page and fail the API with
     // 401. Either is fine; an unauthenticated visitor must not see report data
     // in either case, so assert that invariant directly instead of branching
     // on which enforcement path ran.
+    //
+    // But an absence proves nothing against a page that has not rendered, so
+    // wait for the app to have visibly done one of the two things first --
+    // navigated away, or drawn the page shell. Phrased as "either", so it
+    // holds whichever path enforcement takes and does not encode a guess
+    // about the login screen's markup.
+    await expect
+      .poll(
+        async () => {
+          const stillOnReports = new URL(page.url()).pathname.endsWith(
+            "/reports",
+          );
+          if (!stillOnReports) return true;
+          return page.getByTestId("seller-reports-filters-bar").isVisible();
+        },
+        { timeout: ELEMENT_TIMEOUT_MS },
+      )
+      .toBe(true);
     await expect(page.getByTestId("seller-report-table")).toBeHidden({
       timeout: ELEMENT_TIMEOUT_MS,
     });

--- a/apps/payments/src/features/reports/presentation/components/SellerReportTable.tsx
+++ b/apps/payments/src/features/reports/presentation/components/SellerReportTable.tsx
@@ -17,7 +17,10 @@ export function SellerReportTable({ orders }: SellerReportTableProps) {
 
   if (orders.length === 0) {
     return (
-      <div className="flex items-center justify-center rounded-lg border border-foreground/10 py-16 text-sm text-muted-foreground">
+      <div
+        className="flex items-center justify-center rounded-lg border border-foreground/10 py-16 text-sm text-muted-foreground"
+        {...tid("seller-report-empty")}
+      >
         {t("noResults")}
       </div>
     );

--- a/apps/payments/tests/SellerReportTable.test.tsx
+++ b/apps/payments/tests/SellerReportTable.test.tsx
@@ -47,7 +47,10 @@ function makeOrder(id: string): SellerReportOrder {
 describe("SellerReportTable", () => {
   it("shows empty state when no orders", () => {
     render(<SellerReportTable orders={[]} />);
-    expect(screen.getByText("noResults")).toBeInTheDocument();
+    // Asserted by test id, not by the translated string. The empty state had
+    // no test id at all, which is why the e2e suite could not wait for it and
+    // slept instead -- there was nothing observable to wait for.
+    expect(screen.getByTestId("seller-report-empty")).toBeInTheDocument();
   });
 
   it("renders table with orders", () => {

--- a/apps/store/e2e/auth.setup.ts
+++ b/apps/store/e2e/auth.setup.ts
@@ -2,12 +2,16 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { clerk, clerkSetup } from "@clerk/testing/playwright";
-import { test as setup } from "@playwright/test";
+import { expect, test as setup } from "@playwright/test";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { resolveE2EAppUrls } = require(
   path.resolve(__dirname, "../../../scripts/app-url-resolver.js"),
 );
+
+// resolveProfile() runs on a page load, so this only has to outlast one
+// server round-trip plus the write.
+const PROFILE_TIMEOUT_MS = 15_000;
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 if (!SUPABASE_URL)
@@ -67,12 +71,38 @@ setup("authenticate", async ({ page }) => {
   // permission-gated page and ProtectedRoute check in the suite would fail:
   // there is no DB trigger provisioning profiles anymore (Task 8 removed the
   // `auth.users`-keyed one).
-  await page.goto(`${AUTH_URL}/en/callback`, { waitUntil: "networkidle" });
+  await page.goto(`${AUTH_URL}/en/callback`);
 
   const { createClient } = await import("@supabase/supabase-js");
   const supabaseAdmin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
     auth: { autoRefreshToken: false, persistSession: false },
   });
+
+  // Wait for the row itself, not for the network to go quiet. This step has no
+  // DOM assertion -- the thing it cares about is a server-side write -- so a
+  // networkidle wait was standing in for "the write probably landed by now".
+  // Polling the row makes the wait the actual condition: it ends the moment
+  // resolveProfile() has committed, and fails loudly if it never does.
+  await expect
+    .poll(
+      async () => {
+        const { data } = await supabaseAdmin
+          .from("user_profiles")
+          .select("id")
+          .eq("identity_sub", clerkUser.id)
+          .maybeSingle();
+        return data?.id ?? null;
+      },
+      {
+        timeout: PROFILE_TIMEOUT_MS,
+        message: `resolveProfile() never created a profile for ${clerkUser.id}`,
+      },
+    )
+    .not.toBeNull();
+
+  // Read it back plainly now that the poll has established it exists. Keeping
+  // the row out of the poll's closure avoids narrowing a closure-assigned
+  // variable, which TypeScript cannot follow.
   const { data: profile, error } = await supabaseAdmin
     .from("user_profiles")
     .select("id")

--- a/apps/store/src/features/products/presentation/components/ProductDetail/MobileBar.tsx
+++ b/apps/store/src/features/products/presentation/components/ProductDetail/MobileBar.tsx
@@ -41,7 +41,10 @@ export function MobileBar({
           </span>
         </span>
         {quantityInCart > 0 && (
-          <span className="flex items-center gap-1 text-label-xs font-bold uppercase tracking-widest sm:text-xs">
+          <span
+            className="flex items-center gap-1 text-label-xs font-bold uppercase tracking-widest sm:text-xs"
+            {...tid("product-detail-mobile-in-cart")}
+          >
             <ShoppingCart className="size-3" />
             {t("inCart", { count: quantityInCart })}
           </span>

--- a/apps/store/tests/MobileBar.test.tsx
+++ b/apps/store/tests/MobileBar.test.tsx
@@ -134,7 +134,12 @@ describe("MobileBar", () => {
         quantityInCart={3}
       />,
     );
-    expect(screen.getByText("inCart:3")).toBeInTheDocument();
+    // By test id, not by the translated string. The indicator had no test
+    // id, so an e2e test had no way to see that an item reached the cart
+    // and slept for a fixed 500ms before navigating on instead.
+    expect(
+      screen.getByTestId("product-detail-mobile-in-cart"),
+    ).toHaveTextContent("inCart:3");
   });
 
   it("does not show in-cart when quantityInCart is 0", () => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -138,12 +138,20 @@ const eslintConfig = defineConfig([
   })),
   // Override default ignores of eslint-config-next.
   globalIgnores([
-    // Default ignores of eslint-config-next:
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
+    // Default ignores of eslint-config-next, re-globbed for a monorepo. These
+    // shipped as ".next/**", which only ever matched a .next at the repo root
+    // -- and the build output lives at apps/<app>/.next. `eslint .` was
+    // linting 212 files of minified output per app, ~28k messages each.
+    // `pnpm lint` never showed it because it lists src directories explicitly,
+    // so the gate passed by not looking. "**/node_modules/**" below was
+    // already correct, which is what the others should have looked like.
+    "**/.next/**",
+    "**/out/**",
+    "**/build/**",
+    "**/next-env.d.ts",
     "**/node_modules/**",
+    // Git-ignored agent scratch: throwaway probe scripts, not shipped code.
+    ".superpowers/**",
     // Frozen snapshot of the pre-rework tests. Linting a read-only copy would
     // only ever demand edits to a file that is meant to stay identical to what
     // it is a copy of. Deleted when the rework is verified complete.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -69,8 +69,11 @@ const playwrightConfig = {
     // rewrote `const href = await link.getAttribute("href")` into
     // `const href = link`, silently turning a string into a Locator and breaking
     // the three assertions below it. Typecheck caught it; review every hunk.
-    "playwright/no-networkidle": "warn", // 118 — waits on a heuristic, not a condition
-    "playwright/no-wait-for-timeout": "warn", // 96 — the main flakiness source
+    // Both were "warn" with backlogs of 118 and 96. The backlog is gone: every
+    // site either waits on the condition it actually cared about, or carries a
+    // disable naming the third-party page it cannot anchor against.
+    "playwright/no-networkidle": "error",
+    "playwright/no-wait-for-timeout": "error",
     // expect-expect is an ERROR, not a warning: a test that asserts nothing
     // passes no matter how the product behaves, so it is the one defect a test
     // suite cannot detect on its own. It reported 11 violations before this

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "tunnel:stop": "node scripts/cloudflared-stop.mjs",
     "tunnel:switch": "node scripts/tunnel-switch.mjs",
     "lint:env": "node scripts/check-env-parity.mjs",
-    "lint": "eslint --no-error-on-unmatched-pattern apps/store/src apps/studio/src apps/landing/src apps/payments/src apps/admin/src apps/auth/src apps/playground/src packages/ui/src packages/shared/src packages/api/src packages/app-components/src packages/auth/src apps/store/tests apps/studio/tests apps/landing/tests apps/payments/tests apps/admin/tests apps/auth/tests apps/playground/tests packages/ui/tests packages/shared/tests packages/api/tests packages/app-components/tests packages/auth/tests tests/db apps/store/e2e apps/studio/e2e apps/landing/e2e apps/payments/e2e apps/admin/e2e apps/auth/e2e apps/playground/e2e",
+    "lint": "eslint .",
     "typecheck": "turbo typecheck",
     "test": "turbo test",
     "test:watch": "vitest",


### PR DESCRIPTION
## Lint coverage

`pnpm lint` enumerated **32 source directories**. Anything outside them was unlinted, and nothing said so — 127 files were invisible, including **all ~40 of `scripts/`**, among them `backup-prod.mjs`, the production restore path.

It ran that way because `eslint .` was unusable: eslint-config-next's default ignores arrived as `".next/**"`, which matches only at the repo root, while the build output lives at `apps/<app>/.next`. A bare `eslint .` linted **212 files of minified output per app, ~170k messages total**. The directory list was a workaround for a broken ignore — and the workaround is what let real files slip out of scope.

Re-globbed to `**/.next/**`, which is what `**/node_modules/**` on the next line already looked like. `pnpm lint` is now just `eslint .`.

Widening the scope immediately surfaced one **error** that had been sitting outside it.

## Timing waits → real conditions

Clears every `no-networkidle` and `no-wait-for-timeout` violation in **admin, store and payments** (39 total).

Most were redundant — a wait immediately before a positive, retrying assertion. Four were sleeps before a **one-shot URL read**, now `expect.poll`. 

The interesting ones were the **six sleeps guarding an absence**. I had previously kept five of those deliberately, with a comment arguing a settle window was needed because the assertion was negative. The reasoning was right and the conclusion was wrong: the fix for a negative assertion is to anchor a positive one before it, not to sleep first.

Two of those sleeps existed because **the thing they waited for was not observable**:

- audit filter pills marked the active one with a CSS class and nothing else — exactly what the e2e-selectors rule exists to prevent. Added `aria-pressed`.
- the seller-reports empty state had no test id at all. Added one.

Both TDD, both watched failing first. A pair of one-shot `isVisible()` reads that raced their own render went too.

lint: 0 errors, 233 warnings (was 272 at the start, ~170k before the ignore fix).

---

## Both rules promoted to `error`

`no-networkidle` and `no-wait-for-timeout` were `warn` with backlogs of **118 and 96**. Both are now **`error` with a backlog of zero** — verified by reintroducing a violation, watching it fail, and reverting.

The sweep covered admin, store, payments and auth. Most sites were a wait sitting in front of something that already waits. The interesting ones:

- **approve / delegate flows** — the sleep was covering the gap between clicking and the server committing, so reloading too early showed stale data. Both mutations invalidate their query on success, so the UI updates on its own once the refetch lands. The reload stays, now proving persistence instead of masking a race. I nearly anchored on the confirmation panel closing — reading the source, `setMode(null)` runs synchronously right after `onAction`, so that anchor would have raced the very write the sleep existed for.
- **three places slept because state was rendered but not observable** — audit filter pills (CSS class only), the seller-reports empty state (no test id), the mobile in-cart indicator (no test id). All three got the missing attribute, TDD, watched failing first.

**Two waits stay**, each disabled with its reason inline: Google's poll interval across markup that varies by account state and locale, and Discord's wait before a three-way branch on which of three states its page settled into. Both are third-party pages exercisable only against the live provider.

Worth flagging: my first attempt at those disables **did nothing**. `eslint-disable-next-line` applies to the line after the directive, and mine was the first of five comment lines — so "next line" was another comment. The violation count caught it; the directive itself looked correct.

**lint: 0 errors, 93 warnings** — down from 272 at branch start, and ~170k before the ignore fix.


---

## A regression this branch caused, and what it turned out to be

CI rejected the sweep three times on `full-purchase-flow` Phase 3 — "expected 2 seller groups, received 1". Worth recording because I got the diagnosis wrong twice before getting it right.

The classifier's rule was *"is the next assertion positive and retrying?"* — which is **not** the same question as *"does the next assertion say anything about what this wait was protecting?"* After the add-to-cart click, the next assertion was that the search bar had rendered on the following page. Positive, retrying, and entirely unrelated to the cart.

So I blamed the cart, because that's where the assertion pointed:

1. **Waited for the in-cart indicator** — proves React took the item. Passed, test still failed.
2. **Polled the cart cookie** — the cart persists from a `useEffect`, and it's the cookie, not the DOM, that survives a navigation. Also failed.
3. **Restored the sleeps outright** — *still failed*. That's what finally pointed elsewhere.

The real cause: the store's search is **debounced**. The test fills the search box then takes `product-card-link.first()`, so it was clicking a stale card — **the same product both times**. The debounce sleep I'd removed never guarded this properly either; it made the right card *likely* to be first and never checked that it was.

Filtering by the product name makes the locator wait for the debounced results *and* click the right product. **Three other specs had the same latent shape** and are fixed the same way — they pass today only because they search for a product that happens to sort first.

With that fixed, the cart sleeps came back out and E2E is green — confirming they were never the cause.

## Final state

Both rules are **`error` with zero violations**. Three documented exceptions, each with its reason inline: `@hello-pangea/dnd`'s keyboard drag, and the two OAuth provider pages.
