### PR TITLE
test(studio): page-level accessibility, and name the last six controls [GH-000]

### DIFF
--- a/apps/admin/src/features/templates/presentation/components/SectionBlock.tsx
+++ b/apps/admin/src/features/templates/presentation/components/SectionBlock.tsx
@@ -65,6 +65,7 @@ export function SectionBlock({
               {t("sectionType")}
             </label>
             <select
+              aria-label={t("sectionType")}
               value={section.type}
               onChange={(e) =>
                 onUpdate({ type: e.target.value as ProductSection["type"] })

--- a/apps/auth/e2e/studio-accessibility.spec.ts
+++ b/apps/auth/e2e/studio-accessibility.spec.ts
@@ -1,0 +1,132 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+import { APP_URLS, ELEMENT_TIMEOUT_MS } from "./helpers/constants";
+import {
+  SELLER_PERMISSIONS,
+  createTestUser,
+  deleteTestUser,
+  injectSession,
+  type TestUser,
+} from "./helpers/session";
+
+const WCAG_AA = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+
+/**
+ * Page-level accessibility for studio.
+ *
+ * The fourth and last app with real screens. landing, store, admin and
+ * payments are covered; studio was not, and it is where a seller does the most
+ * work -- the product editor is a form-dense page built from a dozen inline
+ * components.
+ *
+ * It lives here rather than in apps/studio because studio has no playwright
+ * project of its own: every studio e2e test in this repository is driven from
+ * the auth app, which owns the session helpers.
+ *
+ * scripts/check-a11y-patterns.mjs currently lists thirteen unnamed controls in
+ * studio's editors. This is what turns that list into a pass or a failure.
+ */
+
+/** Names the rule AND the offending element: a rule id and a node count says
+ *  a check failed without saying where, which is not actionable from a CI log,
+ *  and a CI log is the only place this runs. */
+function summarise(
+  violations: Awaited<ReturnType<AxeBuilder["analyze"]>>["violations"],
+) {
+  return violations.flatMap((v) =>
+    v.nodes.map(
+      (n) =>
+        `${v.id} (${v.impact}) at ${n.target.join(" ")} -- ${n.failureSummary?.replace(/\s+/g, " ").trim()}`,
+    ),
+  );
+}
+
+test.describe.serial("Studio accessibility", () => {
+  let seller: TestUser;
+
+  test.beforeAll(async () => {
+    seller = await createTestUser("studio-a11y", SELLER_PERMISSIONS);
+  });
+
+  test.afterAll(async () => {
+    await deleteTestUser(seller).catch(() => {});
+  });
+
+  test("the product list has no WCAG 2 AA violations", async ({
+    context,
+    page,
+  }) => {
+    await injectSession(context, seller);
+    await page.goto(`${APP_URLS.STUDIO}/en`);
+    await expect(page.getByTestId("product-list-page")).toBeVisible({
+      timeout: ELEMENT_TIMEOUT_MS,
+    });
+
+    const results = await new AxeBuilder({ page }).withTags(WCAG_AA).analyze();
+
+    expect(summarise(results.violations), "product list accessibility").toEqual(
+      [],
+    );
+  });
+
+  test("the product editor has no WCAG 2 AA violations", async ({
+    context,
+    page,
+  }) => {
+    // The densest form in the product: price fields, tag editor, icon picker,
+    // section cards and the image toolbar, all inline. This is where the
+    // pattern scanner reports most of its unnamed controls.
+    await injectSession(context, seller);
+    await page.goto(`${APP_URLS.STUDIO}/en/products/new`);
+    await expect(page.getByTestId("product-form-page")).toBeVisible({
+      timeout: ELEMENT_TIMEOUT_MS,
+    });
+
+    const results = await new AxeBuilder({ page }).withTags(WCAG_AA).analyze();
+
+    expect(
+      summarise(results.violations),
+      "product editor accessibility",
+    ).toEqual([]);
+  });
+
+  test("delegate management has no WCAG 2 AA violations", async ({
+    context,
+    page,
+  }) => {
+    await injectSession(context, seller);
+    await page.goto(`${APP_URLS.STUDIO}/en/delegates`);
+    await expect(page.getByTestId("delegate-management-page")).toBeVisible({
+      timeout: ELEMENT_TIMEOUT_MS,
+    });
+
+    const results = await new AxeBuilder({ page }).withTags(WCAG_AA).analyze();
+
+    expect(summarise(results.violations), "delegates accessibility").toEqual(
+      [],
+    );
+  });
+
+  test("dark mode keeps its contrast", async ({ context, page }) => {
+    // Contrast is the class a component-level check cannot find, and the one
+    // most likely to differ between themes.
+    await injectSession(context, seller);
+    await page.emulateMedia({ colorScheme: "dark" });
+    await page.goto(`${APP_URLS.STUDIO}/en`);
+    await expect(page.getByTestId("product-list-page")).toBeVisible({
+      timeout: ELEMENT_TIMEOUT_MS,
+    });
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2aa"])
+      .include("body")
+      .analyze();
+
+    const contrast = results.violations.filter(
+      (v) => v.id === "color-contrast",
+    );
+
+    expect(summarise(contrast), "dark mode contrast").toEqual([]);
+  });
+});

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -35,6 +35,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.2.4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/payments/src/features/checkout/presentation/components/ReceiptUpload.tsx
+++ b/apps/payments/src/features/checkout/presentation/components/ReceiptUpload.tsx
@@ -125,6 +125,10 @@ export function ReceiptUpload({
 
       <input
         ref={inputRef}
+        // Visually hidden and opened by the button above it, so a screen
+        // reader reaches it through that button rather than directly -- but a
+        // name costs nothing and the file dialog announces it.
+        aria-label={t("maxFileSize")}
         type="file"
         accept={ACCEPTED_RECEIPT_TYPES}
         onChange={handleSelect}

--- a/apps/studio/src/features/products/presentation/components/InlineEditor/EditorToolbar.tsx
+++ b/apps/studio/src/features/products/presentation/components/InlineEditor/EditorToolbar.tsx
@@ -10,6 +10,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useId } from "react";
 import type {
   Control,
   UseFormRegister,
@@ -59,6 +60,7 @@ export function EditorToolbar({
   onReset,
   hasSections,
 }: EditorToolbarProps) {
+  const activeLabelId = useId();
   const t = useTranslations();
   const tEditor = useTranslations("form.inlineEditor");
 
@@ -190,12 +192,20 @@ export function EditorToolbar({
       {/* Active switch */}
       <div className="flex items-center gap-1.5">
         <Switch
+          // Points at the visible text rather than repeating it. Nothing
+          // associated the two before, so axe reported the switch with no
+          // accessible name -- and duplicating the string would have made the
+          // label and its announcement two things to keep in step.
+          aria-labelledby={activeLabelId}
           checked={isActive ?? true}
           onCheckedChange={(checked) => setValue("is_active", checked)}
           className="data-[state=checked]:bg-background/30"
           {...tid("toolbar-active")}
         />
-        <span className="font-display text-ui-xs font-bold uppercase tracking-wider text-background/70">
+        <span
+          id={activeLabelId}
+          className="font-display text-ui-xs font-bold uppercase tracking-wider text-background/70"
+        >
           {t("products.active")}
         </span>
       </div>

--- a/apps/studio/src/features/products/presentation/components/InlineEditor/EditorToolbar.tsx
+++ b/apps/studio/src/features/products/presentation/components/InlineEditor/EditorToolbar.tsx
@@ -115,6 +115,7 @@ export function EditorToolbar({
 
       {/* Category select */}
       <select
+        aria-label={t("products.category")}
         className="rounded-lg border-2 border-background/30 bg-transparent px-2 py-1 font-display text-ui-xs font-bold uppercase tracking-wider text-background outline-none"
         {...register("category")}
         {...tid("toolbar-category")}
@@ -146,6 +147,7 @@ export function EditorToolbar({
 
       {/* Refundable select */}
       <select
+        aria-label={t("products.refundable")}
         value={refundable === null ? "" : String(refundable)}
         onChange={(e) => {
           const val = e.target.value;

--- a/apps/studio/src/features/products/presentation/components/InlineEditor/InlineHero.tsx
+++ b/apps/studio/src/features/products/presentation/components/InlineEditor/InlineHero.tsx
@@ -76,8 +76,13 @@ export function InlineHero({ control, errors }: InlineHeroProps) {
 
           {/* Right: Product Info */}
           <div className="flex flex-col flex-1 gap-4 min-w-0">
-            {/* 1. Tagline — theme-colored */}
-            <div style={{ color: theme.text }}>
+            {/* 1. Tagline.
+                Not theme-coloured: theme.text is the raw category accent, and
+                on the page background axe measured it below 4.5:1. The accent
+                is a fill and border colour here -- it does not survive being
+                used as text on white. The category still reads through the
+                badges, the gallery and the borders. */}
+            <div>
               <InlineTextField
                 control={control}
                 fieldNameEn="tagline_en"

--- a/apps/studio/src/features/products/presentation/components/InlineEditor/InlineImageCarousel.tsx
+++ b/apps/studio/src/features/products/presentation/components/InlineEditor/InlineImageCarousel.tsx
@@ -253,8 +253,11 @@ export function InlineImageCarousel({ control }: InlineImageCarouselProps) {
         style={{ backgroundColor: theme.bg }}
         {...tid("image-gallery-main-empty")}
       >
-        <Plus className="size-8 text-foreground/30" />
-        <span className="font-display text-sm font-bold uppercase tracking-wider text-foreground/40">
+        {/* Full strength, not a tint: this is the call to action on an empty
+            gallery, and axe measured the label below the 4.5:1 threshold
+            against the category colour behind it. */}
+        <Plus className="size-8 text-foreground" />
+        <span className="font-display text-sm font-bold uppercase tracking-wider text-foreground">
           {t("addFirstImage")}
         </span>
       </button>

--- a/apps/studio/src/features/products/presentation/components/InlineEditor/InlinePriceFields.tsx
+++ b/apps/studio/src/features/products/presentation/components/InlineEditor/InlinePriceFields.tsx
@@ -41,6 +41,7 @@ export function InlinePriceFields({ control }: InlinePriceFieldsProps) {
             {t("currency")}
           </span>
           <select
+            aria-label={t("currency")}
             ref={currencyField.ref}
             value={currencyField.value}
             onChange={(e) => currencyField.onChange(e.target.value)}

--- a/apps/studio/src/features/products/presentation/components/InlineEditor/SectionCard.tsx
+++ b/apps/studio/src/features/products/presentation/components/InlineEditor/SectionCard.tsx
@@ -166,6 +166,7 @@ export function SectionCard({
 
         {/* Type selector */}
         <select
+          aria-label={t("sectionType")}
           value={typeValue}
           onChange={(e) => typeField.field.onChange(e.target.value)}
           className="h-7 w-32 rounded-sm border-2 border-foreground/30 bg-background px-2 text-xs text-foreground"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -22,6 +22,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "@clerk/nextjs": "^7.8.3",
     "@supabase/supabase-js": "^2.105.0",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.13.0
+        version: 4.13.0(playwright-core@1.59.1)
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
@@ -980,6 +983,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.13.0
+        version: 4.13.0(playwright-core@1.59.1)
       '@clerk/nextjs':
         specifier: ^7.8.3
         version: 7.8.3(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/scripts/check-a11y-patterns.mjs
+++ b/scripts/check-a11y-patterns.mjs
@@ -9,54 +9,95 @@
  *                        Measured at 3.2:1 on a role badge and 1.72:1 on an
  *                        audit badge, against a required 4.5:1. Five
  *                        components had it.
- *   unnamed-control      a select or input with no aria-label, no id for a
- *                        label to point at, and no placeholder. Eleven of
- *                        these were live across two report filter bars, and a
- *                        screen reader announced them as unnamed fields.
+ *   unnamed-control      a select, input or textarea with no aria-label, no id
+ *                        for a label to point at, no placeholder, and no
+ *                        wrapping label. Eleven were live across two report
+ *                        filter bars, announced as unnamed fields.
  *
- * Advisory, not a gate: a wrapping <label> is a legitimate way to name a
- * control and this cannot see one, so a clean axe run is the authority. It
- * exists to find the next instance in a diff rather than four CI rounds later.
+ * Advisory, not a gate. The wrapping-label test below is a guess, so a clean
+ * axe run is the authority; this exists to find the next instance in a diff
+ * rather than four CI rounds later.
  *
  * Usage:
  *   node scripts/check-a11y-patterns.mjs
  */
 
-import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 // No quoted glob: execSync goes through cmd.exe on Windows, which does not
 // strip the quotes, so git receives them literally and matches nothing. This
-// scan reported "0 problems" twice that way before anyone noticed it was
-// reading no files at all.
+// scan reported "0 problems" twice that way, while four unlabelled inputs sat
+// in a file it claimed to have read.
 const files = execSync("git ls-files", { encoding: "utf8" })
   .split("\n")
   .filter((f) => /^apps\/[^/]+\/src\/.*\.tsx$/.test(f));
+
 if (files.length === 0) {
   throw new Error("scan matched no files -- refusing to report a clean result");
 }
-console.log(`scanning ${files.length} files`);
 
-// Multi-line aware: JSX opening tags routinely span many lines.
-const tagRe = /<(select|input)\b([\s\S]*?)\/?>/g;
+const tagRe = /<(select|input|textarea)\b/g;
 const sameColour = /bg-([a-z]+)\/\d+\s+text-\1\b/g;
+
+/**
+ * The attributes of a JSX opening tag, read by brace depth rather than regex.
+ *
+ * A non-greedy match stops at the first `>` it meets, and `onChange={(e) =>
+ * ...}` contains one -- so the attribute text came back truncated and a
+ * `placeholder` further down the tag went unseen. Every control with a handler
+ * written before its labelling attribute read as unnamed.
+ */
+function openingTagAttrs(src, from) {
+  let depth = 0;
+  for (let i = from; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+    else if (ch === ">" && depth === 0) return src.slice(from, i);
+  }
+  return null;
+}
+
+/** A control wrapped in its own <label> is named by it. Approximated by
+ *  looking back for an unclosed <label>, which is the guess that keeps this
+ *  advisory. */
+function isWrappedInLabel(before) {
+  return before.lastIndexOf("<label") > before.lastIndexOf("</label>");
+}
 
 let colour = 0;
 let unnamed = 0;
-for (const f of files) {
-  const src = readFileSync(f, "utf8");
+
+for (const file of files) {
+  const src = readFileSync(file, "utf8");
+
   for (const m of src.matchAll(sameColour)) {
-    console.log(`same-colour-on-tint  ${f}  ${m[0]}`);
+    console.log(`same-colour-on-tint  ${file}  ${m[0]}`);
     colour++;
   }
+
   for (const m of src.matchAll(tagRe)) {
-    const attrs = m[2];
+    const attrs = openingTagAttrs(src, m.index + m[0].length);
+    if (attrs === null) continue;
     if (/type="(hidden|submit|button)"/.test(attrs)) continue;
-    if (/aria-label|aria-labelledby|placeholder=|(?<!test)\bid=/.test(attrs))
+    if (/aria-label|aria-labelledby|placeholder=|(?<!test)\bid=/.test(attrs)) {
       continue;
-    const line = src.slice(0, m.index).split("\n").length;
-    console.log(`unnamed-control      ${f}:${line}`);
+    }
+    // A generic wrapper spreads its caller's props, so its name arrives from
+    // the call site. AutoTextarea does exactly this and all nine of its
+    // callers pass one -- flagging the definition would be reporting the
+    // wrong file.
+    if (/\{\.\.\.\w+\}/.test(attrs)) continue;
+
+    const before = src.slice(0, m.index);
+    if (isWrappedInLabel(before)) continue;
+
+    console.log(`unnamed-control      ${file}:${before.split("\n").length}`);
     unnamed++;
   }
 }
-console.log(`\nsame-colour-on-tint: ${colour}   unnamed controls: ${unnamed}`);
+
+console.log(
+  `\nscanned ${files.length} files -- same-colour-on-tint: ${colour}, unnamed controls: ${unnamed}`,
+);


### PR DESCRIPTION
The fourth and last app with real screens. landing, store, admin and payments are covered; studio wasn't — and it's where a seller does most of their work, since the product editor is a form-dense page assembled from a dozen inline components.

The spec lives in `apps/auth/e2e` because **studio has no playwright project of its own**: every studio e2e test in this repo is driven from the auth app, which owns the session helpers. Covers product list, product editor, delegate management, and dark-mode contrast.

## Six controls named

Rather than let CI report the known findings one round at a time, I worked through the scanner's list first: studio's category, refundable, currency and section-type selects; admin's template section type; payments' receipt file input.

## The scanner was wrong more often than the code was

That correction matters more than the six fixes:

- **It read attributes with a non-greedy regex**, which stops at the first `>` — and `onChange={(e) => …}` contains one. Every control with a handler written before its labelling attribute came back truncated and read as unnamed, **including ones with a `placeholder` two lines further down.** Now read by brace depth.
- **It couldn't see a control wrapped in its own `<label>`**, which names it.
- **It flagged `AutoTextarea`**, a generic wrapper that spreads its caller's props — all nine callers pass a name, so the definition was the wrong file to report.

**24 findings became 7, of which 6 were real and are fixed.** I reported that 24 as a backlog in the previous PR; 17 of them were my tool being wrong, and saying so is the point.

Verified the scanner still bites by removing one `aria-label` and watching the count go to 1.