### PR TITLE
chore(tests): pin coverage thresholds to measured coverage [GH-000]

### DIFF
--- a/.claude/skills/verify-code/SKILL.md
+++ b/.claude/skills/verify-code/SKILL.md
@@ -138,14 +138,30 @@ pnpm test
 pnpm test:coverage
 ```
 
-This runs all app/package test suites with coverage enabled. Each workspace has 85% thresholds for statements, branches, functions, and lines.
+This runs all app/package test suites with coverage enabled. **85% is the
+target**, and most workspaces meet it on all four metrics. Two do not, and
+their thresholds are pinned just under measured coverage rather than at the
+target, so the gap can only close:
+
+| workspace         | statements | branches | functions | lines |
+| ----------------- | ---------: | -------: | --------: | ----: |
+| `packages/api`    |         81 |       78 |        71 |    86 |
+| `packages/shared` |         87 |       78 |        92 |    90 |
+
+`apps/playground` has no thresholds at all — it is a sandbox and runs with
+`passWithNoTests`.
+
+Pinning to measured coverage rather than to the target cuts both ways: it is
+below 85 where coverage is, and **above** 85 where coverage is better, so the
+slack cannot be spent without the gate noticing.
 
 **If failures:**
 
-1. Check which workspace failed and which metric is below 85%
+1. Check which workspace failed and which metric is below its threshold
 2. Write meaningful tests to cover the gap — see [Testing Rules](../../rules/testing.md)
 3. If a file is legitimately untestable (type-only, re-export shim, complex RHF internal), add it to the workspace's `vitest.config.ts` coverage exclusions with a comment explaining WHY
-4. Do NOT lower thresholds below 85%
+4. Do NOT lower a threshold to make a failure go away. They are ratchets: raise
+   them when coverage improves, and treat a drop as a missing test
 
 ### Step 7: Production Build
 

--- a/packages/api/vitest.config.mts
+++ b/packages/api/vitest.config.mts
@@ -24,11 +24,15 @@ export default defineConfig({
       // This package had no thresholds and no `test:coverage` script, so its
       // coverage was never measured or enforced. Floors pinned to the first real
       // measurement so regressions fail; raise them as coverage improves.
+      // Below the repo's 85 target, and pinned just under measured coverage
+      // so the numbers can only go up. Measured 78.57 / 71.42 / 86.04 / 81.25;
+      // the previous values sat as much as eleven points under that, which
+      // left room to lose coverage without the gate noticing.
       thresholds: {
-        branches: 75,
-        functions: 60,
-        lines: 80,
-        statements: 75,
+        branches: 78,
+        functions: 71,
+        lines: 86,
+        statements: 81,
       },
       cleanOnRerun: false,
     },

--- a/packages/shared/vitest.config.mts
+++ b/packages/shared/vitest.config.mts
@@ -26,8 +26,14 @@ export default defineConfig({
       // skipped it silently. On first real measurement branches was 78.47%.
       // The floor is pinned just under that so a regression fails, and should be
       // ratcheted back up to 85 as branch coverage improves.
+      // branches is below the repo's 85 target; the rest are pinned just under
+      // measured coverage (87.12 / 78.47 / 92.53 / 90.43) rather than left at
+      // the target, so the slack above 85 cannot be spent silently.
       thresholds: {
-        branches: 78, functions: 85, lines: 85, statements: 85,
+        branches: 78,
+        functions: 92,
+        lines: 90,
+        statements: 87,
       },
     },
     testTimeout: 10_000,


### PR DESCRIPTION
`verify-code/SKILL.md` said *"each workspace has 85% thresholds for statements, branches, functions, and lines"* and *"do NOT lower thresholds below 85%"*.

Two workspaces were already below it. `packages/api` sat at **60** for functions; `packages/shared` at **78** for branches. The instruction described a repository that doesn't exist — the kind of claim nobody checks because it reads like a policy.

## Correcting the doc was the smaller half

The thresholds were also loose in the *other* direction — set well under what the code actually achieves, so coverage could fall a long way before any gate objected:

| workspace | | statements | branches | functions | lines |
| --- | --- | ---: | ---: | ---: | ---: |
| `packages/api` | measured | 81.25 | 78.57 | **71.42** | 86.04 |
| | threshold was | 75 | 75 | **60** | 80 |
| `packages/shared` | measured | 87.12 | 78.47 | 92.53 | 90.43 |
| | threshold was | 85 | 78 | 85 | 85 |

`api`'s functions threshold had **eleven points of slack**.

Every threshold is now pinned just under measured coverage. That cuts both ways: below 85 where coverage is, and **above 85 where coverage is better** — so the slack can't be spent silently.

## Proved they're enforced, not decorative

Raising `shared`'s functions threshold to 96 (above its measured 92.53) produced:

```
ERROR: Coverage for functions (92.53%) does not meet global threshold (96%)
```

exit 1. Reverted.

## The doc now says what's true

Real numbers per workspace; `apps/playground` noted as having no thresholds because it's a sandbox running `passWithNoTests`; and *"do not lower below 85%"* replaced with what these actually are — **ratchets**, raised when coverage improves, with a drop treated as a missing test rather than a number to adjust.

## Verification

`pnpm test:coverage` across all 12 workspaces, plus `check:doc-refs` and `format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt