### PR TITLE
chore(ci): port the doc-freshness gate, and run three gates that ran nowhere [GH-000]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,21 @@ jobs:
           pnpm exec jscpd .
           node scripts/check-source-bytes.mjs
           node scripts/check-feature-boundaries.mjs
+          node scripts/check-a11y-patterns.mjs
           pnpm exec madge --circular --extensions ts,tsx,js,jsx apps/store/src apps/studio/src apps/landing/src apps/payments/src apps/admin/src apps/auth/src apps/playground/src packages/ui/src packages/shared/src packages/api/src packages/app-components/src packages/auth/src tests scripts docker
+
+      # Ported from aeleos with one change: a symbol undocumented on both
+      # sides is skipped. aeleos enforces jsdoc/require-jsdoc so every export
+      # there has a doc; Libra documents about a third of them, and without
+      # the skip this would fail on every undocumented export anyone edited --
+      # a coverage mandate wearing a freshness check's name.
+      #
+      # Measured against the 37 source-touching commits before it existed, it
+      # would have failed 10. That is the retroactive rate, not the steady-state
+      # one: the way past it is to touch the doc, so under the gate authors do,
+      # and the rate falls toward zero. Needs fetch-depth: 0, above.
+      - name: Check documentation moved with the code
+        run: node scripts/check-doc-freshness.mjs "origin/${{ github.base_ref || 'develop' }}"
 
       - name: Lint (scoped)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,8 @@ jobs:
           node scripts/check-source-bytes.mjs
           node scripts/check-feature-boundaries.mjs
           node scripts/check-a11y-patterns.mjs
+          node scripts/check-css-sync.mjs
+          node scripts/check-env-parity.mjs
           pnpm exec madge --circular --extensions ts,tsx,js,jsx apps/store/src apps/studio/src apps/landing/src apps/payments/src apps/admin/src apps/auth/src apps/playground/src packages/ui/src packages/shared/src packages/api/src packages/app-components/src packages/auth/src tests scripts docker
 
       # Ported from aeleos with one change: a symbol undocumented on both

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -207,13 +207,82 @@ Those violate a stated MUST, and they are the real finding.
   1  studio: products -> orders
 ```
 
-Three of those pairs import **each other**: assigned-orders and
+Three of those pairs imported **each other**: assigned-orders and
 received-orders, cart and products, products and seller-admins. A cycle at
-feature level usually means one feature wearing two names, and deciding that
-is a design call rather than an import fix.
+feature level usually means one feature wearing two names, and each of them
+turned out to be exactly that. All thirteen are now resolved, and none were
+resolved by moving an import until the check stopped counting:
 
-`scripts/check-feature-boundaries.mjs` holds the count at 13 and fails on a
-fourteenth. Lower the baseline as pairs are resolved; that is the ratchet.
+- `admin: users -> audit` — `insertAuditLog` was infrastructure both features
+  called, so it moved to `shared/infrastructure`.
+- `store: cart <-> products` — the cart's state, reducer, cookie persistence
+  and `useAddToCart` were never the drawer's business; they moved to
+  `shared/application/cart` and the cart feature became the drawer that reads
+  them.
+- `studio: products <-> seller-admins`, `products -> orders` — two pages were
+  composition roots that happened to live inside a feature; they moved to
+  `shared/presentation/pages`.
+- `payments: assigned-orders <-> received-orders` — counting the files settled
+  it. received-orders held fourteen; assigned-orders held six, none of which
+  was a component, a type, or a domain rule. It was a query and a page, so the
+  two were merged and assigned-orders was deleted.
+
+`scripts/check-feature-boundaries.mjs` now holds the count at **0** and fails
+on the first new one.
+
+---
+
+## Documentation that no longer describes its code
+
+`scripts/check-doc-freshness.mjs` reports an exported symbol whose
+implementation changed while its TSDoc did not. It is a heuristic and says so:
+nothing can see that prose went stale on its own. It catches the case that
+matters — a symbol whose behaviour moved under a comment that still confidently
+describes the old one.
+
+Two properties keep it from becoming noise people learn to ignore. It reports
+per **symbol**, so the message names `getSupabaseAccessToken` rather than a
+file. And it collapses whitespace runs, so re-indenting cannot trigger it.
+
+There is no suppression flag, deliberately: a suppression flag becomes the
+thing everyone types. The way past it is to touch the doc, and restating an
+invariant that still holds is itself worth writing. For the same reason,
+deleting the doc is reported too — otherwise deletion _is_ the suppression
+flag.
+
+It is ported from the sibling AeleOS repository with one change. AeleOS
+enforces `jsdoc/require-jsdoc`, so every export there carries a doc and an
+empty-to-empty comparison can only mean "the doc did not move". Libra
+documents 335 of its 1002 exported symbols. Without the change the same
+comparison would fire on every undocumented export anyone edited — a
+documentation-coverage mandate wearing a freshness check's name, and one
+nobody agreed to. So a symbol undocumented on both sides is skipped, which
+guards the docs that exist and widens on its own as coverage grows.
+
+It covers `.ts`, `.tsx` and `.mjs`. The last is not in the AeleOS original,
+and is here because this repo's tooling lives in `scripts/` and is among its
+most doc-dense code; leaving it out would be the same not-looking this
+document is about. Including it widened the sample by nine commits and
+produced no new findings.
+
+Measured against the 37 source-touching commits that preceded it, it would
+have failed 10. Spot-checking those: `getSupabaseAccessToken` grew a
+three-second Clerk hydration wait while its doc still described the old
+immediate-null behaviour — the exact failure the gate is for. Two others were
+a test-id prop and a deleted lint directive, where the doc had not gone stale
+and the author would have to touch it anyway. That is the accepted cost, and
+27% is the retroactive rate rather than the steady-state one: under the gate
+authors touch the doc, and the rate falls toward zero.
+
+---
+
+## A gate in package.json is not a gate
+
+`check:a11y-patterns` existed as a script and ran in **no workflow and no
+hook** — findable by anyone who went looking for it, enforced on nobody. It is
+the same failure this document catalogues elsewhere in a quieter form: not a
+check scoped to the files it already passes, but a check with no caller at
+all. It now runs in the CI hygiene block beside the others.
 
 ---
 

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -282,7 +282,39 @@ authors touch the doc, and the rate falls toward zero.
 hook** — findable by anyone who went looking for it, enforced on nobody. It is
 the same failure this document catalogues elsewhere in a quieter form: not a
 check scoped to the files it already passes, but a check with no caller at
-all. It now runs in the CI hygiene block beside the others.
+all.
+
+Finding it by accident is not a method, so all 58 `package.json` scripts were
+then checked against `.github/` and `.husky/`. Two more were in the same
+state: **`check-css-sync`** and **`check-env-parity`**. Everything else
+unreferenced was a developer command — `tunnel`, `fix:all`, `supabase:reset`,
+`user:grant-role` — which is what an unreferenced script is supposed to look
+like. All three gates now run in the CI hygiene block.
+
+`check-css-sync` had a second, worse problem. Its header says it "ensures
+globals.css files are synchronized across **all apps**". It held a hardcoded
+list of five — store, studio, landing, payments, admin — and this repository
+has **seven** apps with a `globals.css`. `auth` and `playground` were absent,
+so the check printed "in sync across all apps" while declining to look at two
+of them. That is this document's central failure in its purest form, sitting
+inside a gate that was also not running.
+
+Both omitted files happened to be byte-identical to the reference. That is
+luck rather than evidence: the check could not have said otherwise, and it was
+not running anywhere to say it. The list is now derived from
+`git ls-files apps/*/src/app/globals.css`, which is the same reasoning that
+keeps the other gates honest — a hand-maintained list drifts from the
+repository the moment someone adds an app and does not think of this file.
+
+`check-env-parity` exited **0** when it found fewer than two env files,
+printing "nothing to compare". The politest form of the same thing: success
+reported from an empty comparison. All four `.env.*` files are tracked in git,
+so any checkout that can run the script has them, and their absence means the
+working tree is wrong rather than the comparison unnecessary. It now exits 1.
+
+Both were made to fail deliberately before being trusted to pass — a rule
+appended to `apps/auth/src/app/globals.css` for the first, a copy of the
+second run from a directory with no env files.
 
 ---
 

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -647,3 +647,43 @@ them is safe as far as this repository is concerned, but the values cannot be
 recovered and whether the matching OAuth applications are still live in the
 Google and Discord consoles is not visible from here. That is a decision about
 credentials rather than about code.
+
+---
+
+## One AeleOS gate that does not port: `check-agent-notes`
+
+AeleOS fails a build when a directory's agent note went unread while code under
+it changed. Every `CLAUDE.md` and `AGENTS.md` governs its directory; a change
+below one must be accompanied by a change to it. It is a good gate there. It
+does not transfer here, for two reasons that are worth writing down so nobody
+re-derives them.
+
+**Its central mechanism conflicts with a rule this repo already has.** The
+check walks up from a changed file to the nearest governing note and demands an
+edit. AeleOS's root `CLAUDE.md` is 118KB of running record, so that demand is
+normal there. Libra's root `CLAUDE.md` is a portable template, and
+[portability.md](../../.claude/rules/portability.md) requires it to stay
+project-agnostic — no project names, no dated content, no running record. A
+gate that demanded an edit to it on every commit would push exactly the
+project-specific churn that rule forbids into the file the rule protects. The
+gate would be fighting the codebase's own stated standard, not enforcing it.
+
+**With the root exempted, there is almost nothing left to guard.** Libra has
+two notes: the root template and `.claude/tools/CLAUDE.md`. Across the last 200
+commits on `develop`, exactly one changed something under `.claude/tools/`
+without also editing that note. Roughly 200 lines of script and tests to catch
+a drift that occurs half a percent of the time is ceremony, and this document
+argues elsewhere that a gate nobody's work meets becomes a gate everybody
+learns to satisfy hollowly.
+
+The precondition that would change the answer is real subtree notes — a
+`CLAUDE.md` per app or per package, each describing that subtree's actual
+invariants. With those in place the gate has bounded, meaningful subjects, the
+root exemption stops being load-bearing, and porting it is worth doing. Until
+then it would be a check scoped to a directory it already passes, which is the
+failure this whole document catalogues.
+
+`check-doc-freshness` covers the adjacent ground in the meantime: it is per
+symbol rather than per directory, so it cannot see a note whose subject is a
+different file, but it does guard the prose that sits directly above the code
+it describes.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "check:migrations": "node scripts/check-migration-edits.mjs",
     "check:source-bytes": "node scripts/check-source-bytes.mjs",
     "check:a11y-patterns": "node scripts/check-a11y-patterns.mjs",
-    "check:boundaries": "node scripts/check-feature-boundaries.mjs"
+    "check:boundaries": "node scripts/check-feature-boundaries.mjs",
+    "check:docs": "node scripts/check-doc-freshness.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/api/src/supabase/browser.ts
+++ b/packages/api/src/supabase/browser.ts
@@ -69,9 +69,9 @@ async function waitForClerkHydration(): Promise<ClerkGlobal | undefined> {
  * standalone getter for the handful of call sites that bypass supabase-js
  * entirely with a manual `fetch()` (e.g.
  * `apps/admin/src/shared/infrastructure/auditRestClient.ts` and
- * `apps/admin/src/features/audit/infrastructure/auditQueries.ts`'s
- * `insertAuditLog`, which need the raw bearer token for a request against a
- * schema/view supabase-js's query builder cannot reach). Both uses have the
+ * `apps/admin/src/shared/infrastructure/auditLog.ts`'s `insertAuditLog`,
+ * which need the raw bearer token for a request against a schema/view
+ * supabase-js's query builder cannot reach). Both uses have the
  * same failure mode: a `null` here either falls back to the anon key
  * (supabase-js: `fetchWithAuth`: `const accessToken = (await
  * getAccessToken()) ?? supabaseKey` in `@supabase/supabase-js`'s
@@ -91,17 +91,22 @@ async function waitForClerkHydration(): Promise<ClerkGlobal | undefined> {
  *    have `<ClerkProvider>`, the Clerk JS SDK's script has started
  *    executing and assigned itself to the global, but its own async
  *    initialization (environment fetch, session restore) hasn't finished.
- *    This is the real transient race on first paint: a signed-in request
- *    that merely ran a moment too early would otherwise be silently treated
- *    as anonymous, with no trace of why. Warn.
+ *    This is the real transient race on first paint. It is now **waited
+ *    out** rather than reported: see below.
  * 3. `globalThis.Clerk.loaded === true` and `session` is null/absent —
  *    genuinely signed out, the legitimate state the storefront's anonymous
  *    browsing depends on. Silent.
  *
- * This still can't block the request — there is no good way to "wait" from
- * inside a `SupabaseClient` constructor option — but case 2 is now
- * observable via `console.warn` instead of indistinguishable from case 1 or
- * 3, which was the actual gap this closes.
+ * Case 2 does block the request, for up to
+ * {@link CLERK_HYDRATION_TIMEOUT_MS}. An earlier version of this function
+ * returned `null` immediately and merely warned, on the reasoning that there
+ * was no good way to wait from inside a `SupabaseClient` constructor option.
+ * That reasoning was wrong: the option is an async callback, so awaiting in it
+ * is exactly what it allows. Returning early handed supabase-js the anon key,
+ * and every RLS-protected read a signed-in user made during that window came
+ * back empty rather than failing — which is how the permission cache went
+ * unwritten on first load. The warning now fires only when the wait times out,
+ * because that is the case a developer can act on.
  */
 export async function getSupabaseAccessToken(): Promise<string | null> {
   const clerk = globalThis.Clerk;

--- a/scripts/__tests__/doc-freshness.test.mjs
+++ b/scripts/__tests__/doc-freshness.test.mjs
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { extractSymbols, findStale } from "../lib/doc-freshness.mjs";
+
+const sym = (code) => extractSymbols(code, "a.ts");
+
+describe("extractSymbols", () => {
+  it("pairs an exported symbol with its doc", () => {
+    const out = sym(
+      `/** Adds. */\nexport function add(a, b) { return a + b; }`,
+    );
+    expect(out.get("add").doc).toBe("/** Adds. */");
+    expect(out.get("add").code).toContain("return a + b;");
+  });
+
+  it("collapses whitespace runs so re-indenting is not a change", () => {
+    const a = sym(`/** Adds. */\nexport function add(a, b) { return a + b; }`);
+    const b = sym(
+      `/** Adds. */\nexport function add(a, b) {\n\n      return a + b;\n}`,
+    );
+    expect(a.get("add").code).toBe(b.get("add").code);
+  });
+
+  it("ignores symbols that are not exported", () => {
+    expect(sym(`function hidden() {}`).has("hidden")).toBe(false);
+  });
+
+  it("names an exported const", () => {
+    expect(sym(`/** N. */\nexport const N = 1;`).has("N")).toBe(true);
+  });
+});
+
+describe("findStale", () => {
+  it("reports a documented symbol whose code moved but whose doc did not", () => {
+    const before = sym(
+      `/** Returns null when missing. */\nexport function get() { return null; }`,
+    );
+    const after = sym(
+      `/** Returns null when missing. */\nexport function get() { throw new Error("missing"); }`,
+    );
+    expect(findStale(before, after).map((s) => s.name)).toEqual(["get"]);
+  });
+
+  it("stays quiet when the doc moved with the code", () => {
+    const before = sym(
+      `/** Returns null. */\nexport function get() { return null; }`,
+    );
+    const after = sym(
+      `/** Throws when missing. */\nexport function get() { throw new Error("x"); }`,
+    );
+    expect(findStale(before, after)).toEqual([]);
+  });
+
+  it("stays quiet when only indentation changed", () => {
+    const before = sym(
+      `/** Adds. */\nexport function add(a, b) { return a + b; }`,
+    );
+    const after = sym(
+      `/** Adds. */\nexport function add(a, b) {\n    return a + b;\n}`,
+    );
+    expect(findStale(before, after)).toEqual([]);
+  });
+
+  it("ignores added and deleted symbols", () => {
+    const before = sym(`/** A. */\nexport const a = 1;`);
+    const after = sym(`/** B. */\nexport const b = 2;`);
+    expect(findStale(before, after)).toEqual([]);
+  });
+
+  // The deliberate divergence from AeleOS, which enforces jsdoc/require-jsdoc
+  // and so can read "" === "" as "the doc did not move". Libra documents about
+  // a third of its exports; without this rule the check would fire on every
+  // undocumented export anyone edited -- a coverage mandate wearing a
+  // freshness check's name.
+  it("ignores a symbol that was undocumented before and after", () => {
+    const before = sym(`export function raw() { return 1; }`);
+    const after = sym(`export function raw() { return 2; }`);
+    expect(findStale(before, after)).toEqual([]);
+  });
+
+  // Without this, "delete the doc" is the suppression flag the header says
+  // this check deliberately does not offer.
+  it("reports a doc deleted while the code changed", () => {
+    const before = sym(`/** Adds. */\nexport function add() { return 1; }`);
+    const after = sym(`export function add() { return 2; }`);
+    expect(findStale(before, after).map((s) => s.name)).toEqual(["add"]);
+  });
+
+  it("stays quiet when a doc is deleted but the code did not move", () => {
+    const before = sym(`/** Adds. */\nexport const a = 1;`);
+    const after = sym(`export const a = 1;`);
+    expect(findStale(before, after)).toEqual([]);
+  });
+});

--- a/scripts/check-css-sync.mjs
+++ b/scripts/check-css-sync.mjs
@@ -9,6 +9,7 @@
  * - Blocks wrapped in @css-sync-ignore-start / @css-sync-ignore-end markers
  */
 
+import { execFileSync } from "child_process";
 import { readFileSync, existsSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -16,9 +17,45 @@ import { fileURLToPath } from "url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 
-// Apps to check
-const APPS = ["store", "studio", "landing", "payments", "admin"];
 const CSS_PATH = "src/app/globals.css";
+
+/**
+ * Every app that actually has a `globals.css`, asked of git rather than
+ * listed here.
+ *
+ * This was a hardcoded array of five: store, studio, landing, payments,
+ * admin. `auth` and `playground` both have a `globals.css` and both were
+ * missing from it, so the checker reported "in sync across all apps" while
+ * declining to look at two of them. They happened to be byte-identical when
+ * this was found, which is luck rather than evidence -- the check could not
+ * have told anyone otherwise.
+ *
+ * A hand-maintained list drifts from the repository the moment somebody adds
+ * an app and does not think of this file. Deriving it means a new app is
+ * covered by existing, and there is no list to forget.
+ *
+ * @returns app directory names, sorted, each holding a globals.css.
+ */
+function discoverApps() {
+  const apps = execFileSync("git", ["ls-files", `apps/*/${CSS_PATH}`], {
+    cwd: ROOT,
+    encoding: "utf8",
+  })
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((file) => file.split("/")[1])
+    .sort();
+
+  if (apps.length === 0) {
+    throw new Error(
+      "no apps/*/src/app/globals.css matched -- refusing to report a clean result",
+    );
+  }
+  return apps;
+}
+
+const APPS = discoverApps();
 
 // Lines to ignore when comparing (regex patterns)
 const IGNORE_PATTERNS = [

--- a/scripts/check-doc-freshness.mjs
+++ b/scripts/check-doc-freshness.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * CLI for the stale-documentation check. The logic lives in
+ * scripts/lib/doc-freshness.mjs so the tests can import it without running a
+ * git command.
+ *
+ * Usage:
+ *   node scripts/check-doc-freshness.mjs [baseRef]   compare baseRef...HEAD
+ *   node scripts/check-doc-freshness.mjs --staged     compare HEAD to the index
+ */
+import { execFileSync } from "node:child_process";
+
+import { extractSymbols, findStale } from "./lib/doc-freshness.mjs";
+
+/**
+ * Reads a path at a git ref.
+ *
+ * @param ref - a git ref, or the empty string to read the index.
+ * @param file - the repository-relative path.
+ * @returns the file's contents, or an empty string when it does not exist
+ * there.
+ */
+function atRef(ref, file) {
+  try {
+    // stderr is discarded deliberately: a newly added file makes `git show`
+    // print "fatal: path ... exists on disk, but not in HEAD", which is
+    // expected here and handled by returning "". Letting it through would
+    // print a fatal on every commit that adds a file, and a gate that cries
+    // wolf gets ignored.
+    return execFileSync("git", ["show", `${ref}:${file}`], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Compares two revisions and reports stale documentation.
+ *
+ * @returns nothing; exits non-zero when anything is found.
+ */
+function main() {
+  const staged = process.argv.includes("--staged");
+  const base = staged
+    ? "HEAD"
+    : (process.argv.slice(2).find((a) => !a.startsWith("--")) ??
+      "origin/develop");
+
+  const listArgs = staged
+    ? ["diff", "--cached", "--name-only"]
+    : ["diff", "--name-only", `${base}...HEAD`];
+
+  const changed = execFileSync("git", listArgs, { encoding: "utf8" })
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(
+      (f) =>
+        // .mjs is in scope because this repo's tooling lives in scripts/ and
+        // is among its most doc-dense code. Including it widened the sample
+        // by nine commits and produced no new findings, so it is coverage at
+        // no cost in noise.
+        /\.(tsx?|mjs)$/.test(f) &&
+        !/\.(test|spec)\.(tsx?|mjs)$/.test(f) &&
+        !/(^|\/)(generated|__generated__)\//.test(f),
+    );
+
+  let findings = 0;
+  for (const file of changed) {
+    // "" as a ref reads the index, which is what a pre-commit run compares.
+    const before = atRef(base, file);
+    const after = staged ? atRef("", file) : atRef("HEAD", file);
+    if (!before || !after) continue;
+    for (const { name } of findStale(
+      extractSymbols(before, file),
+      extractSymbols(after, file),
+    )) {
+      findings += 1;
+      console.error(
+        `${file}: \`${name}\` changed but its TSDoc did not. ` +
+          `Update it, or restate the invariant that still holds.`,
+      );
+    }
+  }
+
+  if (findings) {
+    console.error(
+      `\n${findings} symbol(s) with documentation that may be stale.`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `Documentation moved with the code (${changed.length} file(s) checked).`,
+  );
+}
+
+main();

--- a/scripts/check-env-parity.mjs
+++ b/scripts/check-env-parity.mjs
@@ -38,11 +38,18 @@ const envFiles = readdirSync(rootDir)
   .filter((f) => /^\.env\.[a-z]+$/.test(f))
   .sort();
 
+// Exiting 0 here would be the failure this repo keeps finding in its own
+// gates: a check that reports success because it read nothing. The four
+// .env.* files are tracked in git, so any checkout that can run this has
+// them, and their absence means the working tree is wrong rather than the
+// comparison being unnecessary.
 if (envFiles.length < 2) {
-  console.log(
-    "check-env-parity: fewer than 2 env files found, nothing to compare.",
+  console.error(
+    `check-env-parity: found ${envFiles.length} env file(s) in ${rootDir}; ` +
+      "at least 2 are tracked in git. Refusing to report a clean result " +
+      "from an empty comparison.",
   );
-  process.exit(0);
+  process.exit(1);
 }
 
 console.log(`\n🔍 check-env-parity — comparing ${envFiles.length} env files:`);

--- a/scripts/lib/doc-freshness.mjs
+++ b/scripts/lib/doc-freshness.mjs
@@ -1,0 +1,142 @@
+/**
+ * Flags exported symbols whose implementation changed while their TSDoc did not.
+ *
+ * A heuristic by nature. No tool can see that prose went stale: change
+ * `fetchAssignedOrders` from "returns null when missing" to "throws" without
+ * touching the signature and every linter reports green. It is adopted
+ * deliberately, because AI-driven development churns code faster than comments,
+ * and a stale comment is a confident, wrong instruction.
+ *
+ * Two properties keep it from becoming noise people learn to ignore:
+ *
+ * - It reports **per symbol**, so the message names `fetchAssignedOrders`
+ *   rather than a filename.
+ * - It **collapses whitespace runs** before comparing, so re-indenting and
+ *   re-wrapping cannot trigger it. It is not fully format-invariant: adding a
+ *   space after a comma is still a change. That is tolerable because
+ *   `format:check` gates the whole repo, so both sides of any comparison are
+ *   already Prettier-formatted, and a reflow that survives that is one the
+ *   code caused.
+ *
+ * There is no suppression flag, by choice: a suppression flag becomes the thing
+ * everyone types. The way past it is to touch the doc -- restating an invariant
+ * that still holds is itself worth writing.
+ *
+ * Ported from the sibling AeleOS repository with one deliberate change, which
+ * `findStale` documents.
+ */
+import ts from "typescript";
+
+/**
+ * Collapses runs of whitespace so that reformatting cannot register as a
+ * change.
+ *
+ * @param value - the source or comment text to normalise.
+ * @returns the text with all whitespace runs collapsed to single spaces.
+ */
+const normalise = (value) => value.replace(/\s+/g, " ").trim();
+
+/**
+ * The doc comment immediately above a node.
+ *
+ * @param node - the AST node to look above.
+ * @param source - the parsed source file the node belongs to.
+ * @returns the block comment text, or an empty string when there is none.
+ */
+function leadingDoc(node, source) {
+  const ranges = ts.getLeadingCommentRanges(source.text, node.pos) ?? [];
+  return ranges
+    .filter((r) => source.text.slice(r.pos, r.pos + 3) === "/**")
+    .map((r) => source.text.slice(r.pos, r.end))
+    .join("\n");
+}
+
+/**
+ * Whether a node carries the `export` keyword.
+ *
+ * @param node - the AST node to inspect.
+ * @returns true when the node is exported.
+ */
+const isExported = (node) =>
+  node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+
+/**
+ * The declared name of a top-level node.
+ *
+ * @param node - the AST node to name.
+ * @returns the identifier, or null for nodes that do not declare one.
+ */
+function nameOf(node) {
+  if (ts.isVariableStatement(node)) {
+    return node.declarationList.declarations[0]?.name?.getText?.() ?? null;
+  }
+  return node.name?.getText?.() ?? null;
+}
+
+/**
+ * Every exported top-level symbol, paired with its normalised implementation
+ * and documentation.
+ *
+ * @param code - the file's source text.
+ * @param fileName - the path, used only for TypeScript's diagnostics.
+ * @returns a map of symbol name to its normalised code and doc text.
+ */
+export function extractSymbols(code, fileName) {
+  const source = ts.createSourceFile(
+    fileName,
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const out = new Map();
+  source.forEachChild((node) => {
+    if (!isExported(node)) return;
+    const name = nameOf(node);
+    if (!name) return;
+    out.set(name, {
+      code: normalise(node.getText(source)),
+      doc: normalise(leadingDoc(node, source)),
+    });
+  });
+  return out;
+}
+
+/**
+ * Symbols present in both versions whose code moved while their doc stood
+ * still.
+ *
+ * Added and deleted symbols are ignored: naming them here would report a
+ * missing doc, which is a different complaint.
+ *
+ * A symbol undocumented in *both* versions is ignored too, and this is where
+ * the check diverges from the AeleOS original. AeleOS enforces
+ * `jsdoc/require-jsdoc`, so every export there carries a doc and comparing
+ * `"" === ""` can only mean "the doc did not move". Libra documents about a
+ * third of its exports. Without this rule the same comparison would fire on
+ * every undocumented export anyone edited -- a documentation-coverage mandate
+ * wearing a freshness check's name, and one nobody agreed to. Guarding the
+ * docs that exist is the honest subset, and it widens on its own as coverage
+ * grows.
+ *
+ * Deleting a doc while changing the code is reported as its own case. Strictly
+ * read, the doc *did* move -- from something to nothing -- so the equality test
+ * above lets it through. AeleOS can afford that because `jsdoc/require-jsdoc`
+ * rejects the result anyway; here nothing would. Leaving it unguarded would
+ * make "delete the doc" the suppression flag this check's header says it
+ * deliberately does not offer.
+ *
+ * @param before - symbols extracted from the earlier version.
+ * @param after - symbols extracted from the current version.
+ * @returns one entry per stale symbol.
+ */
+export function findStale(before, after) {
+  const stale = [];
+  for (const [name, now] of after) {
+    const then = before.get(name);
+    if (!then) continue;
+    if (then.code === now.code) continue;
+    if (!then.doc && !now.doc) continue;
+    if (then.doc === now.doc || !now.doc) stale.push({ name });
+  }
+  return stale;
+}


### PR DESCRIPTION
Started as a port of AeleOS's `check-doc-freshness`. Auditing how it should be wired turned up three gates that were not wired at all, so the branch covers both.

---

## 1. New gate: documentation that no longer describes its code

Reports an exported symbol whose implementation changed while its TSDoc stood still. A heuristic, adopted knowingly — nothing can detect that prose went stale, and a stale comment is a confident, wrong instruction.

**Two deliberate divergences from AeleOS.**

*A symbol undocumented on both sides is skipped.* AeleOS enforces `jsdoc/require-jsdoc`, so every export there has a doc and `"" === ""` can only mean "the doc did not move". Libra documents **335 of 1002** exports (33%); without the skip this fires on every undocumented export anyone edits — a coverage mandate wearing a freshness check's name.

*Deleting a doc while changing code is reported.* Strictly read the doc did move — from something to nothing — so the original lets it through and `require-jsdoc` catches the result there. Here nothing would, and unguarded, "delete the doc" becomes the suppression flag the check's own header says it does not offer.

**Scope includes `.mjs`**, which the original does not cover. This repo's tooling lives in `scripts/` and is among its most doc-dense code. Measured: widened the sample by nine commits, **zero** new findings.

**Measured cost.** Against the 37 source-touching commits preceding it, it would have failed 10. Spot-checked: `getSupabaseAccessToken` was a true positive; a test-id prop and a deleted lint directive were not. 27% is the *retroactive* rate — the way past the gate is to touch the doc, so under it authors do.

### The first defect it found

`getSupabaseAccessToken`'s TSDoc ended: *"This still can't block the request — there is no good way to 'wait' from inside a `SupabaseClient` constructor option."* Every clause is false. The function waits up to three seconds for Clerk to hydrate. The original reasoning was wrong on its own terms too — `accessToken` is an async callback, so awaiting in it is exactly what it permits. The signature never moved, every linter stayed green, and the comment sat there instructing the next reader that waiting was impossible, directly above the code that waits. Fixed here, along with a reference to `insertAuditLog` at a path it no longer occupies.

---

## 2. Three gates that ran nowhere

`check:a11y-patterns` existed as a `package.json` script called by **no workflow and no hook**. Finding that by accident is not a method, so all 58 scripts were audited against `.github/` and `.husky/`. Two more were in the same state: **`check-css-sync`** and **`check-env-parity`**. Everything else unreferenced was a developer command (`tunnel`, `fix:all`, `supabase:reset`) — which is what an unreferenced script should look like.

### `check-css-sync` also lied about its scope

Its header says it ensures globals.css is synchronized "across **all apps**". It held a hardcoded list of five. The repo has **seven** apps with a `globals.css` — `auth` and `playground` were absent. So it printed *"in sync across all apps"* while declining to look at two of them: a gate scoped to the files it already passes, inside a gate that was not running.

Both omitted files were byte-identical to the reference — luck, not evidence. The list now comes from `git ls-files apps/*/src/app/globals.css`, so a new app is covered by existing.

### `check-env-parity` passed on an empty comparison

It exited **0** when it found fewer than two env files, printing "nothing to compare". All four `.env.*` files are tracked in git, so their absence means the working tree is wrong, not that the comparison is unnecessary. Now exits 1.

---

## 3. One AeleOS gate that does not port

`check-agent-notes` is documented as **deliberately not ported**, with evidence, rather than left as a silent gap:

- Its mechanism walks up to the nearest governing note and demands an edit. AeleOS's root `CLAUDE.md` is a 118KB running record; Libra's is a portable template that `.claude/rules/portability.md` **requires** to stay project-agnostic. The gate would push the exact churn that rule forbids into the file it protects.
- Exempting the root leaves `.claude/tools/CLAUDE.md` as the only governing note. Across 200 commits on `develop`, **one** changed something under it without editing it. ~200 lines of script for a half-percent drift is ceremony.

The precondition that would change the answer — real per-app subtree notes — is recorded so the decision can be revisited on evidence.

---

## Verification

- 11 new unit tests over `extractSymbols` / `findStale`, covering both divergences and the indentation-invariance claim
- **Every changed gate was made to fail before being trusted to pass**: a documented constant changed without its doc (named the symbol, exit 1); a rule appended to `apps/auth/src/app/globals.css` (previously silent, now reported); `check-env-parity` run from a directory with no env files (exit 1). All reverted.
- `pnpm test:workflows` — 140 passed · `pnpm lint` — 0/0 · `pnpm format:check` — clean
- All six custom gates pass

Also corrects `docs/standards/quality-gates.md`, which still claimed 13 cross-feature imports — all thirteen are resolved and the ratchet sits at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt