### PR TITLE
chore: settle the feature barrel question with a measurement [GH-000]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,7 @@ jobs:
           pnpm exec cspell "**/*.{ts,tsx,md,json}" --no-progress
           pnpm exec jscpd .
           node scripts/check-source-bytes.mjs
+          node scripts/check-feature-boundaries.mjs
           pnpm exec madge --circular --extensions ts,tsx,js,jsx apps/store/src apps/studio/src apps/landing/src apps/payments/src apps/admin/src apps/auth/src apps/playground/src packages/ui/src packages/shared/src packages/api/src packages/app-components/src packages/auth/src tests scripts docker
 
       - name: Lint (scoped)

--- a/apps/admin/src/app/api/admin/users/[userId]/delegates/route.ts
+++ b/apps/admin/src/app/api/admin/users/[userId]/delegates/route.ts
@@ -8,7 +8,7 @@ import {
   INTERNAL_SERVER_ERROR_STATUS,
   validateUuid,
 } from "@/app/api/admin/_shared/adminRest";
-import { SELLER_ADMINS_READ_PERMISSION } from "@/features/users/domain/constants";
+import { SELLER_ADMINS_READ_PERMISSION } from "@/features/users";
 
 const SELLER_ADMINS_DELETE = "seller_admins.delete";
 

--- a/apps/admin/src/features/users/index.ts
+++ b/apps/admin/src/features/users/index.ts
@@ -1,2 +1,8 @@
 export { UsersPage } from "./presentation/pages/UsersPage";
 export { UserDetailPage } from "./presentation/pages/UserDetailPage";
+
+// Exported for the API route that consumes it. A route is outside the
+// feature, so what it needs is part of the feature's public API by
+// definition -- reaching past the barrel for it is the thing the
+// architecture rule asks routes not to do.
+export { SELLER_ADMINS_READ_PERMISSION } from "./domain/constants";

--- a/apps/auth/src/app/[locale]/login/page.tsx
+++ b/apps/auth/src/app/[locale]/login/page.tsx
@@ -1,6 +1,6 @@
 import { setRequestLocale } from "next-intl/server";
 
-import { LoginPage } from "@/features/auth/presentation/pages/LoginPage";
+import { LoginPage } from "@/features/auth";
 
 export default async function Page({
   params,

--- a/apps/auth/src/app/[locale]/page.tsx
+++ b/apps/auth/src/app/[locale]/page.tsx
@@ -2,7 +2,7 @@ import { auth } from "@clerk/nextjs/server";
 import { setRequestLocale } from "next-intl/server";
 
 import { AccountSettingsPage } from "@/features/account";
-import { LoginPage } from "@/features/auth/presentation/pages/LoginPage";
+import { LoginPage } from "@/features/auth";
 
 export default async function AuthPage({
   params,

--- a/apps/auth/src/app/[locale]/profile/[id]/page.tsx
+++ b/apps/auth/src/app/[locale]/profile/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { setRequestLocale } from "next-intl/server";
 
-import { UserProfilePage } from "@/features/account/presentation/pages/UserProfilePage";
+import { UserProfilePage } from "@/features/account";
 
 export default async function Page({
   params,

--- a/apps/payments/src/app/api/checkout/payment-methods/route.ts
+++ b/apps/payments/src/app/api/checkout/payment-methods/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from "next/server";
 import type {
   CheckoutPaymentMethodsResponse,
   SellerPaymentMethodWithType,
-} from "@/features/checkout/domain/types";
+} from "@/features/checkout";
 import {
   adminFetchJson,
   createRestPath,

--- a/apps/payments/src/app/api/seller/reports/orders/route.ts
+++ b/apps/payments/src/app/api/seller/reports/orders/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server";
 import { ORDER_STATUS_SET } from "shared/constants/orders";
 import { POPULAR_CURRENCIES_SET } from "shared/utils/currencies";
 
-import type { SellerReportOrder } from "@/features/reports/domain/types";
+import type { SellerReportOrder } from "@/features/reports";
 import type { SupabaseClient } from "@/shared/domain/types";
 import {
   adminFetchJson,

--- a/apps/payments/src/features/checkout/index.ts
+++ b/apps/payments/src/features/checkout/index.ts
@@ -1,1 +1,10 @@
 export { CheckoutPage } from "./presentation/pages/CheckoutPage";
+
+// Exported for the API route that consumes it. A route is outside the
+// feature, so what it needs is part of the feature's public API by
+// definition -- reaching past the barrel for it is the thing the
+// architecture rule asks routes not to do.
+export type {
+  CheckoutPaymentMethodsResponse,
+  SellerPaymentMethodWithType,
+} from "./domain/types";

--- a/apps/payments/src/features/reports/index.ts
+++ b/apps/payments/src/features/reports/index.ts
@@ -1,2 +1,8 @@
 export { SellerReportsPage } from "@/features/reports/presentation/pages/SellerReportsPage";
 export { DelegatedReportsPage } from "@/features/reports/presentation/pages/DelegatedReportsPage";
+
+// Exported for the API route that consumes it. A route is outside the
+// feature, so what it needs is part of the feature's public API by
+// definition -- reaching past the barrel for it is the thing the
+// architecture rule asks routes not to do.
+export type { SellerReportOrder } from "./domain/types";

--- a/apps/studio/src/app/[locale]/products/[id]/delegates/page.tsx
+++ b/apps/studio/src/app/[locale]/products/[id]/delegates/page.tsx
@@ -1,6 +1,6 @@
 import { setRequestLocale } from "next-intl/server";
 
-import { ProductDelegatesPage } from "@/features/seller-admins/presentation/pages/ProductDelegatesPage";
+import { ProductDelegatesPage } from "@/features/seller-admins";
 
 export default async function ProductDelegatesRoute({
   params,

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -170,20 +170,50 @@ Four files were genuinely dead and are deleted:
 - `vitest.aliases.ts` — a shared-alias helper none of the seven
   `vitest.config.mts` files ever adopted.
 
-### Open question: the feature barrel rule
+### The feature barrel rule: measured, and it holds
 
-`.claude/rules/architecture.md` says every feature MUST have an `index.ts`
-exporting its public API. Its own import examples then show deep absolute
-paths (`@/features/dashboard/domain/types`), and the codebase follows the
-examples: across the four barrels knip flagged, there are **126 deep imports
-against 6 barrel imports**.
+This section previously recorded the rule as "inconsistent with itself",
+evidenced by **126 deep imports against 6 barrel imports**, and left the
+decision open. That comparison was counting the wrong thing.
 
-So the barrels are required to exist and are bypassed in practice. They are
-marked as knip entry points here because the rule mandates them — but the rule
-is inconsistent with itself, and someone should decide whether to enforce
-barrel-only imports or drop the requirement. Marking them as entry points also
-means their exports count as used, which slightly weakens the unused-export
-analysis; that is the cost of agreeing with the rule as written.
+`.claude/rules/architecture.md` mandates a barrel as each feature's public API,
+and separately forbids features importing each other. So the barrel is the
+interface for code _outside_ the feature -- and 427 of those "deep imports" are
+a feature importing itself, which the rule never asked to go through a barrel.
+
+Split by who is doing the importing:
+
+| importer          | via barrel | deep  |
+| ----------------- | ---------- | ----- |
+| within a feature  | 0          | 427   |
+| **`app/` routes** | **38**     | **0** |
+| another feature   | 3          | 13    |
+
+Routes were 31 to 7 when this was measured. The seven are fixed: four already
+had what they needed on the barrel, and three barrels were widened to export
+what an API route consumes -- a route is outside the feature, so what it needs
+is part of the public API by definition. The rule is now satisfied wherever it
+applies, and there is nothing to decide.
+
+### What that measurement did surface: 13 cross-feature imports
+
+Those violate a stated MUST, and they are the real finding.
+
+```
+  1  admin: users -> audit                         1  payments: checkout -> orders
+  4  payments: assigned-orders -> received-orders  1  payments: received-orders -> assigned-orders
+  1  store: cart -> products                       1  store: products -> cart
+  2  studio: products -> seller-admins             1  studio: seller-admins -> products
+  1  studio: products -> orders
+```
+
+Three of those pairs import **each other**: assigned-orders and
+received-orders, cart and products, products and seller-admins. A cycle at
+feature level usually means one feature wearing two names, and deciding that
+is a design call rather than an import fix.
+
+`scripts/check-feature-boundaries.mjs` holds the count at 13 and fails on a
+fourteenth. Lower the baseline as pairs are resolved; that is the ratchet.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "test:inventory:diff": "bash scripts/test-inventory-diff.sh",
     "check:migrations": "node scripts/check-migration-edits.mjs",
     "check:source-bytes": "node scripts/check-source-bytes.mjs",
-    "check:a11y-patterns": "node scripts/check-a11y-patterns.mjs"
+    "check:a11y-patterns": "node scripts/check-a11y-patterns.mjs",
+    "check:boundaries": "node scripts/check-feature-boundaries.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/scripts/check-feature-boundaries.mjs
+++ b/scripts/check-feature-boundaries.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Holds the line on cross-feature imports.
+ *
+ * `.claude/rules/architecture.md` states it as a MUST: "Features MUST NOT
+ * import directly from other features", with cross-feature communication going
+ * through shared interfaces, stores, or events. There are 13 that do.
+ *
+ * This is a ratchet, not a clean-up. Each of those 13 needs a decision that
+ * is bigger than an import statement -- three of the pairs import each other,
+ * which usually means they are one feature wearing two names -- and making
+ * that call is not something a lint sweep should do. What this prevents is a
+ * fourteenth arriving while nobody is looking.
+ *
+ * It also replaced a claim in docs/standards/quality-gates.md that the feature
+ * barrel rule "is inconsistent with itself", evidenced by 126 deep imports
+ * against 6 barrel imports. That comparison counted imports *within* a feature,
+ * which the rule never asked to go through a barrel. Split by who is importing,
+ * routes used the barrel 31 times and bypassed it 7; those 7 are fixed, and the
+ * figure is now 38 to 0.
+ *
+ * Usage:
+ *   node scripts/check-feature-boundaries.mjs
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+/**
+ * What the codebase had when this check was written. It may fall; it may not
+ * rise. Lower it when a pair is resolved -- that is the ratchet.
+ */
+const BASELINE = 13;
+
+const FEATURE_IMPORT = /from\s+"(@\/features\/([^/"]+)([^"]*))"/g;
+
+function featureFiles() {
+  const out = execSync("git ls-files", { encoding: "utf-8" })
+    .split("\n")
+    .filter((f) => /^apps\/[^/]+\/src\/features\/.*\.tsx?$/.test(f));
+  if (out.length === 0) {
+    throw new Error(
+      "no feature files matched -- refusing to report a clean result",
+    );
+  }
+  return out;
+}
+
+function crossFeatureImports() {
+  const found = new Map();
+  for (const file of featureFiles()) {
+    const owner = /^apps\/[^/]+\/src\/features\/([^/]+)\//.exec(file)[1];
+    const app = /^apps\/([^/]+)\//.exec(file)[1];
+    for (const m of readFileSync(file, "utf-8").matchAll(FEATURE_IMPORT)) {
+      const [, specifier, target] = m;
+      if (target === owner) continue;
+      const pair = `${app}: ${owner} -> ${target}`;
+      if (!found.has(pair)) found.set(pair, new Set());
+      found.get(pair).add(specifier);
+    }
+  }
+  return found;
+}
+
+function main() {
+  const found = crossFeatureImports();
+  const total = [...found.values()].reduce((n, s) => n + s.size, 0);
+
+  for (const [pair, specifiers] of [...found].sort()) {
+    console.log(`  ${String(specifiers.size).padStart(2)}  ${pair}`);
+  }
+
+  if (total > BASELINE) {
+    console.error(
+      `\n${total} cross-feature imports, up from a baseline of ${BASELINE}.` +
+        "\n\nFeatures must not import each other (.claude/rules/architecture.md)." +
+        "\nMove what is shared into shared/domain, or lift the dependency into" +
+        "\nthe route that composes both.\n",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `\n${total} cross-feature imports, baseline ${BASELINE}.` +
+      (total < BASELINE
+        ? " Lower BASELINE in this file to lock the improvement in."
+        : " No new ones."),
+  );
+}
+
+main();


### PR DESCRIPTION
`quality-gates.md` recorded the barrel rule as *"inconsistent with itself"* and left the decision to someone else. The evidence was **126 deep imports against 6 barrel imports**. That comparison counted the wrong thing.

`architecture.md` mandates a barrel as each feature's public API, and *separately* forbids features importing each other. So the barrel is the interface for code **outside** the feature — and 427 of those "deep imports" are a feature importing **itself**, which the rule never asked to route through a barrel.

Split by who is importing:

| importer | via barrel | deep | |
|---|---|---|---|
| within a feature | 0 | **427** | rule doesn't apply |
| **`app/` routes** | **31 → 38** | **7 → 0** | rule applies |
| another feature | 3 | 13 | forbidden outright |

**The seven are fixed.** Four already had what they needed on the barrel; three barrels were widened to export what an API route consumes — a route is outside the feature, so what it needs is public API by definition. Routes are now **38 to 0**, and there's nothing left to decide.

## What the measurement surfaced instead

**13 cross-feature imports**, violating a stated MUST:

```
 1  admin: users -> audit                         1  payments: checkout -> orders
 4  payments: assigned-orders -> received-orders  1  payments: received-orders -> assigned-orders
 1  store: cart -> products                       1  store: products -> cart
 2  studio: products -> seller-admins             1  studio: seller-admins -> products
 1  studio: products -> orders
```

**Three of those pairs import each other.** A cycle at feature level usually means one feature wearing two names — and deciding that is a design call rather than an import fix, so it isn't one I'm making while nobody's around to disagree.

`scripts/check-feature-boundaries.mjs` holds the count at 13 and fails on a fourteenth — verified by adding one and watching it exit 1. Lower the baseline as pairs are resolved; that's the ratchet.