### PR TITLE
docs: three of the four blocked items were not blocked [GH-000]

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -376,3 +376,35 @@ pnpm lint:env
 | `NEXT_PUBLIC_ENABLE_TEST_IDS` | Enables `data-testid` attributes for E2E |
 | `ENV_DEBUG`                   | Enables env debug viewer at `/en/env`    |
 | `NEXT_PUBLIC_ENV_DEBUG`       | Serialized env snapshot (set by loadEnv) |
+
+## Five GitHub secrets nothing reads
+
+`SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID`, `SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET`,
+`SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID`, `SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET`
+and `DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI` exist as repository secrets, dated
+14 and 19 April 2026. Nothing references them: not a workflow, not a script, not
+an env file, and they are not in the local `.secrets` either, so
+`pnpm sync-secrets` does not pull them.
+
+They configured Supabase Auth's own Google and Discord providers, which Clerk
+replaced. Verify with:
+
+```bash
+gh secret list --repo vaoan/libra | grep SUPABASE_AUTH_EXTERNAL
+grep -rl SUPABASE_AUTH_EXTERNAL --include='*.yml' --include='*.mjs' --include='*.ts' .
+```
+
+**Deliberately not deleted.** Removing them is a one-line command and safe as far
+as this repository is concerned, but the values cannot be recovered afterwards,
+and whether the matching OAuth applications are still live in the Google and
+Discord consoles is not visible from here. If they are, these are real
+credentials and deleting them here removes them from CI without revoking
+anything -- which is worth doing, but is a decision about credentials rather
+than about code.
+
+```bash
+# When that call has been made:
+for s in SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET          SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET          DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI; do
+  gh secret delete "$s" --repo vaoan/libra
+done
+```

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -552,3 +552,29 @@ attribution before debugging the accusation.**
 <!-- The four above are quoted on purpose: three are the deliberate typo
      used to prove the cspell gate fires, and one is the real typo it
      found. Spelling them correctly here would delete the evidence. -->
+
+## Four items that were waiting on someone, resolved
+
+They had been recorded as needing a decision or a credential. Three did not.
+
+**Docker Hub credentials for CI — not needed, and never were.** The
+`docker-build` job authenticates to `ghcr.io` with the built-in `GITHUB_TOKEN`
+via `docker/login-action`. There is no reference to Docker Hub anywhere in
+`.github/workflows/`, `docker/` or `scripts/`, and the job has succeeded in
+every recent run on `develop`. Nothing to provide.
+
+**The Clerk test sign-in flake — not reproducing.** It has not failed in the
+last six `develop` runs. The switch to `@clerk/testing`'s ticket-based
+`emailAddress` mode is the likely reason: the earlier password strategy
+silently established no session. Every playwright config also sets
+`retries: 2` under CI, so a transient failure of an external service does not
+fail the job on its own.
+
+**The feature barrel rule** — measured and settled; see the section above.
+
+**Five orphaned GitHub secrets** — still open, deliberately. They are unused and
+documented in `docs/environment.md` with the command to remove them. Deleting
+them is safe as far as this repository is concerned, but the values cannot be
+recovered and whether the matching OAuth applications are still live in the
+Google and Discord consoles is not visible from here. That is a decision about
+credentials rather than about code.


### PR DESCRIPTION
Four items had been carried as needing a credential or a decision from you. I checked each rather than repeating the list.

| Item | Status |
|---|---|
| **Docker Hub credentials for CI** | **Not needed, and never were.** `docker-build` authenticates to `ghcr.io` with the built-in `GITHUB_TOKEN`. There is no reference to Docker Hub anywhere in the workflows, `docker/` or `scripts/`, and the job has succeeded in every recent run on `develop`. |
| **Clerk sign-in flake** | **Not reproducing** — no failure in the last six `develop` runs. The switch to `@clerk/testing`'s ticket-based `emailAddress` mode is the likely reason; the password strategy it replaced silently established no session. Every playwright config also sets `retries: 2` under CI. |
| **Feature barrel rule** | Measured and settled in #388. |
| **Five orphaned GitHub secrets** | **Still open, deliberately.** |

## Why the last one stays open

They're genuinely unused — nothing in any workflow, script or env file names them, and they aren't in `.secrets`, so `pnpm sync-secrets` doesn't pull them. They configured Supabase Auth's Google and Discord providers, which Clerk replaced. `docs/environment.md` now records what they were for, how to verify that, and the command to remove them.

I didn't delete them because **deleting a secret can't be undone**, and whether the matching OAuth applications are still live in the Google and Discord consoles isn't visible from here. If they are, these are real credentials — and removing them from CI without revoking them is a decision about credentials rather than about code.

Marginal upside, unrecoverable downside, no urgency. It waits for someone who can check the consoles.