### PR TITLE
chore(ci): fail when an instruction file cites something that is not there [GH-000]

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Rules
 
-> This document covers **application-level** Clean Architecture within each app (`apps/web`, `apps/admin`).
+> This document covers **application-level** Clean Architecture within each app (`apps/store`, `apps/admin`).
 > For **repository-level** architecture (packages, apps, dependencies), see [Monorepo Architecture](./monorepo-architecture.md).
 
 ---
@@ -248,7 +248,7 @@ pnpm codegen
 
 ### API Response Handling
 
-The custom Orval mutator (`packages/api/src/mutator/customFetch.ts`) handles API responses:
+The custom Orval mutator (`packages/api/src/rest/mutator/customFetch.ts`) handles API responses:
 
 1. **Response Envelope** - Extracts `data` from `{ success: true, data: T }` wrapper
 2. **No Case Transformation** - Returns data as-is to match generated TypeScript types

--- a/.claude/rules/css-consistency.md
+++ b/.claude/rules/css-consistency.md
@@ -108,7 +108,7 @@ The code review agent checks:
 To check if `globals.css` files are in sync:
 
 ```bash
-diff apps/web/src/app/globals.css apps/admin/src/app/globals.css
+diff apps/store/src/app/globals.css apps/admin/src/app/globals.css
 ```
 
 The only expected differences should be:
@@ -123,7 +123,7 @@ The only expected differences should be:
 ### DON'T: Add CSS to only one app
 
 ```css
-/* BAD: Only in apps/web/globals.css */
+/* BAD: Only in apps/store/globals.css */
 .my-new-class {
   @apply text-primary font-bold;
 }

--- a/.claude/rules/mcp-standards.md
+++ b/.claude/rules/mcp-standards.md
@@ -18,7 +18,7 @@ All MCP servers live in:
 
 - `.claude/tools/github-unified-mcp.mjs`
 - `.claude/tools/git-mcp.mjs`
-- `.claude/tools/skillsmp-mcp.mjs`
+- `.claude/tools/linear-mcp.mjs`
 
 ---
 

--- a/.claude/rules/monorepo-architecture.md
+++ b/.claude/rules/monorepo-architecture.md
@@ -78,7 +78,7 @@ At the repository level, dependencies flow in ONE direction:
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                         APPLICATIONS                             │
-│                    (apps/web, apps/admin)                        │
+│                    (apps/store, apps/admin)                        │
 │         Full Clean Architecture, i18n, feature modules           │
 ├─────────────────────────────────────────────────────────────────┤
 │                      SHARED PACKAGES                             │
@@ -301,7 +301,7 @@ function SheetContent({ closeLabel = "Close", ...props }: SheetContentProps) {
 **In consuming app:**
 
 ```typescript
-// apps/web/src/features/some-feature/presentation/components/MySheet.tsx
+// apps/store/src/features/some-feature/presentation/components/MySheet.tsx
 "use client";
 import { useTranslations } from "next-intl";
 import { Sheet, SheetContent } from "ui";
@@ -322,7 +322,7 @@ export function MySheet() {
 ### Each App Owns Its Translations
 
 ```
-apps/web/src/shared/infrastructure/i18n/
+apps/store/src/shared/infrastructure/i18n/
 ├── messages/
 │   ├── en.json    # Web app English translations
 │   └── es.json    # Web app Spanish translations
@@ -341,7 +341,8 @@ apps/admin/src/shared/infrastructure/i18n/
 
 ## Standard App: Web
 
-The `apps/web` application is the **reference standard**. All other apps MUST comply with its:
+The `apps/store` application is the **reference standard**, matching
+[CLAUDE.md](../../CLAUDE.md#key-principles). All other apps MUST comply with its:
 
 - ESLint configuration (enforced at monorepo root)
 - Clean Architecture patterns
@@ -389,7 +390,7 @@ The `apps/playground` is a **permanent incubation sandbox** for experimenting wi
 | **Never delete components**      | Components remain available for future reference and reuse                 |
 | **Relaxed quality expectations** | Playground may use hardcoded strings, simpler patterns for quick iteration |
 | **Same architecture structure**  | Follows Clean Architecture (features, layers) for consistency              |
-| **Independent from production**  | Playground features do NOT import from web/admin and vice versa            |
+| **Independent from production**  | Playground features do NOT import from store/admin and vice versa          |
 
 ### Workflow: Playground to Production
 
@@ -447,7 +448,7 @@ packages:
 Apps reference packages using `workspace:*`:
 
 ```json
-// apps/web/package.json
+// apps/store/package.json
 {
   "dependencies": {
     "api": "workspace:*",
@@ -462,7 +463,7 @@ Apps reference packages using `workspace:*`:
 Each app has its own path aliases:
 
 ```json
-// apps/web/tsconfig.json
+// apps/store/tsconfig.json
 {
   "compilerOptions": {
     "paths": {
@@ -483,7 +484,7 @@ Each app has its own path aliases:
 Apps must transpile workspace packages:
 
 ```typescript
-// apps/web/next.config.ts
+// apps/store/next.config.ts
 const nextConfig = {
   transpilePackages: ["api", "ui", "shared"],
 };
@@ -526,7 +527,7 @@ Packages are consumed as source code, not pre-built bundles:
 When adding a new application:
 
 1. **Create app folder**: `apps/[app-name]/`
-2. **Copy structure from web**: Use `apps/web` as template
+2. **Copy structure from store**: Use `apps/store` as template
 3. **Set up i18n**: Create own `shared/infrastructure/i18n/` with locale files
 4. **Configure TypeScript**: Extend `tsconfig.base.json`, add path aliases
 5. **Add transpilePackages**: Include `api`, `ui`, and `shared`
@@ -570,14 +571,14 @@ pnpm lint && pnpm typecheck
 
 ## Commands
 
-| Command          | Description                 |
-| ---------------- | --------------------------- |
-| `pnpm dev`       | Start web app development   |
-| `pnpm dev:admin` | Start admin app development |
-| `pnpm build`     | Build all workspaces        |
-| `pnpm lint`      | Lint all apps and packages  |
-| `pnpm typecheck` | Type-check all workspaces   |
-| `pnpm test`      | Run web app tests           |
+| Command            | Description                    |
+| ------------------ | ------------------------------ |
+| `pnpm dev`         | Start all apps with `.env.dev` |
+| `pnpm dev --env X` | Start all apps with `.env.X`   |
+| `pnpm build`       | Build all workspaces           |
+| `pnpm lint`        | Lint all apps and packages     |
+| `pnpm typecheck`   | Type-check all workspaces      |
+| `pnpm test`        | Run web app tests              |
 
 ---
 

--- a/.claude/skills/analyze-bundle/SKILL.md
+++ b/.claude/skills/analyze-bundle/SKILL.md
@@ -353,7 +353,7 @@ bundle-analysis:
   if: docs-only == 'false' && github.event_name == 'pull_request'
   steps:
     - name: Analyze web bundle
-      run: cd apps/web && ANALYZE=true pnpm run build || true
+      run: cd apps/store && ANALYZE=true pnpm run build || true
 ```
 
 ---

--- a/.claude/skills/fix-full-review/SKILL.md
+++ b/.claude/skills/fix-full-review/SKILL.md
@@ -146,7 +146,7 @@ After all issues processed:
 Fixes complete!
 
 Recommended next steps:
-1. Run `pnpm type-check` to verify no type errors
+1. Run `pnpm typecheck` to verify no type errors
 2. Run `pnpm test` to ensure tests pass
 3. Run `/full-review` to verify issues are resolved
 ```

--- a/.claude/skills/generate-setup-guide/SKILL.md
+++ b/.claude/skills/generate-setup-guide/SKILL.md
@@ -252,7 +252,6 @@ cp .env.example .env.local
 # Start development server
 pnpm dev
 ```
-````
 
 Open [http://localhost:3000](http://localhost:3000)
 
@@ -334,26 +333,25 @@ Key skills:
 ## License
 
 [License type]
-
 ````
 
 ### AI Context Template (.ai-context/setup-guide.md)
 
-```markdown
+````markdown
 # Project Setup Guide (AI Context)
 
 > This document provides comprehensive context for AI assistants working on this project.
 
 ## Quick Context
 
-| Aspect | Details |
-|--------|---------|
-| Framework | Next.js X.X with App Router |
-| Language | TypeScript (strict mode) |
-| State | Zustand (client) + React Query (server) |
-| Styling | [MUI/Tailwind/etc.] |
-| Testing | Vitest + Playwright |
-| Package Manager | pnpm |
+| Aspect          | Details                                 |
+| --------------- | --------------------------------------- |
+| Framework       | Next.js X.X with App Router             |
+| Language        | TypeScript (strict mode)                |
+| State           | Zustand (client) + React Query (server) |
+| Styling         | [MUI/Tailwind/etc.]                     |
+| Testing         | Vitest + Playwright                     |
+| Package Manager | pnpm                                    |
 
 ## Architecture Summary
 
@@ -361,19 +359,19 @@ Key skills:
 
 ## Key Files to Know
 
-| File | Purpose |
-|------|---------|
-| `CLAUDE.md` | Main AI instructions |
-| `src/app/layout.tsx` | Root layout with providers |
-| `src/app/providers.tsx` | Client-side providers |
-| `src/features/` | All feature modules |
+| File                    | Purpose                    |
+| ----------------------- | -------------------------- |
+| `CLAUDE.md`             | Main AI instructions       |
+| `src/app/layout.tsx`    | Root layout with providers |
+| `src/app/providers.tsx` | Client-side providers      |
+| `src/features/`         | All feature modules        |
 
 ## Feature Inventory
 
-| Feature | Path | Description |
-|---------|------|-------------|
-| auth | `src/features/auth/` | Authentication & authorization |
-| [etc.] | | |
+| Feature | Path                 | Description                    |
+| ------- | -------------------- | ------------------------------ |
+| auth    | `src/features/auth/` | Authentication & authorization |
+| [etc.]  |                      |                                |
 
 ## Common Tasks
 
@@ -381,6 +379,7 @@ Key skills:
 
 ```bash
 /create-feature [name]
+```
 ````
 
 Creates: domain/, application/, infrastructure/, presentation/ structure.

--- a/.claude/skills/verify-code/SKILL.md
+++ b/.claude/skills/verify-code/SKILL.md
@@ -257,17 +257,17 @@ None.
 
 When checking coverage, verify each workspace individually:
 
-| Workspace         | Command                       | Threshold |
-| ----------------- | ----------------------------- | --------- |
-| `apps/admin`      | `pnpm test:coverage:admin`    | 85%       |
-| `apps/auth`       | `pnpm test:coverage:auth`     | 85%       |
-| `apps/store`      | `pnpm test:coverage:store`    | 85%       |
-| `apps/studio`     | `pnpm test:coverage:studio`   | 85%       |
-| `apps/payments`   | `pnpm test:coverage:payments` | 85%       |
-| `apps/landing`    | N/A (passWithNoTests)         | —         |
-| `apps/playground` | N/A (passWithNoTests)         | —         |
-| `packages/shared` | Part of `pnpm test:coverage`  | 85%       |
-| `packages/ui`     | Part of `pnpm test:coverage`  | 85%       |
+| Workspace         | Command                                | Threshold |
+| ----------------- | -------------------------------------- | --------- |
+| `apps/admin`      | `pnpm --filter admin test:coverage`    | 85%       |
+| `apps/auth`       | `pnpm --filter auth-app test:coverage` | 85%       |
+| `apps/store`      | `pnpm --filter store test:coverage`    | 85%       |
+| `apps/studio`     | `pnpm --filter studio test:coverage`   | 85%       |
+| `apps/payments`   | `pnpm --filter payments test:coverage` | 85%       |
+| `apps/landing`    | N/A (passWithNoTests)                  | —         |
+| `apps/playground` | N/A (passWithNoTests)                  | —         |
+| `packages/shared` | Part of `pnpm test:coverage`           | 85%       |
+| `packages/ui`     | Part of `pnpm test:coverage`           | 85%       |
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,7 @@ jobs:
           node scripts/check-source-bytes.mjs
           node scripts/check-feature-boundaries.mjs
           node scripts/check-a11y-patterns.mjs
+          node scripts/check-doc-references.mjs
           node scripts/check-css-sync.mjs
           node scripts/check-env-parity.mjs
           pnpm exec madge --circular --extensions ts,tsx,js,jsx apps/store/src apps/studio/src apps/landing/src apps/payments/src apps/admin/src apps/auth/src apps/playground/src packages/ui/src packages/shared/src packages/api/src packages/app-components/src packages/auth/src tests scripts docker

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -770,6 +770,51 @@ secrets remain valid there. See
 
 ---
 
+## Instructions that point at things that are not there
+
+`.claude/**` and `CLAUDE.md` are loaded into every session. A wrong instruction
+there is not a stale comment — it is a confident, wrong direction given to
+whoever reads next, and it costs time before anyone works out that the document
+was the thing that was wrong.
+
+The knip work turned up the worst case: `.claude/rules/architecture.md` told the
+reader to `import type { GlobalMetrics } from "api/types/generated"`, a subpath
+`packages/api` declared but whose target directory had never been created. The
+example was from a dashboard API this project does not have. No code had
+followed the instruction, which is the only reason nothing broke.
+
+Auditing the rest found that it was not alone:
+
+| what was cited                            | reality                                                                      |
+| ----------------------------------------- | ---------------------------------------------------------------------------- |
+| `apps/web`, 12 times across 4 files       | there is no `apps/web`; the reference app is `apps/store`, as CLAUDE.md says |
+| `packages/api/src/mutator/customFetch.ts` | it is at `src/rest/mutator/customFetch.ts`                                   |
+| `pnpm type-check`                         | the script is `typecheck`                                                    |
+| `pnpm dev:admin`                          | no such script                                                               |
+| `pnpm test:coverage:<app>` × 5            | no such scripts; per-app coverage is `pnpm --filter <app> test:coverage`     |
+| `.claude/tools/skillsmp-mcp.mjs`          | no such tool                                                                 |
+
+The `apps/web` set is the one worth pausing on. `monorepo-architecture.md`
+opened with "the `apps/web` application is the **reference standard**", while
+CLAUDE.md names `apps/store`. Two instruction files disagreeing about which app
+is the standard is worse than either being merely out of date.
+
+`scripts/check-doc-references.mjs` now fails on any cited path or `pnpm` script
+that does not exist. It reads **prose only** — fenced code blocks are skipped,
+because a skill that generates setup guides shows an example `package.json`
+with scripts this repository does not have, and an audit skill shows an example
+report row naming a file that never existed. Both are illustrations, not
+claims. Paths matched by `.gitignore` are skipped too, since
+`.claude/portability-exceptions.json` is documented as deliberately untracked.
+
+Writing that exemption exposed a real formatting bug: a README template in
+`generate-setup-guide` had a stray closing fence, so eighty lines of template
+content — including a command table citing a `pnpm test:e2e` this repo does not
+have — escaped the code block and rendered as live instruction. The fence is
+fixed rather than the checker taught to ignore it.
+
+---
+
 ## One AeleOS gate that does not port: `check-agent-notes`
 
 AeleOS fails a build when a directory's agent note went unread while code under

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "check:source-bytes": "node scripts/check-source-bytes.mjs",
     "check:a11y-patterns": "node scripts/check-a11y-patterns.mjs",
     "check:boundaries": "node scripts/check-feature-boundaries.mjs",
+    "check:doc-refs": "node scripts/check-doc-references.mjs",
     "check:docs": "node scripts/check-doc-freshness.mjs"
   },
   "devDependencies": {

--- a/scripts/check-doc-references.mjs
+++ b/scripts/check-doc-references.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Fails when an instruction file cites a path or a pnpm script that does not
+ * exist.
+ *
+ * `.claude/**` and `CLAUDE.md` are loaded into every session, so a wrong
+ * instruction there is not a stale comment -- it is a confident, wrong
+ * direction given to whoever reads next, and it costs time before anyone
+ * notices it was the document that was wrong. This repository had several:
+ * twelve references to an `apps/web` that does not exist (the reference app
+ * is `apps/store`, as CLAUDE.md says), a mutator path that had moved, and
+ * `pnpm type-check` for a script named `typecheck`.
+ *
+ * Only prose is checked. Fenced code blocks are skipped, because a skill that
+ * generates setup guides shows an example `package.json` with scripts this
+ * repository does not have, and an audit skill shows an example report row
+ * naming a file that never existed. Both are illustrations, not claims.
+ *
+ * Paths matched by .gitignore are skipped too: `.claude/portability-exceptions.json`
+ * is documented as deliberately untracked.
+ *
+ * Usage:
+ *   node scripts/check-doc-references.mjs
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+/** Paths git is told to ignore, which are absent by design rather than by error. */
+function ignoredPaths(candidates) {
+  if (candidates.length === 0) return new Set();
+  try {
+    const out = execFileSync("git", ["check-ignore", ...candidates], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return new Set(
+      out
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+  } catch {
+    // check-ignore exits 1 when nothing matches, which is not an error here.
+    return new Set();
+  }
+}
+
+/** The file's text with fenced code blocks removed. */
+function proseOnly(src) {
+  const out = [];
+  let fenced = false;
+  for (const line of src.split("\n")) {
+    if (line.trimStart().startsWith("```")) {
+      fenced = !fenced;
+      continue;
+    }
+    out.push(fenced ? "" : line);
+  }
+  return out.join("\n");
+}
+
+// A branch name in the documented convention, e.g. `docs/GH-92_API-Documentation`.
+const BRANCH_NAME = /^(feat|fix|chore|docs|refactor|release)\/GH-\d+_/;
+
+const PATH_RE =
+  /`((?:\.claude|docs|scripts|apps|packages|supabase|\.github)\/[A-Za-z0-9._/-]+)`/g;
+const SCRIPT_RE = /`pnpm (?:run )?([a-z][a-z0-9:-]*)`/g;
+// pnpm's own subcommands, which are not package scripts.
+const PNPM_BUILTINS = new Set([
+  "install",
+  "add",
+  "remove",
+  "update",
+  "audit",
+  "dlx",
+  "exec",
+  "why",
+  "up",
+  "outdated",
+  "list",
+  "link",
+  "publish",
+  "pack",
+  "store",
+  "prune",
+]);
+
+const files = execFileSync("git", ["ls-files"], { encoding: "utf8" })
+  .split("\n")
+  .map((s) => s.trim())
+  .filter((f) => f.endsWith(".md"))
+  .filter((f) => f === "CLAUDE.md" || f.startsWith(".claude/"));
+
+if (files.length === 0) {
+  throw new Error(
+    "no instruction files matched -- refusing to report a clean result",
+  );
+}
+
+const scripts = new Set(
+  Object.keys(JSON.parse(readFileSync("package.json", "utf8")).scripts),
+);
+
+const citedPaths = [];
+const badScripts = [];
+for (const file of files) {
+  const prose = proseOnly(readFileSync(file, "utf8"));
+  for (const m of prose.matchAll(PATH_RE)) {
+    const p = m[1];
+    if (p.includes("*") || BRANCH_NAME.test(p)) continue;
+    if (!existsSync(p)) citedPaths.push([file, p]);
+  }
+  for (const m of prose.matchAll(SCRIPT_RE)) {
+    const s = m[1];
+    if (PNPM_BUILTINS.has(s) || scripts.has(s)) continue;
+    badScripts.push([file, s]);
+  }
+}
+
+const ignored = ignoredPaths([...new Set(citedPaths.map(([, p]) => p))]);
+const badPaths = citedPaths.filter(([, p]) => !ignored.has(p));
+
+for (const [file, p] of badPaths) {
+  console.error(`${file}: cites \`${p}\`, which does not exist.`);
+}
+for (const [file, s] of badScripts) {
+  console.error(
+    `${file}: cites \`pnpm ${s}\`, which is not a script in package.json.`,
+  );
+}
+
+const total = badPaths.length + badScripts.length;
+if (total > 0) {
+  console.error(
+    `\n${total} instruction(s) pointing at something that is not there.`,
+  );
+  process.exit(1);
+}
+console.log(
+  `Instruction files cite only things that exist (${files.length} file(s) checked).`,
+);


### PR DESCRIPTION
`.claude/**` and `CLAUDE.md` load into every session. A wrong instruction there isn't a stale comment — it's a **confident, wrong direction** handed to whoever reads next, and it costs time before anyone works out the document was the thing that was wrong.

The knip work surfaced the worst case: `architecture.md` told the reader to write

```ts
import type { GlobalMetrics } from "api/types/generated";
```

against a subpath `packages/api` declared but whose target directory was never created — with examples from a dashboard API this project doesn't have. Auditing the rest found it wasn't alone.

## What was cited vs. what exists

| cited | reality |
| --- | --- |
| `apps/web` — **12 times across 4 files** | there is no `apps/web`; the reference app is `apps/store` |
| `packages/api/src/mutator/customFetch.ts` | it's at `src/rest/mutator/customFetch.ts` |
| `pnpm type-check` | the script is `typecheck` |
| `pnpm dev:admin` | no such script |
| `pnpm test:coverage:<app>` × 5 | it's `pnpm --filter <app> test:coverage` |
| `.claude/tools/skillsmp-mcp.mjs` | no such tool |

The `apps/web` set is the one worth pausing on. `monorepo-architecture.md` opened with *"the `apps/web` application is the **reference standard**"* while `CLAUDE.md` names `apps/store`. **Two instruction files disagreeing about which app is the standard** is worse than either simply being out of date.

## The checker reads prose only

Fenced code blocks are skipped, because a skill that generates setup guides shows an example `package.json` with scripts this repo doesn't have, and an audit skill shows an example report row naming a file that never existed. Illustrations, not claims. Gitignored paths are skipped too — `.claude/portability-exceptions.json` is documented as deliberately untracked.

Both exemptions were written *after* reading the cases individually. The first pass over-reported **9 of 22**, and each was checked before being dismissed rather than the rule being loosened until the noise stopped.

## The exemption found a real bug

Writing the fence rule exposed one: the README template in `generate-setup-guide` had a **stray closing fence**, so ~80 lines of template — including a command table citing a `pnpm test:e2e` this repo doesn't have — escaped the code block and rendered as live instruction. The fence is fixed, rather than the checker taught to ignore it.

## Verification

- **Proved it fails**: citing a nonexistent path and a nonexistent script in `CLAUDE.md` reported both, exit 1. Reverted.
- `check:doc-refs` (108 files) · `knip` · `lint` · `typecheck` · `format:check` · `test:workflows` · `check-doc-freshness` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt