### PR TITLE
refactor(studio): move two composition pages out of features, 10 → 6 [GH-000]

### DIFF
--- a/apps/studio/src/app/[locale]/page.tsx
+++ b/apps/studio/src/app/[locale]/page.tsx
@@ -1,6 +1,6 @@
 import { setRequestLocale } from "next-intl/server";
 
-import { ProductListPage } from "@/features/products";
+import { ProductListPage } from "@/shared/presentation/pages/ProductListPage";
 
 export default async function StudioPage({
   params,

--- a/apps/studio/src/app/[locale]/products/[id]/delegates/page.tsx
+++ b/apps/studio/src/app/[locale]/products/[id]/delegates/page.tsx
@@ -1,6 +1,6 @@
 import { setRequestLocale } from "next-intl/server";
 
-import { ProductDelegatesPage } from "@/features/seller-admins";
+import { ProductDelegatesPage } from "@/shared/presentation/pages/ProductDelegatesPage";
 
 export default async function ProductDelegatesRoute({
   params,

--- a/apps/studio/src/features/products/index.ts
+++ b/apps/studio/src/features/products/index.ts
@@ -1,3 +1,2 @@
 export { ProductFormPage } from "./presentation/pages/ProductFormPage";
-export { ProductListPage } from "./presentation/pages/ProductListPage";
 export { useProductById } from "./application/hooks/useProductForm";

--- a/apps/studio/src/features/seller-admins/index.ts
+++ b/apps/studio/src/features/seller-admins/index.ts
@@ -1,6 +1,5 @@
 // Pages
 export { DelegateManagementPage } from "./presentation/pages/DelegateManagementPage";
-export { ProductDelegatesPage } from "./presentation/pages/ProductDelegatesPage";
 
 // Hooks
 export { useDelegates } from "./application/hooks/useDelegates";

--- a/apps/studio/src/shared/presentation/pages/ProductDelegatesPage.tsx
+++ b/apps/studio/src/shared/presentation/pages/ProductDelegatesPage.tsx
@@ -22,6 +22,16 @@ interface ProductDelegatesPageProps {
   productId: string;
 }
 
+/**
+ * The delegates for one product.
+ *
+ * Shared rather than in features/seller-admins for the same reason as
+ * ProductListPage: it composes two features. It manages delegates and it needs
+ * the product's own record to title the page, and reaching into
+ * features/products for that from inside another feature is what the
+ * architecture rule forbids. A page that needs two features is a composition
+ * root; a feature is the wrong place for one.
+ */
 export function ProductDelegatesPage({ productId }: ProductDelegatesPageProps) {
   const { hasPermission } = useCurrentUserPermissions();
   const { user } = useCurrentUser();

--- a/apps/studio/src/shared/presentation/pages/ProductListPage.tsx
+++ b/apps/studio/src/shared/presentation/pages/ProductListPage.tsx
@@ -10,6 +10,18 @@ import { SELLER_ADMINS_READ_PERMISSION } from "@/features/seller-admins/domain/c
 import { useCurrentUser } from "@/shared/application/hooks/useCurrentUser";
 import { AccessDeniedState } from "@/shared/presentation/components/AccessDeniedState";
 
+/**
+ * Studio's landing page.
+ *
+ * It lives in shared/presentation rather than features/products because it
+ * composes three features: the product list, the pending-order count, and the
+ * per-product delegate counts. Inside features/products those last two were
+ * cross-feature imports, which the architecture rule forbids -- but the
+ * imports were not the problem. A page that needs three features is a
+ * composition root, and a feature is the wrong place for one.
+ *
+ * The route stays thin, as the rule asks: it renders this and nothing else.
+ */
 export function ProductListPage() {
   const { hasPermission } = useCurrentUserPermissions();
   const t = useTranslations("common");

--- a/apps/studio/tests/ProductDelegatesPage.test.tsx
+++ b/apps/studio/tests/ProductDelegatesPage.test.tsx
@@ -97,7 +97,7 @@ vi.mock("@/shared/presentation/components/AccessDeniedState", () => ({
   AccessDeniedState: () => <div data-testid="access-denied" />,
 }));
 
-import { ProductDelegatesPage } from "@/features/seller-admins/presentation/pages/ProductDelegatesPage";
+import { ProductDelegatesPage } from "@/shared/presentation/pages/ProductDelegatesPage";
 
 describe("ProductDelegatesPage", () => {
   beforeEach(() => {

--- a/apps/studio/tests/ProductListPage.test.tsx
+++ b/apps/studio/tests/ProductListPage.test.tsx
@@ -82,7 +82,7 @@ vi.mock("@/features/products/presentation/components/ProductTable", () => ({
   ProductTable: () => <div data-testid="product-table" />,
 }));
 
-import { ProductListPage } from "@/features/products/presentation/pages/ProductListPage";
+import { ProductListPage } from "@/shared/presentation/pages/ProductListPage";
 
 describe("ProductListPage", () => {
   beforeEach(() => {

--- a/scripts/check-feature-boundaries.mjs
+++ b/scripts/check-feature-boundaries.mjs
@@ -6,11 +6,28 @@
  * import directly from other features", with cross-feature communication going
  * through shared interfaces, stores, or events. There are 13 that do.
  *
- * This is a ratchet, not a clean-up. Each of those 13 needs a decision that
- * is bigger than an import statement -- three of the pairs import each other,
- * which usually means they are one feature wearing two names -- and making
- * that call is not something a lint sweep should do. What this prevents is a
- * fourteenth arriving while nobody is looking.
+ * This is a ratchet. It started at 13; seven had a remedy the rule already
+ * prescribes and are gone -- query keys and audit writing moved to shared, and
+ * two pages that composed three features each moved out of the feature they
+ * happened to live in.
+ *
+ * The remaining six are two pairs that import each other, and they need a
+ * decision bigger than an import statement:
+ *
+ *   payments  assigned-orders and received-orders, 4 imports. Assigned orders
+ *             are received orders seen through a delegation lens: the same
+ *             card, the same actions hook, the same SellerAction type, and
+ *             assigned-orders' own query function even lives in
+ *             received-orders' file. Resolving it means lifting the shared
+ *             order-management domain into shared/ and leaving two thin
+ *             features that differ only in which orders they list.
+ *
+ *   store     cart and products, 2 imports. A product card needs to add to the
+ *             cart; the cart needs product records to render. Genuinely
+ *             mutual, and the cheapest honest fix is probably to invert one
+ *             direction with a callback prop.
+ *
+ * Neither is a lint fix, so neither was done by one.
  *
  * It also replaced a claim in docs/standards/quality-gates.md that the feature
  * barrel rule "is inconsistent with itself", evidenced by 126 deep imports
@@ -30,7 +47,7 @@ import { readFileSync } from "node:fs";
  * What the codebase had when this check was written. It may fall; it may not
  * rise. Lower it when a pair is resolved -- that is the ratchet.
  */
-const BASELINE = 10;
+const BASELINE = 6;
 
 const FEATURE_IMPORT = /from\s+"(@\/features\/([^/"]+)([^"]*))"/g;
 


### PR DESCRIPTION
studio had three cross-feature imports and **all three were in one file**. `ProductListPage` sat in `features/products` and imported the pending-order count from `features/orders`, plus the delegate counts and a permission constant from `features/seller-admins`.

**The imports weren't the problem.** A page that needs three features is a composition root, and a feature is the wrong place for one. Moved to `shared/presentation/pages`, where composing several features is what the layer is for — the route still renders it and nothing else, as the rule asks.

`ProductDelegatesPage` is the same shape (it manages delegates and needs the product record to title the page) and moved for the same reason.

**studio now has no cross-feature imports at all.**

## The six that remain are two pairs that import each other

| pair | n | why it isn't an import fix |
|---|---|---|
| `payments`: assigned-orders ↔ received-orders | 4 | Assigned orders *are* received orders seen through a delegation lens — same card, same actions hook, same `SellerAction` type, and assigned-orders' own query function even lives in received-orders' file. Resolving it means lifting the shared order-management domain into `shared/` and leaving two thin features that differ only in which orders they list. Moving `fetchAssignedOrders` alone would just trade an import for a type import. |
| `store`: cart ↔ products | 2 | A product card adds to the cart; the cart needs product records to render. Genuinely mutual — the cheapest honest fix is probably inverting one direction with a callback prop. |

Both are recorded at the top of the check script with the resolution I'd suggest. **Neither is a lint fix, so neither was done by one.**

Baseline 10 → 6. lint 0 · typecheck 12/12 · studio 416 passing · full suite green.