### PR TITLE
chore: drive knip to zero and enforce it in CI [GH-000]

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -169,9 +169,9 @@ For code shared across MULTIPLE APPS. See [Monorepo Architecture](./monorepo-arc
 ```typescript
 // Import from packages
 import { Button } from "ui";
-import { formatDate } from "shared";
-import { useGetAnomaliesTenantAnomaliesGet } from "api/generated/anomalies/anomalies";
-import type { GlobalMetrics } from "api/types/generated";
+import { formatDate, tid } from "shared";
+import { createBrowserSupabaseClient } from "api/supabase/browser";
+import type { Database } from "api/supabase/types";
 ```
 
 #### 2. App-Level Shared (`apps/[app]/src/shared/`)
@@ -226,11 +226,19 @@ packages/api/src/
 
 **Rules:**
 
-1. Generated types live in `packages/api/src/types/generated/`
-2. Generated hooks live in `packages/api/src/generated/`
-3. **NEVER edit generated files** - they are overwritten on regeneration
-4. Import types: `import type { GlobalMetrics } from 'api/types/generated'`
-5. Import hooks: `import { useGetAnomaliesTenantAnomaliesGet } from 'api/generated/anomalies/anomalies'`
+1. **NEVER edit generated files** - they are overwritten on regeneration
+2. Import the Supabase clients and types from the subpaths `packages/api`
+   actually exports: `api`, `api/supabase`, `api/supabase/browser`,
+   `api/supabase/server`, `api/supabase/types`
+
+> Earlier revisions of this file documented `api/types/generated` and
+> `api/generated/<tag>/<tag>` subpaths, with examples from a dashboard API this
+> project does not have. Those subpaths were declared in
+> `packages/api/package.json` but pointed at directories that were never
+> created, so following the instruction produced an import that could not
+> resolve. The declarations are removed and this section now describes what the
+> package exports. If Orval REST generation is reintroduced, add the export
+> subpath and the generated directory together, and update this list.
 
 **Regenerate with:**
 

--- a/.claude/rules/monorepo-architecture.md
+++ b/.claude/rules/monorepo-architecture.md
@@ -159,17 +159,18 @@ import { Button, Card, cn } from "ui";
 // packages/api/src/index.ts
 export { customFetch } from "./mutator/customFetch";
 export type { ApiError } from "./mutator/types";
-// Hooks and types are imported directly via subpath:
-// import { useGetX } from "api/generated/dashboard/dashboard";
-// import type { X } from "api/types/generated";
+// Supabase clients and types are imported via subpath:
+// import { createBrowserSupabaseClient } from "api/supabase/browser";
+// import type { Database } from "api/supabase/types";
 ```
 
 **Consumption:**
 
 ```typescript
 // In any app
-import { useGetGlobalMetricsTenantGlobalMetricsGet } from "api/generated/dashboard/dashboard";
-import type { GlobalMetrics } from "api/types/generated";
+import { createBrowserSupabaseClient } from "api/supabase/browser";
+import { createServerSupabaseClient } from "api/supabase/server";
+import type { Database } from "api/supabase/types";
 ```
 
 **Regenerate with:**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,9 +205,16 @@ jobs:
       # — real source duplication is 3.95%, under the 5% threshold, so it is
       # enforced here too.
       #
-      # knip stays out. It reports 205 findings, but aeleos runs it with
-      # --no-exit-code and its own knip exits 1 as well: unused-export
-      # detection across barrel files is advisory in both repos, not a gate.
+      # knip is now enforced. It was previously excluded on the grounds that
+      # its 205 findings were advisory noise, which was wrong: they were three
+      # different things, and only one was fuzzy. Its config had `project`
+      # scoped to src/**, so it never saw e2e/ or tests/ and reported anything
+      # used only there as unused. With that fixed it found real defects --
+      # @clerk/backend imported by three e2e files and declared in no
+      # package.json, and packages/api declaring three export subpaths whose
+      # targets do not exist. The remaining 201 were dead barrel re-exports,
+      # dead destructured bindings, exports used only in their own file, and
+      # eight genuinely dead declarations. All resolved; it now exits 0.
       - name: Repo hygiene (workspace + structure checks)
         run: |
           set -euo pipefail
@@ -216,6 +223,7 @@ jobs:
           pnpm exec ls-lint
           pnpm exec cspell "**/*.{ts,tsx,md,json}" --no-progress
           pnpm exec jscpd .
+          pnpm exec knip
           node scripts/check-source-bytes.mjs
           node scripts/check-feature-boundaries.mjs
           node scripts/check-a11y-patterns.mjs

--- a/apps/admin/src/features/reports/domain/types.ts
+++ b/apps/admin/src/features/reports/domain/types.ts
@@ -7,7 +7,7 @@ export type OrderStatus =
   | "rejected"
   | "expired";
 
-export interface ReportOrderItem {
+interface ReportOrderItem {
   id: string;
   product_id: string;
   product_name: string;
@@ -48,15 +48,4 @@ export interface ReportFilters {
 export interface ReportOrdersResponse {
   orders: ReportOrder[];
   total: number;
-}
-
-export interface UserOption {
-  id: string;
-  email: string;
-  display_name: string | null;
-}
-
-export interface ProductOption {
-  id: string;
-  name: string;
 }

--- a/apps/admin/src/features/users/application/hooks/useUserDelegates.ts
+++ b/apps/admin/src/features/users/application/hooks/useUserDelegates.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { getApiBasePath } from "@/shared/application/utils/getApiBasePath";
 
-export const USER_DELEGATES_QUERY_KEY = "user-delegates";
+const USER_DELEGATES_QUERY_KEY = "user-delegates";
 
 const SAME_ORIGIN = "same-origin" as const;
 

--- a/apps/admin/src/features/users/application/utils/exportCsv.ts
+++ b/apps/admin/src/features/users/application/utils/exportCsv.ts
@@ -1,7 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 import type { UserProfileSummary } from "@/features/users/domain/types";
 
-export type UserPermissionsById = Record<string, string[]>;
+type UserPermissionsById = Record<string, string[]>;
 export interface ReceiptBackup {
   userId: string;
   orderId: string;

--- a/apps/admin/src/features/users/application/utils/formatLastSeen.ts
+++ b/apps/admin/src/features/users/application/utils/formatLastSeen.ts
@@ -9,7 +9,7 @@ import {
 } from "@/features/users/domain/constants";
 
 /** Result of computing a relative time label: an i18n key + optional params */
-export interface LastSeenResult {
+interface LastSeenResult {
   key: string;
   params?: Record<string, number>;
 }

--- a/apps/admin/src/features/users/application/utils/index.ts
+++ b/apps/admin/src/features/users/application/utils/index.ts
@@ -1,4 +1,3 @@
 export { computeRole } from "./computeRole";
 export { formatLastSeen } from "./formatLastSeen";
-export type { LastSeenResult } from "./formatLastSeen";
 export { getInitials } from "./getInitials";

--- a/apps/admin/src/features/users/domain/constants.ts
+++ b/apps/admin/src/features/users/domain/constants.ts
@@ -161,9 +161,6 @@ export const PERMISSION_TEMPLATES = {
   none: [],
 } satisfies Record<string, string[]>;
 
-/** @deprecated Import from `@/shared/domain/constants` instead */
-export { ADMIN_APP_ACCESS_KEYS } from "@/shared/domain/constants";
-
 export const SELLER_ADMINS_READ_PERMISSION = "seller_admins.read";
 
 export const USER_PERMISSIONS_QUERY_KEY = "user-permissions";

--- a/apps/admin/src/features/users/infrastructure/userPermissionQueries.ts
+++ b/apps/admin/src/features/users/infrastructure/userPermissionQueries.ts
@@ -178,24 +178,3 @@ export async function revokePermission(
 
   if (error) throw error;
 }
-
-/** Replace all permissions for a user with the given template keys */
-export async function applyTemplate(
-  supabase: SupabaseClient,
-  userId: string,
-  permissionKeys: string[],
-  grantedBy: string,
-): Promise<void> {
-  const { error: deleteError } = await supabase
-    .from(USER_PERMISSIONS_TABLE)
-    .delete()
-    .eq("user_id", userId);
-
-  if (deleteError) throw deleteError;
-
-  await Promise.all(
-    permissionKeys.map((key) =>
-      grantPermission(supabase, userId, key, grantedBy),
-    ),
-  );
-}

--- a/apps/admin/src/shared/infrastructure/config/api.ts
+++ b/apps/admin/src/shared/infrastructure/config/api.ts
@@ -1,6 +1,0 @@
-export {
-  API_REFRESH_INTERVALS,
-  API_DEFAULTS,
-  orvalOptions,
-  type PartialQueryOptions,
-} from "shared/config/api";

--- a/apps/admin/src/shared/infrastructure/config/environment.ts
+++ b/apps/admin/src/shared/infrastructure/config/environment.ts
@@ -1,10 +1,3 @@
-export {
-  environment,
-  featureFlags,
-  getRuntimeEnv,
-  getMockApiBaseUrl,
-  getApiPrefix,
-  buildMswApiUrl,
-} from "shared/config/environment";
+export { getRuntimeEnv } from "shared/config/environment";
 
 export const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/apps/admin/src/shared/infrastructure/config/index.ts
+++ b/apps/admin/src/shared/infrastructure/config/index.ts
@@ -1,17 +1,1 @@
-export {
-  environment,
-  featureFlags,
-  getRuntimeEnv,
-  getMockApiBaseUrl,
-  getApiPrefix,
-  buildMswApiUrl,
-} from "./environment";
-export { tid, TID_ATTR } from "./tid";
-export {
-  API_REFRESH_INTERVALS,
-  API_DEFAULTS,
-  orvalOptions,
-  type PartialQueryOptions,
-} from "./api";
-
 export { appUrls } from "shared/config/appUrls";

--- a/apps/admin/src/shared/infrastructure/config/tid.ts
+++ b/apps/admin/src/shared/infrastructure/config/tid.ts
@@ -1,1 +1,0 @@
-export { tid, TID_ATTR, type TidOptionProps } from "shared/utils/tid";

--- a/apps/admin/src/shared/infrastructure/i18n/index.ts
+++ b/apps/admin/src/shared/infrastructure/i18n/index.ts
@@ -1,4 +1,3 @@
 import { createAppI18n } from "shared/i18n/createAppI18n";
 
-export const { routing, Link, redirect, usePathname, useRouter, getPathname } =
-  createAppI18n();
+export const { routing, Link, useRouter } = createAppI18n();

--- a/apps/admin/tests/ReportFiltersBar.test.tsx
+++ b/apps/admin/tests/ReportFiltersBar.test.tsx
@@ -5,10 +5,6 @@ vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
 }));
 
-vi.mock("@/shared/infrastructure/config/tid", () => ({
-  tid: (id: string) => ({ "data-testid": id }),
-}));
-
 import { ReportFiltersBar } from "@/features/reports/presentation/components/ReportFiltersBar";
 
 import type { ReportFilters } from "@/features/reports/domain/types";

--- a/apps/admin/tests/ReportTable.test.tsx
+++ b/apps/admin/tests/ReportTable.test.tsx
@@ -8,10 +8,6 @@ vi.mock("next-intl", () => ({
   },
 }));
 
-vi.mock("@/shared/infrastructure/config/tid", () => ({
-  tid: (id: string) => ({ "data-testid": id }),
-}));
-
 vi.mock("@/features/reports/presentation/components/OrderStatusBadge", () => ({
   OrderStatusBadge: ({ status }: { status: string }) => (
     <span data-testid={`status-badge-${status}`}>{status}</span>

--- a/apps/admin/tests/ReportsPage.test.tsx
+++ b/apps/admin/tests/ReportsPage.test.tsx
@@ -8,10 +8,6 @@ vi.mock("next-intl", () => ({
   },
 }));
 
-vi.mock("@/shared/infrastructure/config/tid", () => ({
-  tid: (id: string) => ({ "data-testid": id }),
-}));
-
 const mockSetFilters = vi.fn();
 
 vi.mock("@/features/reports/application/hooks/useReportOrders", () => ({

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -36,6 +36,8 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.13.0",
+    "@clerk/backend": "^3.16.13",
+    "@clerk/testing": "^2.2.31",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.2.4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/auth/src/shared/infrastructure/config/environment.ts
+++ b/apps/auth/src/shared/infrastructure/config/environment.ts
@@ -1,8 +1,0 @@
-export {
-  environment,
-  featureFlags,
-  getRuntimeEnv,
-  getMockApiBaseUrl,
-  getApiPrefix,
-  buildMswApiUrl,
-} from "shared/config/environment";

--- a/apps/auth/src/shared/infrastructure/config/index.ts
+++ b/apps/auth/src/shared/infrastructure/config/index.ts
@@ -1,3 +1,1 @@
-export { environment, featureFlags, getRuntimeEnv } from "./environment";
-
 export { appUrls } from "shared/config/appUrls";

--- a/apps/auth/src/shared/infrastructure/i18n/index.ts
+++ b/apps/auth/src/shared/infrastructure/i18n/index.ts
@@ -1,4 +1,3 @@
 import { createAppI18n } from "shared/i18n/createAppI18n";
 
-export const { routing, Link, redirect, usePathname, useRouter, getPathname } =
-  createAppI18n();
+export const { routing } = createAppI18n();

--- a/apps/landing/src/shared/infrastructure/config/environment.ts
+++ b/apps/landing/src/shared/infrastructure/config/environment.ts
@@ -1,8 +1,1 @@
-export {
-  environment,
-  featureFlags,
-  getRuntimeEnv,
-  getMockApiBaseUrl,
-  getApiPrefix,
-  buildMswApiUrl,
-} from "shared/config/environment";
+export { getRuntimeEnv } from "shared/config/environment";

--- a/apps/landing/src/shared/infrastructure/config/index.ts
+++ b/apps/landing/src/shared/infrastructure/config/index.ts
@@ -1,3 +1,1 @@
-export { environment, featureFlags, getRuntimeEnv } from "./environment";
-
 export { appUrls } from "shared/config/appUrls";

--- a/apps/landing/src/shared/infrastructure/i18n/index.ts
+++ b/apps/landing/src/shared/infrastructure/i18n/index.ts
@@ -1,4 +1,3 @@
 import { createAppI18n } from "shared/i18n/createAppI18n";
 
-export const { routing, Link, redirect, usePathname, useRouter, getPathname } =
-  createAppI18n();
+export const { routing } = createAppI18n();

--- a/apps/landing/tests/PrivacyPage.test.tsx
+++ b/apps/landing/tests/PrivacyPage.test.tsx
@@ -9,10 +9,6 @@ vi.mock("next-intl", () => ({
     },
 }));
 
-vi.mock("@/shared/infrastructure/config/tid", () => ({
-  tid: (id: string) => ({ "data-testid": id }),
-}));
-
 import { PrivacyPage } from "@/features/legal/presentation/pages/PrivacyPage";
 
 describe("PrivacyPage", () => {

--- a/apps/landing/tests/TermsPage.test.tsx
+++ b/apps/landing/tests/TermsPage.test.tsx
@@ -9,10 +9,6 @@ vi.mock("next-intl", () => ({
     },
 }));
 
-vi.mock("@/shared/infrastructure/config/tid", () => ({
-  tid: (id: string) => ({ "data-testid": id }),
-}));
-
 import { TermsPage } from "@/features/legal/presentation/pages/TermsPage";
 
 describe("TermsPage", () => {

--- a/apps/payments/src/features/checkout/domain/types.ts
+++ b/apps/payments/src/features/checkout/domain/types.ts
@@ -45,13 +45,6 @@ export interface SellerPaymentMethodWithType {
   requires_transfer_number: boolean;
 }
 
-/** @deprecated Use SellerPaymentMethodWithType (new flat shape) */
-export interface BuyerFieldDescriptor {
-  key: string;
-  type: "text" | "email";
-  required: boolean;
-}
-
 export interface CheckoutPaymentMethodsResponse {
   methods: SellerPaymentMethodWithType[];
   hasStockIssues: boolean;
@@ -62,13 +55,3 @@ export type CheckoutSellerStatus =
   | "submitting"
   | "submitted"
   | "error";
-
-export interface SellerCheckoutState {
-  status: CheckoutSellerStatus;
-  selectedMethodId: string | null;
-  transferNumber: string;
-  receiptFile: File | null;
-  buyerInfo: Record<string, string>;
-  orderId: string | null;
-  error: string | null;
-}

--- a/apps/payments/src/features/checkout/presentation/components/SellerCheckoutContent.tsx
+++ b/apps/payments/src/features/checkout/presentation/components/SellerCheckoutContent.tsx
@@ -63,7 +63,7 @@ function resolveCheckoutError(
     : { message: t("errorOccurred"), detail: error };
 }
 
-export interface SellerCheckoutContentProps {
+interface SellerCheckoutContentProps {
   sellerId: string;
   items: CartItem[];
   subtotal: number;

--- a/apps/payments/src/features/payment-methods/domain/types.ts
+++ b/apps/payments/src/features/payment-methods/domain/types.ts
@@ -6,7 +6,6 @@
  * This re-export keeps internal payment-methods imports working unchanged.
  */
 export type {
-  BuyerSubmission,
   DisplayBlock,
   DisplayBlockType,
   FormField,
@@ -27,7 +26,7 @@ export interface CreatePaymentMethodParams {
   nameEs?: string;
 }
 
-export type UpdatePaymentMethodPatch = Partial<
+type UpdatePaymentMethodPatch = Partial<
   Pick<
     SellerPaymentMethod,
     | "name_en"

--- a/apps/payments/src/features/payment-methods/domain/utils.ts
+++ b/apps/payments/src/features/payment-methods/domain/utils.ts
@@ -9,12 +9,6 @@ import {
   type FormFieldType,
 } from "@/shared/domain/PaymentMethodTypes";
 
-// Re-export shared utils so existing internal imports keep working.
-export {
-  validateBuyerSubmission,
-  validateFileSize,
-} from "@/shared/domain/paymentMethodUtils";
-
 // Derived from the SSOT type-defining arrays — the two stay exhaustive
 // together because the type IS the array.
 const VALID_BLOCK_TYPES: readonly DisplayBlockType[] = DISPLAY_BLOCK_TYPES;

--- a/apps/payments/src/features/payment-methods/presentation/components/BlockEditor.tsx
+++ b/apps/payments/src/features/payment-methods/presentation/components/BlockEditor.tsx
@@ -18,7 +18,7 @@ import type {
 
 // ─── Neobrutalist input class ─────────────────────────────────────────────────
 
-export const inputClass =
+const inputClass =
   "flex h-9 w-full border-strong border-foreground bg-background px-3 py-1 text-sm shadow-brutal-sm focus:outline-none focus:ring-2 focus:ring-brand";
 
 // ─── Block Editor ─────────────────────────────────────────────────────────────

--- a/apps/payments/src/features/payment-methods/presentation/components/FieldRow.tsx
+++ b/apps/payments/src/features/payment-methods/presentation/components/FieldRow.tsx
@@ -12,7 +12,7 @@ import type { FormField } from "@/features/payment-methods/domain/types";
 const inputClass =
   "flex h-8 w-full border-strong border-foreground bg-background px-2 py-1 text-sm shadow-brutal-sm focus:outline-none focus:ring-2 focus:ring-brand";
 
-export interface FieldRowProps {
+interface FieldRowProps {
   field: FormField;
   onUpdate: (updated: FormField) => void;
   onRemove: (id: string) => void;

--- a/apps/payments/src/features/received-orders/domain/types.ts
+++ b/apps/payments/src/features/received-orders/domain/types.ts
@@ -1,5 +1,3 @@
-export type { OrderItem, OrderStatus } from "@/shared/domain/types";
-
 import type { OrderItem, OrderStatus } from "@/shared/domain/types";
 
 /** Statuses a received order can actually have — excludes legacy and pre-payment statuses */

--- a/apps/payments/src/features/reports/domain/types.ts
+++ b/apps/payments/src/features/reports/domain/types.ts
@@ -2,7 +2,7 @@ export type { OrderStatus } from "@/shared/domain/types";
 
 import type { OrderStatus } from "@/shared/domain/types";
 
-export interface SellerReportOrderItem {
+interface SellerReportOrderItem {
   id: string;
   product_id: string;
   product_name: string;

--- a/apps/payments/src/shared/application/context/ErrorContext.tsx
+++ b/apps/payments/src/shared/application/context/ErrorContext.tsx
@@ -1,3 +1,3 @@
 "use client";
 
-export { ErrorProvider, useErrorContext } from "shared/providers";
+export { ErrorProvider } from "shared/providers";

--- a/apps/payments/src/shared/infrastructure/adminRestClient.ts
+++ b/apps/payments/src/shared/infrastructure/adminRestClient.ts
@@ -36,7 +36,7 @@ const supabaseUrl =
   process.env["SUPABASE_URL_INTERNAL"] || process.env.NEXT_PUBLIC_SUPABASE_URL;
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-export function getAdminRestHeaders(extra?: HeadersInit): HeadersInit {
+function getAdminRestHeaders(extra?: HeadersInit): HeadersInit {
   if (!supabaseUrl || !serviceRoleKey) {
     throw new Error("Supabase admin REST client is not configured");
   }
@@ -48,7 +48,7 @@ export function getAdminRestHeaders(extra?: HeadersInit): HeadersInit {
   };
 }
 
-export function getAdminRestUrl(path: string): string {
+function getAdminRestUrl(path: string): string {
   if (!supabaseUrl) {
     throw new Error("Supabase URL is not configured");
   }

--- a/apps/payments/src/shared/infrastructure/config/api.ts
+++ b/apps/payments/src/shared/infrastructure/config/api.ts
@@ -1,6 +1,0 @@
-export {
-  API_REFRESH_INTERVALS,
-  API_DEFAULTS,
-  orvalOptions,
-  type PartialQueryOptions,
-} from "shared/config/api";

--- a/apps/payments/src/shared/infrastructure/config/environment.ts
+++ b/apps/payments/src/shared/infrastructure/config/environment.ts
@@ -1,8 +1,1 @@
-export {
-  environment,
-  featureFlags,
-  getRuntimeEnv,
-  getMockApiBaseUrl,
-  getApiPrefix,
-  buildMswApiUrl,
-} from "shared/config/environment";
+export { getRuntimeEnv } from "shared/config/environment";

--- a/apps/payments/src/shared/infrastructure/config/index.ts
+++ b/apps/payments/src/shared/infrastructure/config/index.ts
@@ -1,17 +1,1 @@
-export {
-  environment,
-  featureFlags,
-  getRuntimeEnv,
-  getMockApiBaseUrl,
-  getApiPrefix,
-  buildMswApiUrl,
-} from "./environment";
-export { tid, TID_ATTR } from "./tid";
-export {
-  API_REFRESH_INTERVALS,
-  API_DEFAULTS,
-  orvalOptions,
-  type PartialQueryOptions,
-} from "./api";
-
 export { appUrls } from "shared/config/appUrls";

--- a/apps/payments/src/shared/infrastructure/config/tid.ts
+++ b/apps/payments/src/shared/infrastructure/config/tid.ts
@@ -1,1 +1,1 @@
-export { tid, TID_ATTR, type TidOptionProps } from "shared/utils/tid";
+export { tid } from "shared/utils/tid";

--- a/apps/payments/src/shared/infrastructure/i18n/index.ts
+++ b/apps/payments/src/shared/infrastructure/i18n/index.ts
@@ -1,4 +1,3 @@
 import { createAppI18n } from "shared/i18n/createAppI18n";
 
-export const { routing, Link, redirect, usePathname, useRouter, getPathname } =
-  createAppI18n();
+export const { routing, Link } = createAppI18n();

--- a/apps/payments/src/shared/infrastructure/receiptActions.ts
+++ b/apps/payments/src/shared/infrastructure/receiptActions.ts
@@ -9,7 +9,7 @@ import {
 } from "@/shared/domain/receipt";
 import { adminFetchJson } from "@/shared/infrastructure/adminRestClient";
 
-export type ReceiptUploadResult =
+type ReceiptUploadResult =
   | { ok: true; path: string }
   | {
       ok: false;

--- a/apps/payments/src/shared/presentation/components/PaymentsSidebarNav.tsx
+++ b/apps/payments/src/shared/presentation/components/PaymentsSidebarNav.tsx
@@ -113,7 +113,7 @@ const NAV_SECTIONS: readonly NavSection[] = [
 const INACTIVE_LINK_CLASS =
   "text-muted-foreground hover:bg-muted hover:text-foreground";
 
-export interface PaymentsSidebarNavProps {
+interface PaymentsSidebarNavProps {
   appPath: string;
   collapsed?: boolean;
   grantedKeys: string[];

--- a/apps/payments/src/test/fixtures/appUrls.ts
+++ b/apps/payments/src/test/fixtures/appUrls.ts
@@ -2,7 +2,7 @@
  * Mock appUrls for unit tests.
  * Use in vi.mock('@/shared/infrastructure/config', () => mockPaymentsConfig).
  */
-export const mockAppUrls = {
+const mockAppUrls = {
   landing: "http://localhost:5004",
   store: "http://localhost:5001",
   admin: "http://localhost:5002",

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -26,7 +26,8 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "shared": "workspace:*",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@faker-js/faker": "^10.4.0",

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -26,8 +26,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "shared": "workspace:*",
-    "tw-animate-css": "^1.4.0",
-    "ui": "workspace:*"
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^10.4.0",

--- a/apps/playground/src/shared/infrastructure/config/environment.ts
+++ b/apps/playground/src/shared/infrastructure/config/environment.ts
@@ -1,8 +1,0 @@
-export {
-  environment,
-  featureFlags,
-  getRuntimeEnv,
-  getMockApiBaseUrl,
-  getApiPrefix,
-  buildMswApiUrl,
-} from "shared/config/environment";

--- a/apps/playground/src/shared/infrastructure/config/index.ts
+++ b/apps/playground/src/shared/infrastructure/config/index.ts
@@ -1,3 +1,1 @@
-export { environment, featureFlags, getRuntimeEnv } from "./environment";
-
 export { appUrls } from "shared/config/appUrls";

--- a/apps/playground/src/shared/infrastructure/i18n/index.ts
+++ b/apps/playground/src/shared/infrastructure/i18n/index.ts
@@ -1,4 +1,3 @@
 import { createAppI18n } from "shared/i18n/createAppI18n";
 
-export const { routing, Link, redirect, usePathname, useRouter, getPathname } =
-  createAppI18n();
+export const { routing } = createAppI18n();

--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.13.0",
+    "@clerk/backend": "^3.16.13",
     "@clerk/testing": "^2.2.31",
     "@faker-js/faker": "^10.4.0",
     "@playwright/test": "^1.59.1",

--- a/apps/store/src/features/cart/presentation/components/CartItemRow.tsx
+++ b/apps/store/src/features/cart/presentation/components/CartItemRow.tsx
@@ -12,7 +12,7 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- next-intl Translator type is complex; accepting any callable
 type TranslatorFn = (...args: any[]) => string;
 
-export interface CartItemTranslators {
+interface CartItemTranslators {
   t: TranslatorFn;
   tProducts: TranslatorFn;
   tTypes: TranslatorFn;

--- a/apps/store/src/features/products/application/hooks/useSellerInfo.ts
+++ b/apps/store/src/features/products/application/hooks/useSellerInfo.ts
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useSupabase } from "shared";
 
-export interface SellerInfo {
+interface SellerInfo {
   displayName: string;
   avatarUrl: string | null;
 }

--- a/apps/store/src/features/products/presentation/components/ProductDetail/Sections/index.ts
+++ b/apps/store/src/features/products/presentation/components/ProductDetail/Sections/index.ts
@@ -1,5 +1,1 @@
 export { SectionRenderer } from "./SectionRenderer";
-export { AccordionSection } from "./AccordionSection";
-export { CardsSection } from "./CardsSection";
-export { GallerySection } from "./GallerySection";
-export { TwoColumnSection } from "./TwoColumnSection";

--- a/apps/store/src/shared/application/cart/cartCookiePersistence.ts
+++ b/apps/store/src/shared/application/cart/cartCookiePersistence.ts
@@ -57,6 +57,4 @@ export function removeCartCookie() {
     deleteCookie(CART_COOKIE_KEY, { path: "/" });
   }
 }
-
-export { getSharedCookieDomain } from "shared";
 export { CART_COOKIE_KEY as COOKIE_KEY } from "shared/constants/cart";

--- a/apps/store/src/shared/application/cart/cartReducer.ts
+++ b/apps/store/src/shared/application/cart/cartReducer.ts
@@ -1,6 +1,6 @@
 import type { CartItem, CartState } from "@/shared/domain/cart";
 
-export type CartAction =
+type CartAction =
   | {
       type: "ADD_ITEM";
       payload: Omit<CartItem, "quantity"> & { quantity?: number };
@@ -31,7 +31,7 @@ function toCartSnapshot(
   };
 }
 
-export function addItemToItems(
+function addItemToItems(
   items: CartItem[],
   payload: Omit<CartItem, "quantity"> & { quantity?: number },
 ): CartItem[] {
@@ -66,7 +66,7 @@ export function addItemToItems(
   ];
 }
 
-export function updateItemQuantity(
+function updateItemQuantity(
   items: CartItem[],
   id: string,
   quantity: number,
@@ -88,7 +88,7 @@ export function updateItemQuantity(
   );
 }
 
-export function deriveState(items: CartItem[]): CartState {
+function deriveState(items: CartItem[]): CartState {
   return {
     items,
     itemCount: items.reduce((sum, item) => sum + item.quantity, 0),

--- a/apps/store/src/shared/application/cart/index.ts
+++ b/apps/store/src/shared/application/cart/index.ts
@@ -1,3 +1,3 @@
-export { CartProvider, useCart } from "./CartContext";
-export { FlyToCartProvider, useFlyToCartContext } from "./FlyToCartContext";
+export { CartProvider } from "./CartContext";
+export { FlyToCartProvider } from "./FlyToCartContext";
 export { useAddToCart } from "./useAddToCart";

--- a/apps/store/src/shared/domain/cart.ts
+++ b/apps/store/src/shared/domain/cart.ts
@@ -32,10 +32,3 @@ export interface SellerGroup {
   items: CartItem[];
   subtotal: number;
 }
-
-/** A seller profile subset used for cart seller display names. */
-export interface SellerProfile {
-  id: string;
-  display_name: string | null;
-  email: string;
-}

--- a/apps/store/src/shared/infrastructure/config/api.ts
+++ b/apps/store/src/shared/infrastructure/config/api.ts
@@ -1,6 +1,0 @@
-export {
-  API_REFRESH_INTERVALS,
-  API_DEFAULTS,
-  orvalOptions,
-  type PartialQueryOptions,
-} from "shared/config/api";

--- a/apps/store/src/shared/infrastructure/config/environment.ts
+++ b/apps/store/src/shared/infrastructure/config/environment.ts
@@ -1,8 +1,1 @@
-export {
-  environment,
-  featureFlags,
-  getRuntimeEnv,
-  getMockApiBaseUrl,
-  getApiPrefix,
-  buildMswApiUrl,
-} from "shared/config/environment";
+export { getRuntimeEnv } from "shared/config/environment";

--- a/apps/store/src/shared/infrastructure/config/index.ts
+++ b/apps/store/src/shared/infrastructure/config/index.ts
@@ -1,17 +1,1 @@
-export {
-  environment,
-  featureFlags,
-  getRuntimeEnv,
-  getMockApiBaseUrl,
-  getApiPrefix,
-  buildMswApiUrl,
-} from "./environment";
-export { tid, TID_ATTR } from "./tid";
-export {
-  API_REFRESH_INTERVALS,
-  API_DEFAULTS,
-  orvalOptions,
-  type PartialQueryOptions,
-} from "./api";
-
 export { appUrls } from "shared/config/appUrls";

--- a/apps/store/src/shared/infrastructure/config/tid.ts
+++ b/apps/store/src/shared/infrastructure/config/tid.ts
@@ -1,1 +1,0 @@
-export { tid, TID_ATTR, type TidOptionProps } from "shared/utils/tid";

--- a/apps/store/src/shared/infrastructure/i18n/index.ts
+++ b/apps/store/src/shared/infrastructure/i18n/index.ts
@@ -1,4 +1,3 @@
 import { createAppI18n } from "shared/i18n/createAppI18n";
 
-export const { routing, Link, redirect, usePathname, useRouter, getPathname } =
-  createAppI18n();
+export const { routing, Link } = createAppI18n();

--- a/apps/store/src/test/fixtures/appUrls.ts
+++ b/apps/store/src/test/fixtures/appUrls.ts
@@ -2,7 +2,7 @@
  * Mock appUrls for unit tests.
  * Use in vi.mock('@/shared/infrastructure/config', () => mockStoreConfig).
  */
-export const mockAppUrls = {
+const mockAppUrls = {
   landing: "http://localhost:5004",
   store: "http://localhost:5001",
   admin: "http://localhost:5002",

--- a/apps/studio/src/features/products/domain/constants.ts
+++ b/apps/studio/src/features/products/domain/constants.ts
@@ -27,7 +27,7 @@ export const PRODUCT_CATEGORIES: ProductCategory[] = [
   "deals",
 ];
 
-export interface BadgeTone {
+interface BadgeTone {
   backgroundColor: string;
   color: string;
 }

--- a/apps/studio/src/features/products/domain/validationSchema.ts
+++ b/apps/studio/src/features/products/domain/validationSchema.ts
@@ -46,25 +46,6 @@ function createSectionSchema(t: ValidationT) {
     });
 }
 
-/** Section item type (matches the Zod schema shape without needing runtime schema) */
-export interface SectionItem {
-  title_en: string;
-  title_es: string;
-  description_en: string;
-  description_es: string;
-  icon: string;
-  image_url: string;
-  sort_order: number;
-}
-
-export type Section = {
-  name_en: string;
-  name_es: string;
-  type: (typeof SECTION_TYPES)[number];
-  sort_order: number;
-  items: SectionItem[];
-};
-
 /** Product image schema */
 export const productImageSchema = z.object({
   url: z.string().url(),
@@ -74,8 +55,6 @@ export const productImageSchema = z.object({
   is_store_cover: z.boolean().optional().default(false),
   fit: z.enum(["cover", "contain"]).optional().default("cover"),
 });
-
-export type ProductImage = z.infer<typeof productImageSchema>;
 
 /**
  * Create the product form schema with translated validation messages.
@@ -127,6 +106,9 @@ export function createProductFormSchema(t: ValidationT) {
 }
 
 /** Static schema for type inference only (no translated messages) */
-export const productFormSchema = createProductFormSchema((key) => key);
-
-export type ProductFormValues = z.infer<typeof productFormSchema>;
+// Derived from the factory's return type rather than from a module-level
+// instance: the schema was only ever built at import time to feed z.infer,
+// so nothing needs to construct one.
+export type ProductFormValues = z.infer<
+  ReturnType<typeof createProductFormSchema>
+>;

--- a/apps/studio/src/features/seller-admins/domain/types.ts
+++ b/apps/studio/src/features/seller-admins/domain/types.ts
@@ -1,8 +1,3 @@
-import type { Tables } from "api/supabase/types";
-
-/** Raw row from the seller_admins table */
-export type SellerAdminRow = Tables<"seller_admins">;
-
 /** Permission keys that can be delegated to admin users */
 export type DelegatePermission =
   | "orders.approve"

--- a/apps/studio/src/shared/application/context/ErrorContext.tsx
+++ b/apps/studio/src/shared/application/context/ErrorContext.tsx
@@ -1,3 +1,3 @@
 "use client";
 
-export { ErrorProvider, useErrorContext } from "shared/providers";
+export { ErrorProvider } from "shared/providers";

--- a/apps/studio/src/shared/infrastructure/config/api.ts
+++ b/apps/studio/src/shared/infrastructure/config/api.ts
@@ -1,6 +1,0 @@
-export {
-  API_REFRESH_INTERVALS,
-  API_DEFAULTS,
-  orvalOptions,
-  type PartialQueryOptions,
-} from "shared/config/api";

--- a/apps/studio/src/shared/infrastructure/config/environment.ts
+++ b/apps/studio/src/shared/infrastructure/config/environment.ts
@@ -1,8 +1,1 @@
-export {
-  environment,
-  featureFlags,
-  getRuntimeEnv,
-  getMockApiBaseUrl,
-  getApiPrefix,
-  buildMswApiUrl,
-} from "shared/config/environment";
+export { getRuntimeEnv } from "shared/config/environment";

--- a/apps/studio/src/shared/infrastructure/config/index.ts
+++ b/apps/studio/src/shared/infrastructure/config/index.ts
@@ -1,17 +1,1 @@
-export {
-  environment,
-  featureFlags,
-  getRuntimeEnv,
-  getMockApiBaseUrl,
-  getApiPrefix,
-  buildMswApiUrl,
-} from "./environment";
-export { tid, TID_ATTR } from "./tid";
-export {
-  API_REFRESH_INTERVALS,
-  API_DEFAULTS,
-  orvalOptions,
-  type PartialQueryOptions,
-} from "./api";
-
 export { appUrls } from "shared/config/appUrls";

--- a/apps/studio/src/shared/infrastructure/config/tid.ts
+++ b/apps/studio/src/shared/infrastructure/config/tid.ts
@@ -1,1 +1,0 @@
-export { tid, TID_ATTR, type TidOptionProps } from "shared/utils/tid";

--- a/apps/studio/src/shared/infrastructure/i18n/index.ts
+++ b/apps/studio/src/shared/infrastructure/i18n/index.ts
@@ -1,4 +1,3 @@
 import { createAppI18n } from "shared/i18n/createAppI18n";
 
-export const { routing, Link, redirect, usePathname, useRouter, getPathname } =
-  createAppI18n();
+export const { routing, Link, useRouter } = createAppI18n();

--- a/apps/studio/src/test/fixtures/appUrls.ts
+++ b/apps/studio/src/test/fixtures/appUrls.ts
@@ -2,7 +2,7 @@
  * Mock appUrls for unit tests.
  * Use in vi.mock('@/shared/infrastructure/config', () => mockStudioConfig).
  */
-export const mockAppUrls = {
+const mockAppUrls = {
   landing: "http://localhost:5004",
   store: "http://localhost:5001",
   admin: "http://localhost:5002",

--- a/apps/studio/tests/useProductTemplates.test.tsx
+++ b/apps/studio/tests/useProductTemplates.test.tsx
@@ -16,6 +16,8 @@ import { useProductTemplates } from "@/features/products/application/hooks/usePr
 
 import { fetchActiveTemplates } from "@/features/products/infrastructure/templateQueries";
 
+import type { ActiveTemplate } from "@/features/products/infrastructure/templateQueries";
+
 function createWrapper() {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -29,17 +31,16 @@ describe("useProductTemplates", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("returns templates on success", async () => {
-    const mock: import("@/features/products/infrastructure/templateQueries").ActiveTemplate[] =
-      [
-        {
-          id: "t1",
-          name_en: "Basic",
-          name_es: "Básico",
-          description_en: null,
-          description_es: null,
-          sections: [],
-        },
-      ];
+    const mock: ActiveTemplate[] = [
+      {
+        id: "t1",
+        name_en: "Basic",
+        name_es: "Básico",
+        description_en: null,
+        description_es: null,
+        sections: [],
+      },
+    ];
     vi.mocked(fetchActiveTemplates).mockResolvedValue(mock);
 
     const { result } = renderHook(() => useProductTemplates(), {

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -188,6 +188,28 @@ inline `import("...").ActiveTemplate[]`, a form knip does not follow. That was
 fixed in the test rather than suppressed in the config; a normal `import type`
 is clearer and is also what knip can see.
 
+A second false positive cost a CI run and is worth recording, because the
+local checks could not have caught it. knip reported `ui` as an unused
+dependency of `apps/playground`, and a grep for `from "ui"` in that app agreed.
+Both were looking only at TypeScript. The app consumes the package from CSS:
+
+```css
+@import "ui/globals";
+```
+
+Removing the dependency still passed `lint`, `typecheck`, `test` and `build`
+locally, because pnpm's workspace links resolve `ui` whether or not the
+manifest asks for it. Docker builds from a clean install, and only there did it
+fail: `Can't resolve 'ui/globals'`. Every one of the seven apps imports `ui`
+this way, so it is never legitimately unused; it now sits in
+`ignoreDependencies` beside `tailwindcss` and `tw-animate-css`, which are in
+that list for exactly the same reason. `knip.json` is JSON and cannot hold the
+explanation, which is why it is here.
+
+The lesson generalises: a dependency check that reads only the import graph of
+one language will be wrong about a polyglot build, and a local build that
+resolves through workspace links cannot confirm a manifest is complete.
+
 Its _file_ report had already been made truthful earlier — it went from 28
 unused files to 0, and only four of the 28 were real:
 

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -143,12 +143,53 @@ untested by CI.
 
 ## knip
 
-`knip` is configured but **not yet enforced in CI**: it still reports 202
-unused exports and 46 unused exported types, which need triage rather than
-configuration.
+`knip` is now **enforced in CI** and reports zero.
 
-Its _file_ report is now truthful — it went from 28 unused files to 0, and
-only four of the 28 were real:
+It was previously left advisory on the reasoning that its ~205 findings were
+unused-export noise, and that the sibling AeleOS repo runs it with
+`--no-exit-code` too. That reasoning was wrong twice over.
+
+First, "205 findings" was one number covering three unrelated things, and only
+one of them was fuzzy. Second, most of the count was an artefact of knip's own
+configuration: every workspace set `project` to `src/**`, so knip never saw
+`e2e/` or `tests/`, and anything consumed only there was reported as unused.
+A gate measuring the wrong file set is the failure this document is about,
+and it had been dismissed as noise rather than read.
+
+With the config corrected — `project` and `entry` extended to `tests/` and
+`e2e/`, dead entry patterns removed, `.mts` config names fixed — knip found
+two defects that had been invisible:
+
+- **`@clerk/backend` was imported by three e2e files and declared in no
+  `package.json` at all.** It resolved only as a transitive dependency of
+  `@clerk/nextjs`, so a minor bump of that package could have removed it with
+  no lockfile signal and no warning.
+- **`packages/api` declared three export subpaths whose targets do not
+  exist** — `./generated/*`, `./types/generated`, `./graphql/generated`. Worse,
+  `.claude/rules/architecture.md` instructed importing from exactly those
+  paths, so the repository's own AI instructions told the reader to write an
+  import that cannot resolve. No code had done it, which is why nothing broke.
+
+The remaining 201 sorted cleanly once classified:
+
+| what it was                                 | count | what it needed        |
+| ------------------------------------------- | ----: | --------------------- |
+| barrel re-exports nothing imports           |   134 | drop from the barrel  |
+| destructured bindings nothing uses          |    29 | drop from the pattern |
+| exports consumed only inside their own file |    27 | drop the `export`     |
+| declarations consumed nowhere               |     8 | delete                |
+
+Nine barrels emptied completely and were deleted. Five test files carried a
+`vi.mock` for one of them — a module the components never imported, so the
+mock had never once been consulted.
+
+One genuine knip false positive surfaced: a test declared a type through an
+inline `import("...").ActiveTemplate[]`, a form knip does not follow. That was
+fixed in the test rather than suppressed in the config; a normal `import type`
+is clearer and is also what knip can see.
+
+Its _file_ report had already been made truthful earlier — it went from 28
+unused files to 0, and only four of the 28 were real:
 
 | Was reported                                                         | Why it was wrong                                                                                   |
 | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |

--- a/knip.json
+++ b/knip.json
@@ -125,8 +125,9 @@
   "ignoreDependencies": [
     "@faker-js/faker",
     "@secretlint/secretlint-rule-preset-recommend",
+    "tailwindcss",
     "tw-animate-css",
-    "tailwindcss"
+    "ui"
   ],
   "ignoreBinaries": ["semgrep"]
 }

--- a/knip.json
+++ b/knip.json
@@ -7,8 +7,9 @@
         "docker/ci/playwright.config.ts",
         ".claude/tools/*.mjs",
         "vitest.config.integration.ts",
-        "vitest.config.scripts.js"
+        "tests/db/**/*.ts"
       ],
+      "project": ["scripts/**/*.mjs", "tests/**/*.ts", "docker/**/*.{mjs,ts}"],
       "ignore": ["tests/legacy/**"]
     },
     "apps/admin": {
@@ -16,101 +17,116 @@
         "src/app/**/*.{ts,tsx}",
         "src/shared/infrastructure/i18n/request.ts",
         "src/features/*/index.ts",
-        "src/features/*/*/index.ts",
-        "src/shared/domain/index.ts"
+        "tests/**/*.{ts,tsx}",
+        "e2e/**/*.ts"
       ],
-      "project": ["src/**/*.{ts,tsx,js,jsx}"],
-      "ignore": ["**/*.test.*", "**/*.spec.*"]
+      "project": [
+        "src/**/*.{ts,tsx,js,jsx}",
+        "tests/**/*.{ts,tsx}",
+        "e2e/**/*.ts"
+      ]
     },
     "apps/auth": {
       "entry": [
         "src/app/**/*.{ts,tsx}",
         "src/shared/infrastructure/i18n/request.ts",
         "src/features/*/index.ts",
-        "src/features/*/*/index.ts",
-        "src/shared/domain/index.ts"
+        "tests/**/*.{ts,tsx}",
+        "e2e/**/*.ts"
       ],
-      "project": ["src/**/*.{ts,tsx,js,jsx}"],
-      "ignore": ["**/*.test.*", "**/*.spec.*"]
+      "project": [
+        "src/**/*.{ts,tsx,js,jsx}",
+        "tests/**/*.{ts,tsx}",
+        "e2e/**/*.ts"
+      ]
     },
     "apps/landing": {
       "entry": [
         "src/app/**/*.{ts,tsx}",
         "src/shared/infrastructure/i18n/request.ts",
         "src/features/*/index.ts",
-        "src/features/*/*/index.ts",
-        "src/shared/domain/index.ts"
+        "tests/**/*.{ts,tsx}",
+        "e2e/**/*.ts"
       ],
-      "project": ["src/**/*.{ts,tsx,js,jsx}"],
-      "ignore": ["**/*.test.*", "**/*.spec.*"]
+      "project": [
+        "src/**/*.{ts,tsx,js,jsx}",
+        "tests/**/*.{ts,tsx}",
+        "e2e/**/*.ts"
+      ]
     },
     "apps/payments": {
       "entry": [
         "src/app/**/*.{ts,tsx}",
         "src/shared/infrastructure/i18n/request.ts",
         "src/features/*/index.ts",
-        "src/features/*/*/index.ts",
-        "src/shared/domain/index.ts"
+        "tests/**/*.{ts,tsx}",
+        "e2e/**/*.ts"
       ],
-      "project": ["src/**/*.{ts,tsx,js,jsx}"],
-      "ignore": ["**/*.test.*", "**/*.spec.*", "src/mocks/**", "src/test/**"]
+      "project": [
+        "src/**/*.{ts,tsx,js,jsx}",
+        "tests/**/*.{ts,tsx}",
+        "e2e/**/*.ts"
+      ]
     },
     "apps/playground": {
       "entry": [
         "src/app/**/*.{ts,tsx}",
         "src/shared/infrastructure/i18n/request.ts",
-        "src/features/*/index.ts",
-        "src/features/*/*/index.ts",
-        "src/shared/domain/index.ts"
+        "src/features/*/index.ts"
       ],
-      "project": ["src/**/*.{ts,tsx,js,jsx}"],
-      "ignore": ["**/*.test.*", "**/*.spec.*"]
+      "project": ["src/**/*.{ts,tsx,js,jsx}"]
     },
     "apps/store": {
       "entry": [
         "src/app/**/*.{ts,tsx}",
         "src/shared/infrastructure/i18n/request.ts",
         "src/features/*/index.ts",
-        "src/features/*/*/index.ts",
-        "src/shared/domain/index.ts"
+        "src/features/*/domain/index.ts",
+        "src/shared/domain/index.ts",
+        "tests/**/*.{ts,tsx}",
+        "e2e/**/*.ts"
       ],
-      "project": ["src/**/*.{ts,tsx,js,jsx}"],
-      "ignore": ["**/*.test.*", "**/*.spec.*", "src/mocks/**", "src/test/**"]
+      "project": [
+        "src/**/*.{ts,tsx,js,jsx}",
+        "tests/**/*.{ts,tsx}",
+        "e2e/**/*.ts"
+      ]
     },
     "apps/studio": {
       "entry": [
         "src/app/**/*.{ts,tsx}",
         "src/shared/infrastructure/i18n/request.ts",
         "src/features/*/index.ts",
-        "src/features/*/*/index.ts",
-        "src/shared/domain/index.ts"
+        "tests/**/*.{ts,tsx}"
       ],
-      "project": ["src/**/*.{ts,tsx,js,jsx}"],
-      "ignore": ["**/*.test.*", "**/*.spec.*", "src/mocks/**", "src/test/**"]
+      "project": ["src/**/*.{ts,tsx,js,jsx}", "tests/**/*.{ts,tsx}"]
     },
     "packages/api": {
-      "project": ["src/**/*.{ts,tsx}"],
-      "ignore": ["src/generated/**", "src/types/generated/**"]
+      "entry": ["tests/**/*.{ts,tsx}"],
+      "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"]
     },
     "packages/app-components": {
-      "project": ["src/**/*.{ts,tsx}"]
+      "entry": ["tests/**/*.{ts,tsx}"],
+      "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"]
     },
     "packages/auth": {
-      "project": ["src/**/*.{ts,tsx}"]
+      "entry": ["tests/**/*.{ts,tsx}"],
+      "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"]
     },
     "packages/shared": {
-      "project": ["src/**/*.{ts,tsx}"]
+      "entry": ["tests/**/*.{ts,tsx}"],
+      "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"]
     },
     "packages/ui": {
-      "project": ["src/**/*.{ts,tsx}"]
+      "entry": ["tests/**/*.{ts,tsx}"],
+      "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"]
     }
   },
-  "ignoreFiles": ["docker/e2e/**", "orval.config.ts"],
   "ignoreDependencies": [
     "@faker-js/faker",
-    "orval",
     "@secretlint/secretlint-rule-preset-recommend",
     "tw-animate-css",
     "tailwindcss"
-  ]
+  ],
+  "ignoreBinaries": ["semgrep"]
 }

--- a/package.json
+++ b/package.json
@@ -79,8 +79,6 @@
     "eslint-plugin-better-tailwindcss": "^4.4.1",
     "eslint-plugin-boundaries": "^6.0.2",
     "eslint-plugin-i18next": "^6.1.4",
-    "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-playwright": "^2.11.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-security": "^4.0.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,9 +6,6 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./generated/*": "./src/rest/generated/*",
-    "./types/generated": "./src/rest/types/generated/index.ts",
-    "./graphql/generated": "./src/graphql/generated/index.ts",
     "./supabase": "./src/supabase/index.ts",
     "./supabase/browser": "./src/supabase/browser.ts",
     "./supabase/server": "./src/supabase/server.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -22,7 +22,6 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@axe-core/playwright": "^4.13.0",
     "@clerk/nextjs": "^7.8.3",
     "@supabase/supabase-js": "^2.105.0",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,12 +61,6 @@ importers:
       eslint-plugin-i18next:
         specifier: ^6.1.4
         version: 6.1.4
-      eslint-plugin-import:
-        specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-jsx-a11y:
-        specifier: ^6.10.2
-        version: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-playwright:
         specifier: ^2.11.0
         version: 2.11.0(eslint@9.39.4(jiti@2.6.1))
@@ -318,6 +312,12 @@ importers:
       '@axe-core/playwright':
         specifier: ^4.13.0
         version: 4.13.0(playwright-core@1.59.1)
+      '@clerk/backend':
+        specifier: ^3.16.13
+        version: 3.16.13(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@clerk/testing':
+        specifier: ^2.2.31
+        version: 2.2.31(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
@@ -602,9 +602,6 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
-      ui:
-        specifier: workspace:*
-        version: link:../../packages/ui
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -703,6 +700,9 @@ importers:
       '@axe-core/playwright':
         specifier: ^4.13.0
         version: 4.13.0(playwright-core@1.59.1)
+      '@clerk/backend':
+        specifier: ^3.16.13
+        version: 3.16.13(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@clerk/testing':
         specifier: ^2.2.31
         version: 2.2.31(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -983,9 +983,6 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
-      '@axe-core/playwright':
-        specifier: ^4.13.0
-        version: 4.13.0(playwright-core@1.59.1)
       '@clerk/nextjs':
         specifier: ^7.8.3
         version: 7.8.3(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -13310,7 +13307,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -13322,16 +13319,6 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
       - supports-color
 
@@ -13394,35 +13381,6 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
-      hasown: 2.0.3
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      ui:
+        specifier: workspace:*
+        version: link:../../packages/ui
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0


### PR DESCRIPTION
knip was left advisory on the reasoning that its ~205 findings were unused-export noise, and that AeleOS runs it with `--no-exit-code` too. **That reasoning was wrong twice over.**

"205 findings" was one number covering three unrelated things, and only one was fuzzy. And most of the count was an artefact of knip's own configuration: every workspace set `project` to `src/**`, so knip **never saw `e2e/` or `tests/`**, and anything consumed only there was reported as unused. A gate measuring the wrong file set is the exact failure this repo has spent several PRs fixing — this one had been dismissed as noise rather than read.

## Two defects that had been invisible

**`@clerk/backend` was declared in no `package.json` at all**, while three e2e files import it. It resolved only as a transitive dependency of `@clerk/nextjs` — a minor bump there could have removed it with no lockfile signal and no warning.

**`packages/api` declared three export subpaths whose targets don't exist** — `./generated/*`, `./types/generated`, `./graphql/generated`. Worse, `.claude/rules/architecture.md` instructed importing from exactly those paths, with examples from a dashboard API this project doesn't have:

```ts
// what the rules told every reader (and every session) to write:
import type { GlobalMetrics } from "api/types/generated";        // cannot resolve
import { useGetAnomaliesTenantAnomaliesGet } from "api/generated/anomalies/anomalies";
```

No code had followed the instruction, which is why nothing broke. Both the declarations and the instructions are corrected, and every documented subpath was then verified to resolve to a real file.

## The remaining 201, classified rather than counted

| what it was | count | what it needed |
| --- | ---: | --- |
| barrel re-exports nothing imports | 134 | drop from the barrel |
| destructured bindings nothing uses | 29 | drop from the pattern |
| exports used only in their own file | 27 | drop the `export` keyword |
| declarations used nowhere | 8 | delete |

Nine barrels emptied completely and were deleted. Five test files carried a `vi.mock` for one of them — a module the components never imported, so **the mock had never once been consulted**. The real `tid` returns the same shape outside production, so removing them changes no behaviour.

## Two findings rejected, not applied

`eslint-plugin-import` and `eslint-plugin-jsx-a11y` looked unused but reach the flat config through `eslint-config-next`, as the config's own comment says. Removing the root declarations was verified safe **by probe**: a file with a misordered import and an `alt`-less `<img>` still reports `import/order` and `jsx-a11y/alt-text`. A lint that passes because a plugin silently vanished would be worse than one that fails.

One genuine knip false positive: a test declared a type through an inline `import("...").ActiveTemplate[]`, which knip doesn't follow. Fixed **in the test** with a normal `import type` rather than suppressed in the config — it's clearer code and it's also what knip can see.

## Verification

- `pnpm knip` — **0 findings, exit 0**; proved it fails by adding one dead export (exit 1), then reverting
- `lint` · `typecheck` (12/12) · `format:check` · `test` (12/12) · `test:workflows` · `build` (7/7)
- All five custom gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt