### PR TITLE
fix(payments): report range filters used a column that does not exist [GH-000]

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -248,6 +248,26 @@ chore(deps): update React to v19 [GH-88]
 3. Link to GitHub issue with `Closes #XXX` or `Fixes #XXX`
 4. Include summary of changes
 
+#### The title length the CI check actually enforces
+
+The **subject** — everything after `type(scope): `, including the `[GH-XXX]`
+suffix — must be **80 characters or fewer**. The `PR Title` job enforces it with
+`subjectPattern: ^.{1,80}$` and fails with "PR title must be less than 80
+characters".
+
+The scope and type are not counted, so the whole title can exceed 80 while
+still passing, and a title well under 100 can still fail. Count from the space
+after the colon:
+
+```
+fix(payments): report range filters used a column that does not exist [GH-000]
+               ^------------------------ 63 characters -------------------^
+```
+
+The job runs on `edited`, so correcting the title clears the failure without
+pushing a commit — see [The PR Title check could not see a corrected
+title](../../docs/standards/quality-gates.md).
+
 ### PR Template
 
 ```markdown

--- a/apps/payments/src/app/api/seller/reports/orders/route.ts
+++ b/apps/payments/src/app/api/seller/reports/orders/route.ts
@@ -56,46 +56,67 @@ type BuildQueryResult =
   | { ok: true; query: Record<string, string | readonly string[]> }
   | { ok: false; error: string };
 
+/**
+ * Adds a filter, keeping any filter already set on the same column.
+ *
+ * PostgREST expresses a range by repeating the column -- `created_at=gte.X`
+ * AND `created_at=lte.Y` -- and `createRestPath` appends an array as repeated
+ * keys for exactly that. A plain object cannot hold the key twice, which this
+ * route previously worked around with a `created_at_lte` key: a column
+ * `orders` does not have, so the second bound was never applied.
+ */
+function addFilter(
+  query: Record<string, string | readonly string[]>,
+  column: string,
+  clause: string,
+): void {
+  const existing = query[column];
+  if (existing === undefined) {
+    query[column] = clause;
+    return;
+  }
+  query[column] = [
+    ...(Array.isArray(existing) ? existing : [existing]),
+    clause,
+  ];
+}
+
 function applyDateFilters(
-  query: Record<string, string>,
+  query: Record<string, string | readonly string[]>,
   params: URLSearchParams,
 ): string | null {
   const dateFrom = params.get("dateFrom");
   if (dateFrom) {
     if (!isValidIsoDate(dateFrom)) return "Invalid dateFrom";
-    query["created_at"] = `gte.${dateFrom}`;
+    addFilter(query, "created_at", `gte.${dateFrom}`);
   }
   const dateTo = params.get("dateTo");
   if (dateTo) {
     if (!isValidIsoDate(dateTo)) return "Invalid dateTo";
-    if (query["created_at"]) {
-      query["created_at_lte"] = `lte.${dateTo}T23:59:59`;
-    } else {
-      query["created_at"] = `lte.${dateTo}T23:59:59`;
-    }
+    addFilter(query, "created_at", `lte.${dateTo}T23:59:59`);
   }
   return null;
 }
 
 function applyAmountFilters(
-  query: Record<string, string>,
+  query: Record<string, string | readonly string[]>,
   params: URLSearchParams,
 ): string | null {
   const amountMin = params.get("amountMin");
   if (amountMin) {
     if (!isValidAmount(amountMin)) return "Invalid amountMin";
-    query["total"] = `gte.${amountMin}`;
+    addFilter(query, "total", `gte.${amountMin}`);
   }
   const amountMax = params.get("amountMax");
   if (amountMax) {
     if (!isValidAmount(amountMax)) return "Invalid amountMax";
-    query[query["total"] ? "total_lte" : "total"] = `lte.${amountMax}`;
+    addFilter(query, "total", `lte.${amountMax}`);
   }
   return null;
 }
 
 function applyScalarFilters(
-  query: Record<string, string>,
+  query: Record<string, string | readonly string[]>,
   params: URLSearchParams,
 ): string | null {
   const status = params.get("status");
@@ -121,7 +142,7 @@ function buildQuery(
   sellerId: string,
   params: URLSearchParams,
 ): BuildQueryResult {
-  const query: Record<string, string> = {
+  const query: Record<string, string | readonly string[]> = {
     seller_id: `eq.${sellerId}`,
     select:
       "id,created_at,payment_status,total,currency,transfer_number,receipt_url,user_id,order_items(id,product_id,quantity,unit_price,currency,products(name_en))",

--- a/apps/payments/tests/seller-reports-orders-route.test.ts
+++ b/apps/payments/tests/seller-reports-orders-route.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("api/supabase/server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+
+const SELLER_ID = "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12";
+
+async function loadRoute(signedIn = true) {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.test";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+  vi.resetModules();
+
+  const routeModule = await import("@/app/api/seller/reports/orders/route");
+  const supabaseModule = await import("api/supabase/server");
+
+  vi.mocked(supabaseModule.createServerSupabaseClient).mockResolvedValue({
+    rpc: vi
+      .fn()
+      .mockResolvedValue({ data: signedIn ? SELLER_ID : null, error: null }),
+  } as unknown as Awaited<
+    ReturnType<typeof supabaseModule.createServerSupabaseClient>
+  >);
+
+  return routeModule.GET;
+}
+
+const makeRequest = (qs: string) =>
+  new Request(`http://localhost/api/seller/reports/orders?${qs}`);
+
+/** The orders query URL that the route handed to fetch. */
+function ordersUrl() {
+  const call = vi.mocked(fetch).mock.calls[0];
+  return String(call?.[0]);
+}
+
+describe("GET /api/seller/reports/orders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => [] } as Response),
+    );
+  });
+
+  it("scopes the query to the signed-in seller", async () => {
+    const GET = await loadRoute();
+    await GET(makeRequest(""));
+    expect(ordersUrl()).toContain(`seller_id=eq.${SELLER_ID}`);
+  });
+
+  it("rejects requests with no signed-in session", async () => {
+    const GET = await loadRoute(false);
+    const response = await GET(makeRequest(""));
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects an invalid date", async () => {
+    const GET = await loadRoute();
+    const response = await GET(makeRequest("dateFrom=not-a-date"));
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects an unknown status", async () => {
+    const GET = await loadRoute();
+    const response = await GET(makeRequest("status=whatever"));
+    expect(response.status).toBe(400);
+  });
+
+  it("applies a lone date bound", async () => {
+    const GET = await loadRoute();
+    await GET(makeRequest("dateFrom=2026-01-01"));
+    expect(ordersUrl()).toContain("created_at=gte.2026-01-01");
+  });
+
+  // PostgREST expresses a range by repeating the column. A JS object cannot
+  // hold the same key twice, and the route worked around that with a
+  // `created_at_lte` key -- a column `orders` does not have, so the filter
+  // either errors or drops the upper bound. createRestPath already accepts an
+  // array and appends repeated keys, which is the idiom that works.
+  it("sends both date bounds as repeated created_at filters", async () => {
+    const GET = await loadRoute();
+    await GET(makeRequest("dateFrom=2026-01-01&dateTo=2026-01-31"));
+
+    const url = ordersUrl();
+    expect(url).not.toContain("created_at_lte");
+    expect(url).toContain("created_at=gte.2026-01-01");
+    expect(url).toContain("created_at=lte.2026-01-31T23%3A59%3A59");
+  });
+
+  it("sends both amount bounds as repeated total filters", async () => {
+    const GET = await loadRoute();
+    await GET(makeRequest("amountMin=10&amountMax=100"));
+
+    const url = ordersUrl();
+    expect(url).not.toContain("total_lte");
+    expect(url).toContain("total=gte.10");
+    expect(url).toContain("total=lte.100");
+  });
+});

--- a/tests/INVENTORY.md
+++ b/tests/INVENTORY.md
@@ -6,7 +6,7 @@ Every test case in the repo, so a refactor can be checked for losses:
 regenerate and diff. Counting files or totals is not enough -- a rework
 can keep both and still drop the one assertion that mattered.
 
-**2680 cases across 371 files** (0 skipped, 9 parameterised).
+**2687 cases across 372 files** (0 skipped, 9 parameterised).
 
 Source-level cases: a `.each` case is one entry here and many in vitest
 output, so this total is deliberately not the runner total.
@@ -902,7 +902,7 @@ output, so this total is deliberately not the runner total.
 - TermsPage > renders a last-updated line
 - TermsPage > renders all 10 section headings
 
-## app:payments -- 557 cases
+## app:payments -- 564 cases
 
 ### `apps/payments/tests/ActionButtons.test.tsx`
 
@@ -1430,6 +1430,16 @@ output, so this total is deliberately not the runner total.
 - ResubmitEvidenceForm > removes the file when the remove button is clicked
 - ResubmitEvidenceForm > clicking the upload button triggers the file input click handler
 - ResubmitEvidenceForm > submits with the file when both transfer number and receipt are provided
+
+### `apps/payments/tests/seller-reports-orders-route.test.ts`
+
+- GET /api/seller/reports/orders > scopes the query to the signed-in seller
+- GET /api/seller/reports/orders > rejects requests with no signed-in session
+- GET /api/seller/reports/orders > rejects an invalid date
+- GET /api/seller/reports/orders > rejects an unknown status
+- GET /api/seller/reports/orders > applies a lone date bound
+- GET /api/seller/reports/orders > sends both date bounds as repeated created_at filters
+- GET /api/seller/reports/orders > sends both amount bounds as repeated total filters
 
 ### `apps/payments/tests/SellerCheckoutCard.test.tsx`
 


### PR DESCRIPTION
PostgREST expresses a range by **repeating the column**:

```
created_at=gte.2026-01-01&created_at=lte.2026-01-31T23:59:59
```

A JS object can't hold the same key twice. This route worked around that by writing the second bound to `created_at_lte` — and `total_lte` for amounts. **Neither is a column on `orders`.**

So picking *both* ends of a range sent a filter on a column that doesn't exist: the request either errors or drops the bound. Either way, the range never applied.

## The shape that works was already there

`createRestPath` appends an array as repeated keys, and `BuildQueryResult` already declares `Record<string, string | readonly string[]>` — the correct shape was anticipated and then not used. The three filter helpers were still typed `Record<string, string>`, which is exactly what forced the invented key names. They now share an `addFilter()` that appends to a column already filtered.

## Why it survived

A **single** bound always worked. The bug needs both ends of a range — and this route had no tests at all. 232 lines serving the seller reports page.

## Tests

Seven cases, written test-first; the two range assertions failed before the fix:

- both date bounds emitted as repeated `created_at`, with no `created_at_lte`
- both amount bounds emitted as repeated `total`, with no `total_lte`
- a lone bound still applied
- query scoped to the signed-in seller
- 401 unauthenticated, 400 on an invalid date, 400 on an unknown status

## Authorization checked too, and it's sound

Found while auditing this route for access control. `buildQuery` takes the seller id **from the session**, not from a query parameter, so a seller can't read another's orders. Every filter is validated against a regex, an allowlist, or a type check before reaching the query — no PostgREST injection.

## Verification

`lint` · `typecheck` · `format:check` · `knip` · `check:doc-refs` · `test` (568 in payments) · `test:workflows` · `test-inventory-diff` · `check-doc-freshness`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt