### PR TITLE
fix: API authorization ignored deny rows the database honours [GH-000]

### DIFF
--- a/apps/admin/src/app/api/admin/_shared/adminRest.ts
+++ b/apps/admin/src/app/api/admin/_shared/adminRest.ts
@@ -93,6 +93,57 @@ type GrantedPermissionRow = {
   resource_permissions: { permissions: { key: string } };
 };
 
+/** A row as stored, including which side of grant/deny it is on. */
+export type PermissionModeRow = GrantedPermissionRow & {
+  mode: "grant" | "deny";
+};
+
+/**
+ * The permission keys a user effectively holds, by the same rule the database
+ * uses.
+ *
+ * `public.has_permission()` is the authority -- every RLS policy calls it --
+ * and it reads:
+ *
+ *   exists(grant, unexpired)  AND  NOT exists(deny, unexpired)
+ *
+ * A deny revokes the key outright. The API layer used to ask only for
+ * `mode=eq.grant`, which reimplements that rule with its second half missing,
+ * so a denied user would be refused by RLS and admitted by these routes.
+ *
+ * `user_permissions` is unique on (user_id, resource_permission_id), so one
+ * scope cannot hold both. But `resource_permissions` is unique on
+ * (permission_id, resource_type, resource_id) -- the table exists to scope one
+ * permission across many resources -- so one KEY can be granted on one scope
+ * and denied on another. That is the case the missing clause got wrong.
+ *
+ * @param rows - the user's permission rows, both modes, as stored.
+ * @returns the keys that survive, deduplicated.
+ */
+export function getEffectivePermissionKeys(
+  rows: readonly PermissionModeRow[],
+): string[] {
+  const now = Date.now();
+  const active = rows.filter(
+    (row) => !row.expires_at || Date.parse(row.expires_at) > now,
+  );
+
+  const denied = new Set(
+    active
+      .filter((row) => row.mode === "deny")
+      .map((row) => row.resource_permissions.permissions.key),
+  );
+
+  return [
+    ...new Set(
+      active
+        .filter((row) => row.mode !== "deny")
+        .map((row) => row.resource_permissions.permissions.key)
+        .filter((key) => !denied.has(key)),
+    ),
+  ];
+}
+
 function getActiveGrantedPermissions(rows: GrantedPermissionRow[]) {
   const now = Date.now();
 
@@ -127,6 +178,29 @@ export async function fetchGrantedPermissionKeys(
   return (await fetchGrantedPermissions(userId)).map((row) => row.key);
 }
 
+/**
+ * Every permission row for a user, both modes, so denies can be honoured.
+ *
+ * Deliberately separate from {@link fetchGrantedPermissions}, which returns
+ * grant rows for the editor to revoke and must keep doing exactly that.
+ *
+ * @param userId - the user to read.
+ * @returns the keys the user effectively holds.
+ */
+async function fetchEffectivePermissionKeys(userId: string): Promise<string[]> {
+  const response = await adminFetch(
+    createRestPath("user_permissions", {
+      user_id: `eq.${validateUuid(userId)}`,
+      select:
+        "expires_at,mode,resource_permission_id,resource_permissions!inner(permissions!inner(key))",
+    }),
+  );
+
+  return getEffectivePermissionKeys(
+    (await response.json()) as PermissionModeRow[],
+  );
+}
+
 export async function getAuthorizedAdmin(
   requiredKeys: string[],
 ): Promise<string | null> {
@@ -135,7 +209,7 @@ export async function getAuthorizedAdmin(
 
   if (!userId) return null;
 
-  const grantedKeys = await fetchGrantedPermissionKeys(userId);
+  const grantedKeys = await fetchEffectivePermissionKeys(userId);
   const authorized = requiredKeys.every((key) => grantedKeys.includes(key));
 
   return authorized ? userId : null;

--- a/apps/admin/tests/effectivePermissions.test.ts
+++ b/apps/admin/tests/effectivePermissions.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getEffectivePermissionKeys,
+  type PermissionModeRow,
+} from "@/app/api/admin/_shared/adminRest";
+
+const row = (
+  key: string,
+  mode: "grant" | "deny",
+  expires_at: string | null = null,
+  resourcePermissionId = `${key}:${mode}`,
+): PermissionModeRow => ({
+  expires_at,
+  mode,
+  resource_permission_id: resourcePermissionId,
+  resource_permissions: { permissions: { key } },
+});
+
+const HOUR = 60 * 60 * 1000;
+const future = () => new Date(Date.now() + HOUR).toISOString();
+const past = () => new Date(Date.now() - HOUR).toISOString();
+
+describe("getEffectivePermissionKeys", () => {
+  it("returns granted keys", () => {
+    expect(
+      getEffectivePermissionKeys([row("orders.approve", "grant")]),
+    ).toEqual(["orders.approve"]);
+  });
+
+  it("drops an expired grant", () => {
+    expect(
+      getEffectivePermissionKeys([row("orders.approve", "grant", past())]),
+    ).toEqual([]);
+  });
+
+  it("keeps a grant that has not expired yet", () => {
+    expect(
+      getEffectivePermissionKeys([row("orders.approve", "grant", future())]),
+    ).toEqual(["orders.approve"]);
+  });
+
+  // The rule public.has_permission() enforces, which every RLS policy calls:
+  //   exists(grant, unexpired) AND NOT exists(deny, unexpired)
+  // resource_permissions is unique on (permission_id, resource_type,
+  // resource_id), so one key can be granted on one scope and denied on
+  // another. The API layer used to ask only for mode=eq.grant and would have
+  // admitted this user while RLS refused them.
+  it("a deny on one scope revokes a key granted on another", () => {
+    const rows = [
+      row("orders.approve", "grant", null, "rp-global"),
+      row("orders.approve", "deny", null, "rp-seller-42"),
+    ];
+    expect(getEffectivePermissionKeys(rows)).toEqual([]);
+  });
+
+  it("an expired deny does not revoke anything", () => {
+    const rows = [
+      row("orders.approve", "grant", null, "rp-global"),
+      row("orders.approve", "deny", past(), "rp-seller-42"),
+    ];
+    expect(getEffectivePermissionKeys(rows)).toEqual(["orders.approve"]);
+  });
+
+  it("a deny on one key leaves other keys alone", () => {
+    const rows = [
+      row("orders.approve", "grant"),
+      row("orders.request_proof", "grant"),
+      row("orders.approve", "deny", null, "rp-other"),
+    ];
+    expect(getEffectivePermissionKeys(rows)).toEqual(["orders.request_proof"]);
+  });
+
+  it("deduplicates a key granted on several scopes", () => {
+    const rows = [
+      row("orders.approve", "grant", null, "rp-a"),
+      row("orders.approve", "grant", null, "rp-b"),
+    ];
+    expect(getEffectivePermissionKeys(rows)).toEqual(["orders.approve"]);
+  });
+
+  it("returns nothing for a user with no rows", () => {
+    expect(getEffectivePermissionKeys([])).toEqual([]);
+  });
+});

--- a/apps/payments/src/app/api/checkout/payment-methods/route.ts
+++ b/apps/payments/src/app/api/checkout/payment-methods/route.ts
@@ -36,6 +36,7 @@ type ProductStockRow = {
 
 type PermissionRow = {
   expires_at: string | null;
+  mode: "grant" | "deny";
   resource_permissions: {
     permissions: {
       key: string;
@@ -100,13 +101,36 @@ function mapPaymentMethod(row: PaymentMethodRow): SellerPaymentMethodWithType {
   };
 }
 
+/**
+ * Whether the caller holds every required key, by the same rule the database
+ * uses.
+ *
+ * `public.has_permission()` is `exists(grant, unexpired) AND NOT exists(deny,
+ * unexpired)`, so a deny revokes the key. Asking only for `mode=eq.grant`
+ * reimplements that rule with its second half missing, which would let a
+ * denied buyer past a check RLS refuses.
+ */
 function hasRequiredPermissions(rows: PermissionRow[]) {
   const now = Date.now();
-  const grantedKeys = new Set(
-    rows
-      .filter((row) => !row.expires_at || Date.parse(row.expires_at) > now)
-      .map((row) => row.resource_permissions?.permissions?.key)
+  const active = rows.filter(
+    (row) => !row.expires_at || Date.parse(row.expires_at) > now,
+  );
+  const keyOf = (row: PermissionRow) =>
+    row.resource_permissions?.permissions?.key;
+
+  const denied = new Set(
+    active
+      .filter((row) => row.mode === "deny")
+      .map((row) => keyOf(row))
       .filter((key): key is string => typeof key === "string"),
+  );
+
+  const grantedKeys = new Set(
+    active
+      .filter((row) => row.mode !== "deny")
+      .map((row) => keyOf(row))
+      .filter((key): key is string => typeof key === "string")
+      .filter((key) => !denied.has(key)),
   );
 
   return REQUIRED_PERMISSION_KEYS.every((key) => grantedKeys.has(key));
@@ -116,8 +140,8 @@ async function fetchGrantedPermissions(userId: string) {
   return adminFetchJson<PermissionRow[]>(
     createRestPath("user_permissions", {
       user_id: `eq.${validateUuid(userId)}`,
-      mode: "eq.grant",
-      select: "expires_at,resource_permissions!inner(permissions!inner(key))",
+      select:
+        "expires_at,mode,resource_permissions!inner(permissions!inner(key))",
     }),
   );
 }

--- a/apps/payments/tests/checkout-payment-methods-route.test.ts
+++ b/apps/payments/tests/checkout-payment-methods-route.test.ts
@@ -188,6 +188,47 @@ describe("POST /api/checkout/payment-methods", () => {
     expect(fetch).toHaveBeenCalledTimes(2);
   });
 
+  // public.has_permission() is exists(grant) AND NOT exists(deny), and every
+  // RLS policy uses it. This route asked only for mode=eq.grant, so a buyer
+  // denied the permission would have been admitted here while the database
+  // refused them. resource_permissions is scoped per resource, so one key can
+  // be granted on one scope and denied on another.
+  it("refuses a buyer whose permission is denied on another scope", async () => {
+    const { POST } = await loadRouteModule();
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        {
+          expires_at: null,
+          mode: "grant",
+          resource_permissions: { permissions: { key: "orders.create" } },
+        },
+        {
+          expires_at: null,
+          mode: "grant",
+          resource_permissions: { permissions: { key: "receipts.create" } },
+        },
+        {
+          expires_at: null,
+          mode: "deny",
+          resource_permissions: { permissions: { key: "orders.create" } },
+        },
+      ],
+    } as Response);
+
+    const response = await POST(
+      makeRequest({
+        sellerId: SELLER_ID,
+        items: [{ id: PRODUCT_ID, quantity: 1 }],
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    // Refused before any product or payment-method lookup.
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects users without checkout permissions", async () => {
     const { POST } = await loadRouteModule();
 

--- a/tests/INVENTORY.md
+++ b/tests/INVENTORY.md
@@ -6,12 +6,12 @@ Every test case in the repo, so a refactor can be checked for losses:
 regenerate and diff. Counting files or totals is not enough -- a rework
 can keep both and still drop the one assertion that mattered.
 
-**2687 cases across 372 files** (0 skipped, 9 parameterised).
+**2696 cases across 373 files** (0 skipped, 9 parameterised).
 
 Source-level cases: a `.each` case is one entry here and many in vitest
 output, so this total is deliberately not the runner total.
 
-## app:admin -- 517 cases
+## app:admin -- 525 cases
 
 ### `apps/admin/tests/ActivityRow.test.tsx`
 
@@ -163,6 +163,17 @@ output, so this total is deliberately not the runner total.
 - DashboardPage > renders activity rows from audit data
 - DashboardPage > renders quick actions section with audit log link
 - DashboardPage > renders system status rows
+
+### `apps/admin/tests/effectivePermissions.test.ts`
+
+- getEffectivePermissionKeys > returns granted keys
+- getEffectivePermissionKeys > drops an expired grant
+- getEffectivePermissionKeys > keeps a grant that has not expired yet
+- getEffectivePermissionKeys > a deny on one scope revokes a key granted on another
+- getEffectivePermissionKeys > an expired deny does not revoke anything
+- getEffectivePermissionKeys > a deny on one key leaves other keys alone
+- getEffectivePermissionKeys > deduplicates a key granted on several scopes
+- getEffectivePermissionKeys > returns nothing for a user with no rows
 
 ### `apps/admin/tests/exportCsv.test.ts`
 
@@ -902,7 +913,7 @@ output, so this total is deliberately not the runner total.
 - TermsPage > renders a last-updated line
 - TermsPage > renders all 10 section headings
 
-## app:payments -- 564 cases
+## app:payments -- 565 cases
 
 ### `apps/payments/tests/ActionButtons.test.tsx`
 
@@ -980,6 +991,7 @@ output, so this total is deliberately not the runner total.
 
 - POST /api/checkout/payment-methods > returns payment methods when the cart quantities are valid
 - POST /api/checkout/payment-methods > returns no payment methods when the cart exceeds stock
+- POST /api/checkout/payment-methods > refuses a buyer whose permission is denied on another scope
 - POST /api/checkout/payment-methods > rejects users without checkout permissions
 - POST /api/checkout/payment-methods > rejects requests with no signed-in Clerk session
 - POST /api/checkout/payment-methods > rejects invalid payloads


### PR DESCRIPTION
`public.has_permission()` is the authority — **every RLS policy calls it** — and it reads:

```sql
exists(grant, unexpired)  AND  NOT exists(deny, unexpired)
```

A deny **revokes** the key. Two API paths reimplemented that rule with its second half missing, asking PostgREST for `mode=eq.grant` and never seeing denies:

- `getAuthorizedAdmin` in `apps/admin/.../_shared/adminRest.ts` — gates **all four** admin routes, including the one that grants and revokes permissions
- `hasRequiredPermissions` in the payments checkout route

A denied user would be **refused by RLS and admitted by these routes**.

## Not currently exploitable — and this PR doesn't claim otherwise

No code writes a deny row (`grantPermissions` hardcodes `mode: "grant"`), and the seeded data maps each permission to one `resource_permission`.

What makes it worth fixing is that **neither of those is a property of the design**. The table comment says `resource_permissions` *"scopes a permission to a resource type and optional specific instance"*, and it's unique on `(permission_id, resource_type, resource_id)` — one key across many scopes is the intended shape. `user_permissions` being unique on `(user_id, resource_permission_id)` prevents a grant and deny on the *same scope*, not on two.

So the moment a per-resource deny is written, RLS refuses and the API admits — silently, in the layer that grants permissions.

It's also the same defect as #401: **one rule with two implementations, where the weaker one guards the more dangerous operation.**

## Scope kept deliberately narrow

`fetchGrantedPermissions` is **unchanged**. It returns grant *rows* for the permissions editor to revoke and must keep returning exactly those — the new `fetchEffectivePermissionKeys` is a separate read used only for the authorization decision.

## Tests

Nine. `getEffectivePermissionKeys` is exported and covered directly: expiry on both modes, a deny on one scope revoking a key granted on another, an expired deny revoking nothing, dedup across scopes.

**Verified load-bearing** — deleting the deny clause fails exactly the two cases that encode it, and nothing else. The checkout route gains a case proving it refuses a denied buyer *before* any product or payment-method lookup.

## Verification

`lint` · `typecheck` · `format:check` · `knip` · `check:doc-refs` · `test` (569 payments, 531 admin) · `test:workflows` · `test-inventory-diff` · `check-doc-freshness`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt