### PR TITLE
docs: record the five orphaned auth secrets as deleted [GH-000]

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -377,34 +377,32 @@ pnpm lint:env
 | `ENV_DEBUG`                   | Enables env debug viewer at `/en/env`    |
 | `NEXT_PUBLIC_ENV_DEBUG`       | Serialized env snapshot (set by loadEnv) |
 
-## Five GitHub secrets nothing reads
+## Five GitHub secrets that were deleted
 
 `SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID`, `SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET`,
 `SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID`, `SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET`
-and `DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI` exist as repository secrets, dated
-14 and 19 April 2026. Nothing references them: not a workflow, not a script, not
-an env file, and they are not in the local `.secrets` either, so
-`pnpm sync-secrets` does not pull them.
+and `DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI` existed as repository secrets,
+dated 14 and 19 April 2026. They configured Supabase Auth's own Google and
+Discord providers, which Clerk replaced.
 
-They configured Supabase Auth's own Google and Discord providers, which Clerk
-replaced. Verify with:
+Nothing read them: no workflow, no script, no env file. They were not in the
+local `.secrets` either, so `pnpm sync-secrets` never pulled them, and they were
+not in the `env:` block of `sync-secrets.yml`, so nothing broke by their going
+away. The only occurrence of the string left in the repository is a comment in
+`scripts/load-root-env.cjs` recounting a past bug about empty
+`SUPABASE_AUTH_EXTERNAL_*` values — prose, not a reference.
+
+They were deleted on the owner's instruction after that was re-verified. The
+repository went from 61 repository secrets to 56.
+
+**Deleting them removed them from CI. It did not revoke anything.** If the
+matching OAuth applications are still live in the Google Cloud and Discord
+developer consoles, those client secrets remain valid there and should be
+rotated or the applications deleted, which is a change to make in those
+consoles rather than here.
+
+To confirm the state at any time:
 
 ```bash
-gh secret list --repo vaoan/libra | grep SUPABASE_AUTH_EXTERNAL
-grep -rl SUPABASE_AUTH_EXTERNAL --include='*.yml' --include='*.mjs' --include='*.ts' .
-```
-
-**Deliberately not deleted.** Removing them is a one-line command and safe as far
-as this repository is concerned, but the values cannot be recovered afterwards,
-and whether the matching OAuth applications are still live in the Google and
-Discord consoles is not visible from here. If they are, these are real
-credentials and deleting them here removes them from CI without revoking
-anything -- which is worth doing, but is a decision about credentials rather
-than about code.
-
-```bash
-# When that call has been made:
-for s in SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET          SUPABASE_AUTH_EXTERNAL_DISCORD_CLIENT_ID SUPABASE_AUTH_EXTERNAL_DISCORD_SECRET          DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI; do
-  gh secret delete "$s" --repo vaoan/libra
-done
+gh secret list --repo vaoan/Libra | grep SUPABASE_AUTH_EXTERNAL   # expect no output
 ```

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -755,12 +755,18 @@ fail the job on its own.
 
 **The feature barrel rule** — measured and settled; see the section above.
 
-**Five orphaned GitHub secrets** — still open, deliberately. They are unused and
-documented in `docs/environment.md` with the command to remove them. Deleting
-them is safe as far as this repository is concerned, but the values cannot be
-recovered and whether the matching OAuth applications are still live in the
-Google and Discord consoles is not visible from here. That is a decision about
-credentials rather than about code.
+**Five orphaned GitHub secrets** — deleted, on the owner's instruction. They
+were the `SUPABASE_AUTH_EXTERNAL_*` pair for Google and Discord plus a dev
+redirect URI, left behind when Clerk replaced Supabase Auth's own providers.
+Nothing read them, which was re-checked before deletion rather than taken from
+the earlier note: no workflow, no script, no env file, absent from `.secrets`
+and from `sync-secrets.yml`'s `env:` block. The repository went from 61 secrets
+to 56.
+
+Deleting them removed them from CI; it revoked nothing. If the matching OAuth
+applications are still live in the Google and Discord consoles, those client
+secrets remain valid there. See
+[Environment System](../environment.md#five-github-secrets-that-were-deleted).
 
 ---
 


### PR DESCRIPTION
The `SUPABASE_AUTH_EXTERNAL_*` pair for Google and Discord, plus `DEV_SUPABASE_AUTH_EXTERNAL_REDIRECT_URI`, are **deleted** from the repository's secrets on the owner's instruction. The repo went from **61 secrets to 56**.

They were left behind when Clerk replaced Supabase Auth's own providers.

## Re-verified before deleting, not taken on trust

The earlier note said "nothing references them: not a workflow, not a script." Re-checking found that **slightly wrong** — `scripts/load-root-env.cjs` does contain the string. It's a comment recounting a past bug about empty `SUPABASE_AUTH_EXTERNAL_*` values slipping through CI. Prose, not a reference.

Everything else held:

| checked | result |
| --- | --- |
| workflows, scripts, env files | no live reference |
| `.secrets` | absent — `pnpm sync-secrets` never pulled them |
| `sync-secrets.yml` `env:` block | absent — nothing breaks by their going away |
| existence on GitHub | all five present, dated 14 and 19 April 2026 as documented |

That last one mattered: had they been in the sync workflow's `env:` list, deleting them would have broken the secret sync.

## What deletion did and did not do

**Removed them from CI. Revoked nothing.** If the Google and Discord OAuth applications are still live in their consoles, those client secrets remain valid there and want rotating — a change to make in those consoles, not here. Both docs keep that caveat rather than declaring the matter closed.

## Docs

`docs/environment.md` and `docs/standards/quality-gates.md` both described this as an open decision. Both now describe what was done, with the verification command to confirm the state at any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt