### PR TITLE
fix(admin): a bad permission key was reported as a server error [GH-000]

### DIFF
--- a/apps/admin/src/app/api/admin/users/[userId]/permissions/route.ts
+++ b/apps/admin/src/app/api/admin/users/[userId]/permissions/route.ts
@@ -16,6 +16,46 @@ import {
   validateUuid,
 } from "@/app/api/admin/_shared/adminRest";
 
+/**
+ * An error caused by what the caller sent, not by a fault on our side.
+ *
+ * Unknown permission keys used to reach the generic catch and come back as
+ * 500 "Failed to update permission". That is wrong twice: the caller cannot
+ * tell a typo from an outage, and every typo shows up in monitoring as a
+ * server error.
+ */
+class ClientError extends Error {}
+
+/**
+ * The response a thrown error deserves.
+ *
+ * The three handlers had this logic copied out with only the fallback message
+ * differing, and each copy recognised exactly one client error --
+ * INVALID_PAYLOAD_ERROR from validateUuid -- so every other bad input became a
+ * 500.
+ *
+ * @param error - whatever was thrown.
+ * @param fallbackMessage - what to say when the fault is ours.
+ * @returns a 400 for anything the caller can fix, otherwise a 500.
+ */
+function errorResponse(error: unknown, fallbackMessage: string) {
+  const isClientError =
+    error instanceof ClientError ||
+    (error instanceof Error && error.message === INVALID_PAYLOAD_ERROR);
+
+  if (isClientError) {
+    return NextResponse.json(
+      { error: (error as Error).message },
+      { status: BAD_REQUEST_STATUS },
+    );
+  }
+
+  return NextResponse.json(
+    { error: fallbackMessage },
+    { status: INTERNAL_SERVER_ERROR_STATUS },
+  );
+}
+
 const USER_PERMISSIONS_READ = "user_permissions.read";
 const USER_PERMISSIONS_CREATE = "user_permissions.create";
 const USER_PERMISSIONS_DELETE = "user_permissions.delete";
@@ -35,7 +75,7 @@ async function findResourcePermissionId(
   const permissionId = permissions[0]?.id;
 
   if (!permissionId) {
-    throw new Error(`Unknown permission key: ${permissionKey}`);
+    throw new ClientError(`Unknown permission key: ${permissionKey}`);
   }
 
   const resourceResponse = await adminFetch(
@@ -51,7 +91,9 @@ async function findResourcePermissionId(
 
   const preferred = rows.find((row) => row.resource_id === null) ?? rows[0];
   if (!preferred) {
-    throw new Error(`No resource permission found for key: ${permissionKey}`);
+    throw new ClientError(
+      `No resource permission found for key: ${permissionKey}`,
+    );
   }
 
   return preferred.id;
@@ -227,20 +269,7 @@ export async function GET(
 
     return NextResponse.json({ grantedKeys });
   } catch (error) {
-    return NextResponse.json(
-      {
-        error:
-          error instanceof Error && error.message === INVALID_PAYLOAD_ERROR
-            ? INVALID_PAYLOAD_ERROR
-            : "Failed to load user permissions",
-      },
-      {
-        status:
-          error instanceof Error && error.message === INVALID_PAYLOAD_ERROR
-            ? BAD_REQUEST_STATUS
-            : INTERNAL_SERVER_ERROR_STATUS,
-      },
-    );
+    return errorResponse(error, "Failed to load user permissions");
   }
 }
 
@@ -278,20 +307,7 @@ export async function POST(
 
     return NextResponse.json({ ok: true });
   } catch (error) {
-    return NextResponse.json(
-      {
-        error:
-          error instanceof Error && error.message === INVALID_PAYLOAD_ERROR
-            ? INVALID_PAYLOAD_ERROR
-            : "Failed to update permission",
-      },
-      {
-        status:
-          error instanceof Error && error.message === INVALID_PAYLOAD_ERROR
-            ? BAD_REQUEST_STATUS
-            : INTERNAL_SERVER_ERROR_STATUS,
-      },
-    );
+    return errorResponse(error, "Failed to update permission");
   }
 }
 
@@ -321,19 +337,6 @@ export async function PUT(
 
     return NextResponse.json({ ok: true });
   } catch (error) {
-    return NextResponse.json(
-      {
-        error:
-          error instanceof Error && error.message === INVALID_PAYLOAD_ERROR
-            ? INVALID_PAYLOAD_ERROR
-            : "Failed to apply permission template",
-      },
-      {
-        status:
-          error instanceof Error && error.message === INVALID_PAYLOAD_ERROR
-            ? BAD_REQUEST_STATUS
-            : INTERNAL_SERVER_ERROR_STATUS,
-      },
-    );
+    return errorResponse(error, "Failed to apply permission template");
   }
 }

--- a/apps/admin/tests/userPermissionsRoute.test.ts
+++ b/apps/admin/tests/userPermissionsRoute.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("api/supabase/server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+
+const ADMIN_ID = "c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13";
+const TARGET_ID = "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12";
+const PERMISSION_ID = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+const RESOURCE_PERMISSION_ID = "d0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14";
+
+const ok = (json: unknown) =>
+  ({ ok: true, json: async () => json }) as Response;
+
+/** A permission row as `getEffectivePermissionKeys` expects it. */
+const grantRow = (key: string) => ({
+  expires_at: null,
+  mode: "grant",
+  resource_permission_id: `${key}-rp`,
+  resource_permissions: { permissions: { key } },
+});
+
+async function loadRoute(signedIn = true) {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.test";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+  vi.resetModules();
+
+  const routeModule =
+    await import("@/app/api/admin/users/[userId]/permissions/route");
+  const supabaseModule = await import("api/supabase/server");
+
+  vi.mocked(supabaseModule.createServerSupabaseClient).mockResolvedValue({
+    rpc: vi
+      .fn()
+      .mockResolvedValue({ data: signedIn ? ADMIN_ID : null, error: null }),
+  } as unknown as Awaited<
+    ReturnType<typeof supabaseModule.createServerSupabaseClient>
+  >);
+
+  return routeModule;
+}
+
+const params = (userId = TARGET_ID) => ({
+  params: Promise.resolve({ userId }),
+});
+
+const post = (body: unknown) =>
+  new Request("http://localhost/api/admin/users/x/permissions", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+const put = (body: unknown) =>
+  new Request("http://localhost/api/admin/users/x/permissions", {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+
+/** The caller's own permission lookup, which every handler does first. */
+function mockCallerPermissions(...keys: string[]) {
+  vi.mocked(fetch).mockResolvedValueOnce(ok(keys.map((k) => grantRow(k))));
+}
+
+describe("admin users/[userId]/permissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  describe("GET", () => {
+    it("refuses a caller without user_permissions.read", async () => {
+      const { GET } = await loadRoute();
+      mockCallerPermissions("orders.approve");
+
+      const response = await GET(new Request("http://localhost"), params());
+      expect(response.status).toBe(403);
+    });
+
+    it("refuses a caller with no session", async () => {
+      const { GET } = await loadRoute(false);
+
+      const response = await GET(new Request("http://localhost"), params());
+      expect(response.status).toBe(403);
+    });
+
+    it("returns the target user's granted keys", async () => {
+      const { GET } = await loadRoute();
+      mockCallerPermissions("user_permissions.read");
+      vi.mocked(fetch).mockResolvedValueOnce(
+        ok([grantRow("orders.approve"), grantRow("orders.request_proof")]),
+      );
+
+      const response = await GET(new Request("http://localhost"), params());
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        grantedKeys: ["orders.approve", "orders.request_proof"],
+      });
+    });
+
+    it("rejects a target id that is not a uuid", async () => {
+      const { GET } = await loadRoute();
+      mockCallerPermissions("user_permissions.read");
+
+      const response = await GET(
+        new Request("http://localhost"),
+        params("not-a-uuid"),
+      );
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("POST", () => {
+    it("rejects a payload with no permissionKey", async () => {
+      const { POST } = await loadRoute();
+      const response = await POST(post({ grant: true }), params());
+      expect(response.status).toBe(400);
+    });
+
+    it("rejects a payload whose grant is not a boolean", async () => {
+      const { POST } = await loadRoute();
+      const response = await POST(
+        post({ permissionKey: "orders.approve", grant: "yes" }),
+        params(),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it("granting requires user_permissions.create", async () => {
+      const { POST } = await loadRoute();
+      mockCallerPermissions("user_permissions.delete");
+
+      const response = await POST(
+        post({ permissionKey: "orders.approve", grant: true }),
+        params(),
+      );
+      expect(response.status).toBe(403);
+    });
+
+    it("revoking requires user_permissions.delete", async () => {
+      const { POST } = await loadRoute();
+      mockCallerPermissions("user_permissions.create");
+
+      const response = await POST(
+        post({ permissionKey: "orders.approve", grant: false }),
+        params(),
+      );
+      expect(response.status).toBe(403);
+    });
+
+    it("grants a permission", async () => {
+      const { POST } = await loadRoute();
+      mockCallerPermissions("user_permissions.create");
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(ok([{ id: PERMISSION_ID }]))
+        .mockResolvedValueOnce(
+          ok([{ id: RESOURCE_PERMISSION_ID, resource_id: null }]),
+        )
+        .mockResolvedValueOnce(ok([]));
+
+      const response = await POST(
+        post({ permissionKey: "orders.approve", grant: true }),
+        params(),
+      );
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ ok: true });
+    });
+
+    // An unknown key is the caller's mistake. It used to reach the generic
+    // catch and come back as 500 "Failed to update permission", which cannot
+    // be told apart from an outage either by the caller or in monitoring.
+    it("reports an unknown permission key as a client error", async () => {
+      const { POST } = await loadRoute();
+      mockCallerPermissions("user_permissions.create");
+      vi.mocked(fetch).mockResolvedValueOnce(ok([]));
+
+      const response = await POST(
+        post({ permissionKey: "not.a.real.permission", grant: true }),
+        params(),
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: expect.stringContaining("not.a.real.permission"),
+      });
+    });
+  });
+
+  describe("PUT", () => {
+    it("requires both create and delete", async () => {
+      const { PUT } = await loadRoute();
+      mockCallerPermissions("user_permissions.create");
+
+      const response = await PUT(
+        put({ permissionKeys: ["orders.approve"] }),
+        params(),
+      );
+      expect(response.status).toBe(403);
+    });
+
+    it("rejects a payload whose permissionKeys is not an array", async () => {
+      const { PUT } = await loadRoute();
+      mockCallerPermissions(
+        "user_permissions.create",
+        "user_permissions.delete",
+      );
+
+      const response = await PUT(put({ permissionKeys: "all" }), params());
+      expect(response.status).toBe(400);
+    });
+  });
+});

--- a/tests/INVENTORY.md
+++ b/tests/INVENTORY.md
@@ -6,12 +6,12 @@ Every test case in the repo, so a refactor can be checked for losses:
 regenerate and diff. Counting files or totals is not enough -- a rework
 can keep both and still drop the one assertion that mattered.
 
-**2696 cases across 373 files** (0 skipped, 9 parameterised).
+**2708 cases across 374 files** (0 skipped, 9 parameterised).
 
 Source-level cases: a `.each` case is one entry here and many in vitest
 output, so this total is deliberately not the runner total.
 
-## app:admin -- 525 cases
+## app:admin -- 537 cases
 
 ### `apps/admin/tests/ActivityRow.test.tsx`
 
@@ -641,6 +641,21 @@ output, so this total is deliberately not the runner total.
 - grantPermission > throws when no resource permission rows exist
 - grantPermission > prefers null resource_id row over non-null when multiple rows
 - revokePermission > revokes permission successfully
+
+### `apps/admin/tests/userPermissionsRoute.test.ts`
+
+- refuses a caller without user_permissions.read
+- refuses a caller with no session
+- returns the target user's granted keys
+- rejects a target id that is not a uuid
+- rejects a payload with no permissionKey
+- rejects a payload whose grant is not a boolean
+- granting requires user_permissions.create
+- revoking requires user_permissions.delete
+- grants a permission
+- reports an unknown permission key as a client error
+- requires both create and delete
+- rejects a payload whose permissionKeys is not an array
 
 ### `apps/admin/tests/UserRow.test.tsx`
 


### PR DESCRIPTION
The permissions route is **339 lines** behind GET, POST and PUT, it grants and revokes every permission in the system, and it had **no tests**. This adds twelve and fixes what writing them found.

## The bug

`findResourcePermissionId` throws on an unknown key. But each handler's catch recognised exactly *one* client error — `INVALID_PAYLOAD_ERROR`, the message `validateUuid` throws. Everything else fell through:

```ts
error instanceof Error && error.message === INVALID_PAYLOAD_ERROR
  ? BAD_REQUEST_STATUS
  : INTERNAL_SERVER_ERROR_STATUS   // ← unknown permission key landed here
```

So `POST` with a mistyped permission key answered **500 "Failed to update permission"**. The caller can't tell a typo from an outage, and in monitoring every typo looks like one.

Unknown keys now throw a `ClientError` and come back as **400**, carrying the key that wasn't found.

The three catch bodies were also copied out with only the fallback message differing — each carrying its own copy of the one-error classification. They're now one `errorResponse()`.

## Tests, for the parts that had nothing

- `GET` requires `user_permissions.read`; no session is refused
- `POST` requires **create** to grant and **delete** to revoke — and checks the right one per direction
- `PUT` requires **both**
- a non-uuid target is a 400, not a 500
- payload shapes: missing `permissionKey`, non-boolean `grant`, non-array `permissionKeys`
- the unknown-key case above

**Verified load-bearing**: restoring the old classification fails exactly the unknown-key case and nothing else.

## Checked and deliberately left alone

- `permissionKey` reaches PostgREST through `URLSearchParams`, which encodes it — **no injection**.
- `POST` parses the body *before* authorizing, which reads like the wrong order but is forced: the permission it must require depends on the `grant` flag inside that body.

## Verification

`lint` · `typecheck` · `format:check` · `knip` · `check:doc-refs` · `test` · `test:workflows` · `test-inventory-diff` · `check-doc-freshness`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt