### PR TITLE
feat(ci): fail on control characters in source [GH-000]

### DIFF
--- a/.ai-context/reviews/2026-03-24_21-46-41_review.md
+++ b/.ai-context/reviews/2026-03-24_21-46-41_review.md
@@ -655,7 +655,7 @@
 
 ### [COMP-007] NarrowedProduct interface and toNarrowed helper co-located with ProductSections component
 
-- **File:** `apps/store/src/features/productspresentation/components/product-detail/ProductSections.tsx`
+- **File:** `apps/store/src/features/products/presentation/components/product-detail/ProductSections.tsx`
 - **Line:** 23
 - **Description:** ProductSections.tsx contains a NarrowedProduct interface and two helper functions (hasTypeDetails, toNarrowed) that handle product data narrowing logic. This is domain-level logic co-located in a presentation file. The component itself follows good structure (hooks -> derived -> render).
 - **Fix:** Consider moving NarrowedProduct and toNarrowed to the domain layer (e.g., features/products/domain/narrowProduct.ts) since they represent business logic about what product data is available.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
           pnpm exec ls-lint
           pnpm exec cspell "**/*.{ts,tsx,md,json}" --no-progress
           pnpm exec jscpd .
+          node scripts/check-source-bytes.mjs
           pnpm exec madge --circular --extensions ts,tsx,js,jsx apps/store/src apps/studio/src apps/landing/src apps/payments/src apps/admin/src apps/auth/src apps/playground/src packages/ui/src packages/shared/src packages/api/src packages/app-components/src packages/auth/src tests scripts docker
 
       - name: Lint (scoped)

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "test:db": "node scripts/test-db.mjs",
     "test:inventory": "node scripts/test-inventory.mjs",
     "test:inventory:diff": "bash scripts/test-inventory-diff.sh",
-    "check:migrations": "node scripts/check-migration-edits.mjs"
+    "check:migrations": "node scripts/check-migration-edits.mjs",
+    "check:source-bytes": "node scripts/check-source-bytes.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/scripts/__tests__/check-source-bytes.test.mjs
+++ b/scripts/__tests__/check-source-bytes.test.mjs
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { findControlByte } from "../check-source-bytes.mjs";
+
+describe("findControlByte", () => {
+  it("accepts ordinary text", () => {
+    expect(findControlByte(Buffer.from("const a = 1;\n"))).toBeNull();
+  });
+
+  it("accepts tab, newline and carriage return", () => {
+    // The three a text file legitimately holds; CRLF checkouts depend on it.
+    expect(findControlByte(Buffer.from("a\tb\r\nc\n"))).toBeNull();
+  });
+
+  it("finds the byte a mangled \b escape leaves behind", () => {
+    // 0x08 is what a shell heredoc wrote in place of `\b` in a URL regex,
+    // four separate times, while removing Playwright's timing waits.
+    const buf = Buffer.from(`const re = /\u0008auth/;\n`);
+
+    expect(findControlByte(buf)).toEqual({ byte: 8, line: 1, column: 13 });
+  });
+
+  it("reports the line the byte is on, not the first line", () => {
+    const buf = Buffer.from(`line one\nline two\nthree \u0010 here\n`);
+
+    expect(findControlByte(buf)?.line).toBe(3);
+  });
+
+  it("finds a NUL", () => {
+    // aeleos's case: a literal NUL inside content-['—\00a0'] reached main and
+    // rendered a replacement glyph on every public page.
+    expect(findControlByte(Buffer.from("content-['\u0000a0']"))?.byte).toBe(0);
+  });
+});

--- a/scripts/__tests__/load-env.test.js
+++ b/scripts/__tests__/load-env.test.js
@@ -19,8 +19,9 @@ import {
   vi,
 } from "vitest";
 import fc from "fast-check";
-import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -36,27 +37,33 @@ const TRACKED_KEYS = [
 
 let savedEnv = {};
 
-// The local resolution path reads .secrets, which is gitignored and so absent
-// in CI. That is why widening test:workflows to this file first turned CI red.
-// Rather than narrow the gate back, write a placeholder .secrets for the run
-// and remove it again -- but only when there is none, so a developer's real
-// file is never touched.
-const secretsPath = resolve(__dirname, "../../.secrets");
-let wroteSecretsFixture = false;
+// The local resolution path reads a secrets file. Pointing it at a temp file
+// keeps the suite off the repository's real .secrets: writing a placeholder
+// there and deleting it afterwards is shared mutable state, and it failed
+// about one run in six. The key names come from the $secret: references in
+// .env.dev, so the fixture cannot drift out of step with them.
+const secretsFixture = join(
+  mkdtempSync(join(tmpdir(), "libra-load-env-")),
+  ".secrets",
+);
+let previousSecretsPath;
 
 beforeAll(() => {
-  if (existsSync(secretsPath)) return;
   const envDev = readFileSync(resolve(__dirname, "../../.env.dev"), "utf-8");
   const refs = [...envDev.matchAll(/\$secret:([A-Z0-9_]+)/g)].map((m) => m[1]);
   const body = [...new Set(refs)]
     .map((name) => `${name}=fixture-${name.toLowerCase()}`)
     .join("\n");
-  writeFileSync(secretsPath, `# written by load-env.test.js\n${body}\n`);
-  wroteSecretsFixture = true;
+  writeFileSync(secretsFixture, `# written by load-env.test.js\n${body}\n`);
+  previousSecretsPath = process.env.LOAD_ENV_SECRETS_PATH;
+  process.env.LOAD_ENV_SECRETS_PATH = secretsFixture;
 });
 
 afterAll(() => {
-  if (wroteSecretsFixture) rmSync(secretsPath, { force: true });
+  rmSync(dirname(secretsFixture), { recursive: true, force: true });
+  if (previousSecretsPath === undefined)
+    delete process.env.LOAD_ENV_SECRETS_PATH;
+  else process.env.LOAD_ENV_SECRETS_PATH = previousSecretsPath;
 });
 
 beforeEach(() => {

--- a/scripts/check-source-bytes.mjs
+++ b/scripts/check-source-bytes.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Fails when a file that could reach a commit carries a control character.
+ *
+ * A gate on the repository rather than a unit test, and a plain script for
+ * that reason: it reads a couple of thousand files, and bulk IO inside a test
+ * runner is a body being timed against a budget meant for unit tests.
+ *
+ * **It exists because this class of damage is invisible to every other
+ * check.** A mangled escape is still valid source: TypeScript parses it,
+ * Prettier reformats around it, ESLint reports green. The only symptom is
+ * usually grep calling a file binary in the output of an unrelated search,
+ * which is not a test.
+ *
+ * Two instances, both real and both silent:
+ *
+ * - This repository carried a 0x10 where a `/` belonged, so a review document
+ *   recorded a source path as `features<DLE>presentation`. It had been in the
+ *   tree since March and nothing had ever reported it.
+ * - While removing Playwright's timing waits, a shell heredoc turned `\b` in
+ *   a URL regex into a literal 0x08 four separate times. Each one changed
+ *   what the pattern matched, and each was found by eye, through `cat -v`,
+ *   after the behaviour looked wrong.
+ *
+ * Adapted from aeleos's script of the same name, which was written after a
+ * literal NUL reached main inside a Tailwind `content-['—\00a0']` and rendered
+ * a replacement glyph on every public page.
+ *
+ * Usage:
+ *   node scripts/check-source-bytes.mjs
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+
+/** The extensions worth reading. Anything else may legitimately be binary. */
+const TEXT = /\.(ts|tsx|js|jsx|mjs|cjs|css|json|sql|md|ya?ml)$/;
+
+/** Tab, newline, carriage return — the three a text file legitimately holds. */
+const ALLOWED_CONTROL = new Set([9, 10, 13]);
+
+/**
+ * Every text file that could reach a commit: tracked, plus untracked files git
+ * would not ignore.
+ *
+ * Asked of git rather than crawled, which is a correctness choice before it is
+ * a speed one — a hand-written list of directories to skip is .gitignore
+ * restated, and free to drift from it. `--others --exclude-standard` keeps a
+ * file written a moment ago and not yet staged inside the gate, which is
+ * exactly when a mangled escape is still cheap to fix.
+ */
+function candidateFiles() {
+  const ask = (args) =>
+    execFileSync("git", args, { encoding: "utf-8" })
+      .split("\n")
+      .filter(Boolean);
+
+  const paths = new Set([
+    ...ask(["ls-files", "--cached"]),
+    ...ask(["ls-files", "--others", "--exclude-standard"]),
+  ]);
+
+  // --cached reports what the INDEX holds, which includes a file deleted in
+  // the working tree whose deletion is not yet staged: a path with no bytes
+  // behind it.
+  return [...paths].filter((p) => TEXT.test(p) && existsSync(p));
+}
+
+/**
+ * @param {Buffer} buf
+ * @returns {{ byte: number, line: number, column: number } | null}
+ */
+export function findControlByte(buf) {
+  let line = 1;
+  let column = 1;
+  for (const byte of buf) {
+    if (byte === 10) {
+      line += 1;
+      column = 1;
+      continue;
+    }
+    if (byte < 32 && !ALLOWED_CONTROL.has(byte)) return { byte, line, column };
+    column += 1;
+  }
+  return null;
+}
+
+function main() {
+  const files = candidateFiles();
+  const offenders = [];
+
+  for (const file of files) {
+    const found = findControlByte(readFileSync(file));
+    if (found) offenders.push({ file, ...found });
+  }
+
+  if (offenders.length === 0) {
+    console.log(`✓ No control characters in ${files.length} text files.`);
+    return;
+  }
+
+  console.error("Control characters found:\n");
+  for (const o of offenders) {
+    const hex = o.byte.toString(16).padStart(2, "0");
+    console.error(`  ${o.file}:${o.line}:${o.column}  0x${hex}`);
+  }
+  console.error(
+    "\nThese are almost always a mangled escape -- a tool wrote the character" +
+      "\nthe escape names instead of the escape. `cat -v <file>` shows them as" +
+      "\n^X. Nothing else in this repository reports them: the file is still" +
+      "\nvalid source, so the compiler, the formatter and the linter all pass.\n",
+  );
+  process.exit(1);
+}
+
+// Importable for its test; only scans when run directly.
+if (process.argv[1]?.endsWith("check-source-bytes.mjs")) main();

--- a/scripts/load-env.mjs
+++ b/scripts/load-env.mjs
@@ -73,12 +73,29 @@ function readEnvFile(env) {
   return parseEnvContent(readFileSync(fullPath, "utf-8")); // nosemgrep: AIK_ts_generic_path_traversal
 }
 
-// Reads and parses the .secrets file. Path is fully hardcoded — no external
-// input flows into the file read.
+// Where the secrets file lives. Hardcoded to the repository root, with one
+// documented exception: LOAD_ENV_SECRETS_PATH.
+//
+// The exception exists for the test suite. These tests used to exercise the
+// local path by writing a placeholder .secrets at the repository root and
+// removing it afterwards, which is shared mutable state -- it failed roughly
+// one run in six, and a flaky gate teaches people to re-run rather than read.
+// Pointing the test at its own temp file removes the shared state instead of
+// retrying around it.
+//
+// It is read from the environment rather than passed as an argument because
+// loadEnv is called by scripts that must not know about it.
+function secretsFilePath() {
+  return process.env.LOAD_ENV_SECRETS_PATH
+    ? resolve(process.env.LOAD_ENV_SECRETS_PATH) // nosemgrep: AIK_ts_generic_path_traversal
+    : resolve(rootDir, ".secrets");
+}
+
+// Reads and parses the secrets file.
 function readSecretsFile() {
-  const fullPath = resolve(rootDir, ".secrets");
+  const fullPath = secretsFilePath();
   if (!existsSync(fullPath)) return {};
-  return parseEnvContent(readFileSync(fullPath, "utf-8"));
+  return parseEnvContent(readFileSync(fullPath, "utf-8")); // nosemgrep: AIK_ts_generic_path_traversal
 }
 
 const SECRET_RE = /(?<!\$)\$secret:([A-Z][A-Z0-9_]*)/g;
@@ -160,7 +177,7 @@ export function loadEnv(targetEnv) {
         }
       }
     } else {
-      if (!existsSync(resolve(rootDir, ".secrets"))) {
+      if (!existsSync(secretsFilePath())) {
         throw new Error("Missing .secrets file. Run pnpm sync-secrets.");
       }
       resolveSecrets(vars, readSecretsFile());


### PR DESCRIPTION
Ported from AeleOS. It catches a class of damage every other check is **structurally blind to**: a mangled escape is still valid source, so TypeScript parses it, Prettier reformats around it and ESLint reports green. The usual symptom is grep calling a file binary in the output of an unrelated search — which is not a test.

## Two real instances

- **This repository carried a `0x10` where a `/` belonged**, so a review document recorded a source path as `features<DLE>presentation`. It had been in the tree since March. Fixed here.
- While removing Playwright's timing waits earlier in this work, a shell heredoc turned `\b` in a URL regex into a **literal `0x08`, four separate times**. Each changed what the pattern matched; each was found by eye with `cat -v` after the behaviour looked wrong.

AeleOS wrote theirs after a literal NUL reached `main` inside a Tailwind `content-['—\00a0']`, rendering a replacement glyph on every public page.

The file set is asked of **git** rather than crawled — a hand-written list of directories to skip is `.gitignore` restated and free to drift from it. Untracked-but-not-ignored files are included, because that's exactly when a mangled escape is still cheap to fix.

Five tests on the byte finder, plus an end-to-end run against a planted `0x08`: reports file, line and column, exits 1.

## Also: a flake I introduced two commits ago, fixed before it reached anyone

Widening `test:workflows` brought `load-env.test.js` into the gate, and I'd made it write a placeholder `.secrets` at the repo root and delete it afterwards. That's **shared mutable state, and it failed about one run in six** — I only caught it by running the suite eight times instead of once.

A flaky gate is worse than no gate: it teaches people to re-run instead of read.

`load-env.mjs` now takes `LOAD_ENV_SECRETS_PATH`, so the test points at its own temp file and touches nothing shared. The override is documented at the function, opt-in, and the default path is unchanged — verified by loading `.env.dev` without it and watching the real secret resolve. **Eight consecutive clean runs** after.