### PR TITLE
fix(admin): report amount ceiling silently ignored with a date range [GH-000]

### DIFF
--- a/apps/admin/src/app/api/admin/_shared/reportsFilters.ts
+++ b/apps/admin/src/app/api/admin/_shared/reportsFilters.ts
@@ -63,6 +63,12 @@ function addAmountFilters(
  * - sellerId / buyerId pass through unchanged — they're UUIDs from the
  *   admin's own select boxes, not free-form input.
  *
+ * - a second upper bound cannot reuse the column key an object already holds,
+ *   so date and amount ceilings go into a single `and=(a,b)` group. One group,
+ *   not one per bound: PostgREST answers `and=(a),(b)` with the first group
+ *   alone and drops the rest without erroring, which silently ignored the
+ *   amount ceiling whenever a date range was also set.
+ *
  * Used by both `/api/admin/reports/orders` (returns JSON) and
  * `/api/admin/reports/export` (returns XLSX). The filter shape is identical.
  */

--- a/apps/admin/src/app/api/admin/_shared/reportsFilters.ts
+++ b/apps/admin/src/app/api/admin/_shared/reportsFilters.ts
@@ -16,6 +16,7 @@ function isValidAmount(value: string): boolean {
 
 function addDateFilters(
   filters: Record<string, string>,
+  and: string[],
   dateFrom: string | null,
   dateTo: string | null,
 ): void {
@@ -25,8 +26,7 @@ function addDateFilters(
     const end = new Date(validTo);
     end.setDate(end.getDate() + 1);
     filters["created_at"] = `gte.${validFrom}`;
-    filters["and"] =
-      `(created_at.lt.${end.toISOString().slice(0, ISO_DATE_LENGTH)})`;
+    and.push(`created_at.lt.${end.toISOString().slice(0, ISO_DATE_LENGTH)}`);
   } else if (validFrom) {
     filters["created_at"] = `gte.${validFrom}`;
   } else if (validTo) {
@@ -38,6 +38,7 @@ function addDateFilters(
 
 function addAmountFilters(
   filters: Record<string, string>,
+  and: string[],
   amountMin: string | null,
   amountMax: string | null,
 ): void {
@@ -45,10 +46,7 @@ function addAmountFilters(
   const validMax = amountMax && isValidAmount(amountMax) ? amountMax : null;
   if (validMin && validMax) {
     filters["total"] = `gte.${validMin}`;
-    const existing = filters["and"] ?? "";
-    filters["and"] = existing
-      ? `${existing},(total.lte.${validMax})`
-      : `(total.lte.${validMax})`;
+    and.push(`total.lte.${validMax}`);
   } else if (validMin) {
     filters["total"] = `gte.${validMin}`;
   } else if (validMax) {
@@ -72,17 +70,31 @@ export function buildAdminOrderFilters(
   searchParams: URLSearchParams,
 ): Record<string, string> {
   const filters: Record<string, string> = {};
+  // Every extra upper bound goes in ONE `and=(...)` group. Emitting a group
+  // each -- `and=(a),(b)` -- does not fail: PostgREST parses the first group
+  // and SILENTLY DROPS the rest. Verified against the local PostgREST, where
+  // `permissions?and=(key.like.orders*),(key.like.receipts*)` returns the five
+  // orders.* keys while the single group `and=(key.like.orders*,key.like.
+  // receipts*)` correctly returns none. So a report filtered by both a date
+  // range and an amount range silently ignored the amount ceiling.
+  const and: string[] = [];
 
   addDateFilters(
     filters,
+    and,
     searchParams.get("dateFrom"),
     searchParams.get("dateTo"),
   );
   addAmountFilters(
     filters,
+    and,
     searchParams.get("amountMin"),
     searchParams.get("amountMax"),
   );
+
+  if (and.length > 0) {
+    filters["and"] = `(${and.join(",")})`;
+  }
 
   const status = searchParams.get("status");
   const sellerId = searchParams.get("sellerId");

--- a/apps/admin/tests/reportsFilters.test.ts
+++ b/apps/admin/tests/reportsFilters.test.ts
@@ -113,7 +113,13 @@ describe("buildAdminOrderFilters — amount filters", () => {
     });
   });
 
-  it("appends to an existing and= clause when dates are also present", () => {
+  // Both upper bounds must land in ONE and= group. This previously emitted
+  // `(created_at.lt.X),(total.lte.Y)`, which PostgREST does not reject: it
+  // parses the first group and silently drops the rest, so the amount ceiling
+  // was ignored whenever a date range was also chosen. Verified against a real
+  // PostgREST -- `permissions?and=(key.like.orders*),(key.like.receipts*)`
+  // returns the five orders.* keys, while the single group returns none.
+  it("puts both upper bounds in one and= group", () => {
     expect(
       build({
         dateFrom: "2026-01-01",
@@ -123,9 +129,23 @@ describe("buildAdminOrderFilters — amount filters", () => {
       }),
     ).toEqual({
       created_at: "gte.2026-01-01",
-      and: "(created_at.lt.2026-02-01),(total.lte.100)",
+      and: "(created_at.lt.2026-02-01,total.lte.100)",
       total: "gte.10",
     });
+  });
+
+  it("never emits more than one and= group", () => {
+    const and = build({
+      dateFrom: "2026-01-01",
+      dateTo: "2026-01-31",
+      amountMin: "10",
+      amountMax: "100",
+    })["and"];
+
+    expect(and?.startsWith("(")).toBe(true);
+    expect(and?.endsWith(")")).toBe(true);
+    // A second group would show up as a ")" before the end.
+    expect(and?.slice(0, -1).includes(")")).toBe(false);
   });
 
   it("ignores negative or non-numeric amounts", () => {

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -367,6 +367,25 @@ tree and listed those names twice; the diff compares sorted lists with `comm`,
 which is duplicate-sensitive, so a name appearing twice before and once now
 produced a line of output. The report was surplus, not loss.
 
+A rename trips it too, and that needed an answer. The gate compares case
+NAMES, so replacing a test with a better-named one reads as a loss, and the
+comparison is against the base branch — regenerating `tests/INVENTORY.md` on
+the branch does not change what CI compares. Without a way through, the gate
+blocks ordinary work, and a gate that blocks ordinary work is one somebody
+deletes.
+
+`tests/retired-cases.txt` is that way through, and it is deliberately
+awkward: one line per case, the name exactly as it appeared, and a reason
+after `#`. You have to name the assertion you are dropping and say what
+replaced it, in a tracked file a reviewer sees in the diff. Retired names are
+subtracted from the losses rather than from the baseline, so a case that comes
+back stops being reported as retired instead of staying hidden.
+
+It is not a suppression flag in the sense this document warns about elsewhere.
+A flag is one token that silences everything; this silences exactly one named
+case and leaves the reasoning in the repository. Verified: with the file in
+place, deleting an unrelated case still fails with exit 1.
+
 That episode is the reason the CI step carries a warning in its comment.
 Regenerating `tests/INVENTORY.md` makes any failure disappear without
 answering it, which is precisely how a real loss would be buried. The rule is

--- a/scripts/test-inventory-diff.sh
+++ b/scripts/test-inventory-diff.sh
@@ -11,7 +11,6 @@ set -euo pipefail
 ref="${1:-$(git merge-base HEAD develop)}"
 before=$(mktemp)
 after=$(mktemp)
-trap 'rm -f "$before" "$after"' EXIT
 
 # Compare on the case NAME, not "suite > name". Suite attribution can shift
 # without a case being lost -- moving a file, or improving how this scanner
@@ -29,7 +28,20 @@ git show "$ref:tests/INVENTORY.md" 2>/dev/null | grep '^- ' | strip_suite | sort
 node scripts/test-inventory.mjs > /dev/null
 grep '^- ' tests/INVENTORY.md | strip_suite | sort > "$after"
 
-lost=$(comm -23 "$before" "$after" | wc -l | tr -d ' ')
+# Cases whose removal was deliberate and explained. Without this, any rename
+# fails the gate with no way through, and a gate that blocks ordinary work is
+# a gate somebody deletes. Naming the case and the reason is the cost.
+retired=$(mktemp)
+trap 'rm -f "$before" "$after" "$retired"' EXIT
+if [ -f tests/retired-cases.txt ]; then
+  sed 's/#.*//' tests/retired-cases.txt | sed 's/[[:space:]]*$//'     | grep -v '^$' | sort > "$retired"
+else
+  : > "$retired"
+fi
+
+# Subtract retired names from the losses, not from the baseline: a case that
+# comes back should stop being reported as retired rather than stay hidden.
+lost=$(comm -23 "$before" "$after" | comm -23 - "$retired" | wc -l | tr -d ' ')
 added=$(comm -13 "$before" "$after" | wc -l | tr -d ' ')
 
 echo "against $ref: $(wc -l < "$before" | tr -d ' ') cases -> $(wc -l < "$after" | tr -d ' ') cases"
@@ -37,7 +49,7 @@ echo
 
 if [ "$lost" -gt 0 ]; then
   echo "LOST ($lost):"
-  comm -23 "$before" "$after" | sed 's/^/  /'
+  comm -23 "$before" "$after" | comm -23 - "$retired" | sed 's/^/  /'
   echo
 fi
 

--- a/tests/INVENTORY.md
+++ b/tests/INVENTORY.md
@@ -6,12 +6,12 @@ Every test case in the repo, so a refactor can be checked for losses:
 regenerate and diff. Counting files or totals is not enough -- a rework
 can keep both and still drop the one assertion that mattered.
 
-**2708 cases across 374 files** (0 skipped, 9 parameterised).
+**2709 cases across 374 files** (0 skipped, 9 parameterised).
 
 Source-level cases: a `.each` case is one entry here and many in vitest
 output, so this total is deliberately not the runner total.
 
-## app:admin -- 537 cases
+## app:admin -- 538 cases
 
 ### `apps/admin/tests/ActivityRow.test.tsx`
 
@@ -348,7 +348,8 @@ output, so this total is deliberately not the runner total.
 - buildAdminOrderFilters — amount filters > builds a single-bound filter for amountMin alone
 - buildAdminOrderFilters — amount filters > builds a single-bound filter for amountMax alone
 - buildAdminOrderFilters — amount filters > builds a combined range using the and= clause
-- buildAdminOrderFilters — amount filters > appends to an existing and= clause when dates are also present
+- buildAdminOrderFilters — amount filters > puts both upper bounds in one and= group
+- buildAdminOrderFilters — amount filters > never emits more than one and= group
 - buildAdminOrderFilters — amount filters > ignores negative or non-numeric amounts
 - buildAdminOrderFilters — empty input > returns an empty object when no params are given
 

--- a/tests/retired-cases.txt
+++ b/tests/retired-cases.txt
@@ -1,0 +1,13 @@
+# Test cases deliberately removed, so scripts/test-inventory-diff.sh can tell
+# an intentional retirement from a lost assertion.
+#
+# One case name per line, then a reason after `#`. The name must match the
+# case exactly as it appeared, which is what makes an entry hard to add
+# casually: you have to name the assertion you are dropping and say why.
+#
+# This is NOT a way to make a failure go away. If a case is gone because the
+# behaviour it checked still matters, restore the case. Retire it only when
+# the assertion itself became wrong or was replaced by a better one, and name
+# the replacement here.
+
+appends to an existing and= clause when dates are also present  # asserted the broken `and=(a),(b)` output, which PostgREST silently truncates; replaced by "puts both upper bounds in one and= group" and "never emits more than one and= group"


### PR DESCRIPTION
`buildAdminOrderFilters` puts a second upper bound in a PostgREST `and=` group. With **both** a date range and an amount range it emitted:

```
and=(created_at.lt.2026-02-01),(total.lte.100)
```

Two groups, not one. **PostgREST does not reject that** — it parses the first group and silently drops the rest. So the amount ceiling was discarded whenever a date range was also chosen, and the sales report listed orders **above the maximum the admin asked for**.

## Verified empirically, because my first guess was wrong

I assumed the malformed form would 400. It doesn't. Proved against the real PostgREST in the local Supabase:

| query | result |
| --- | --- |
| `permissions?and=(key.like.orders*),(key.like.receipts*)` | the 5 `orders.*` keys — **second condition dropped** |
| `permissions?and=(key.like.orders*,key.like.receipts*)` | `[]` — correct, no key is both |

And the fixed output ANDs properly: `and=(key.like.orders*,key.like.*create)` returns only `orders.create`.

Conditions are now collected into one array and joined into a single group. Affects **both** `/api/admin/reports/orders` and `/api/admin/reports/export`, which share this builder.

## The test was recording the bug

The existing case asserted the broken string verbatim — it captured what the code produced, not what PostgREST does with it. That's precisely how a test written after the implementation passes while the behaviour is wrong. Replaced by one asserting the correct grouping and one asserting a single balanced group.

## Retiring it exposed a flaw in the gate I added in #397

`test-inventory-diff` compares case **names** against the base branch, so any rename reads as a lost assertion — and regenerating `INVENTORY.md` on the branch doesn't change what CI compares. No way through. **A gate that blocks ordinary work is a gate somebody deletes.**

`tests/retired-cases.txt` is the way through, and it's deliberately awkward: the exact case name plus a reason, in a tracked file a reviewer sees in the diff. Retired names are subtracted from the **losses**, not the baseline — so a case that comes back stops being marked retired instead of staying hidden.

It isn't the kind of suppression flag this repo warns about: a flag is one token that silences everything; this silences exactly one named case and leaves the reasoning in the repository. **Verified it doesn't blunt the gate** — with the file in place, deleting an unrelated case still fails with exit 1.

## Verification

`lint` · `typecheck` · `format:check` · `knip` · `check:doc-refs` · `test` · `test:workflows` · `test-inventory-diff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt