### PR TITLE
chore(ci): run the test-inventory diff, the fourth gate with no caller [GH-000]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,21 @@ jobs:
       - name: Check documentation moved with the code
         run: node scripts/check-doc-freshness.mjs "origin/${{ github.base_ref || 'develop' }}"
 
+      # The fourth gate in this series found running in no workflow and no hook.
+      # It answers the one question a test-count cannot: did a rework drop a
+      # case? Neither file counts nor totals catch that -- both can hold while
+      # an assertion disappears. It compares the committed inventory at the
+      # merge base against one regenerated from the working tree, and fails on
+      # any case name present before and absent now. Needs fetch-depth: 0,
+      # above, for the merge base to exist.
+      #
+      # If it fails, the fix is to restore the case. Regenerating
+      # tests/INVENTORY.md makes the failure disappear without answering it,
+      # which is how a real loss gets buried -- only regenerate after checking
+      # each reported name against the live tree, and say what you checked.
+      - name: Check no test case was dropped
+        run: bash scripts/test-inventory-diff.sh "origin/${{ github.base_ref || 'develop' }}"
+
       - name: Lint (scoped)
         run: |
           set -euo pipefail

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -354,6 +354,25 @@ unreferenced was a developer command — `tunnel`, `fix:all`, `supabase:reset`,
 `user:grant-role` — which is what an unreferenced script is supposed to look
 like. All three gates now run in the CI hygiene block.
 
+A fourth turned up later, from a different direction: **`test-inventory-diff`**.
+It answers the one question a test count cannot -- did a rework drop a case?
+Neither a file count nor a total catches that, because both can hold while an
+assertion disappears. It ran nowhere, and when finally run it reported 14 lost
+cases.
+
+None were lost. All fourteen were checked individually against the live test
+tree and every one was present. The committed inventory predated the scanner's
+`LEGACY_SNAPSHOT` exclusion, so it counted `tests/legacy` as well as the live
+tree and listed those names twice; the diff compares sorted lists with `comm`,
+which is duplicate-sensitive, so a name appearing twice before and once now
+produced a line of output. The report was surplus, not loss.
+
+That episode is the reason the CI step carries a warning in its comment.
+Regenerating `tests/INVENTORY.md` makes any failure disappear without
+answering it, which is precisely how a real loss would be buried. The rule is
+to check each reported name against the live tree first, and to say what was
+checked -- the baseline moves only after that, never instead of it.
+
 `check-css-sync` had a second, worse problem. Its header says it "ensures
 globals.css files are synchronized across **all apps**". It held a hardcoded
 list of five — store, studio, landing, payments, admin — and this repository


### PR DESCRIPTION
`scripts/test-inventory-diff.sh` answers the one question a test count cannot: **did a rework drop a case?** A file count and a total both hold while an assertion quietly disappears. It ran in no workflow and no hook — the fourth such gate in this series.

## Why it needed a preceding PR

Run against the stale baseline it reported **14 lost cases**. None were lost. All fourteen were verified present in the live test tree; the committed inventory predated the scanner's `LEGACY_SNAPSHOT` exclusion and so counted `tests/legacy` as well as the live tree, listing those names twice. `comm` is duplicate-sensitive, so a name appearing twice before and once now yields a line of output. Surplus, not loss. #396 corrected the baseline.

## The warning in the CI step

Regenerating `tests/INVENTORY.md` makes **any** failure of this gate disappear without answering it — which is precisely how a genuine lost test would be buried. So the step doesn't just carry a command, it carries the rule:

> If it fails, the fix is to restore the case. Only regenerate after checking each reported name against the live tree, and say what you checked.

That is the procedure this PR's predecessor followed, and the reason it's written down rather than assumed.

## Verification

Proved it fails, not just passes: deleting `it("calls onToggle when clicked")` from `packages/ui/tests/ThemeToggle.test.tsx` produced

```
LOST (1):
  calls onToggle when clicked
```

with exit 1. Restored, and `OK: no cases lost.` against `origin/develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt