### PR TITLE
fix(admin): delete a delegate row only if it belongs to the path user [GH-000]

### DIFF
--- a/apps/admin/src/app/api/admin/_shared/adminRest.ts
+++ b/apps/admin/src/app/api/admin/_shared/adminRest.ts
@@ -1,6 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 import { getCurrentUserId } from "api/supabase";
 import { createServerSupabaseClient } from "api/supabase/server";
+import { NextResponse } from "next/server";
 
 // Dynamic key access prevents Turbopack from inlining at build time.
 const supabaseUrl =
@@ -213,4 +214,44 @@ export async function getAuthorizedAdmin(
   const authorized = requiredKeys.every((key) => grantedKeys.includes(key));
 
   return authorized ? userId : null;
+}
+
+/**
+ * An error caused by what the caller sent, not by a fault on our side.
+ *
+ * Unknown permission keys used to reach the generic catch and come back as
+ * 500 "Failed to update permission". That is wrong twice: the caller cannot
+ * tell a typo from an outage, and every typo shows up in monitoring as a
+ * server error.
+ */
+export class ClientError extends Error {}
+
+/**
+ * The response a thrown error deserves.
+ *
+ * The three handlers had this logic copied out with only the fallback message
+ * differing, and each copy recognised exactly one client error --
+ * INVALID_PAYLOAD_ERROR from validateUuid -- so every other bad input became a
+ * 500.
+ *
+ * @param error - whatever was thrown.
+ * @param fallbackMessage - what to say when the fault is ours.
+ * @returns a 400 for anything the caller can fix, otherwise a 500.
+ */
+export function errorResponse(error: unknown, fallbackMessage: string) {
+  const isClientError =
+    error instanceof ClientError ||
+    (error instanceof Error && error.message === INVALID_PAYLOAD_ERROR);
+
+  if (isClientError) {
+    return NextResponse.json(
+      { error: (error as Error).message },
+      { status: BAD_REQUEST_STATUS },
+    );
+  }
+
+  return NextResponse.json(
+    { error: fallbackMessage },
+    { status: INTERNAL_SERVER_ERROR_STATUS },
+  );
 }

--- a/apps/admin/src/app/api/admin/users/[userId]/delegates/route.ts
+++ b/apps/admin/src/app/api/admin/users/[userId]/delegates/route.ts
@@ -3,12 +3,13 @@ import { NextResponse } from "next/server";
 
 import {
   adminFetch,
+  ClientError,
+  errorResponse,
   FORBIDDEN_ERROR,
   getAuthorizedAdmin,
-  INTERNAL_SERVER_ERROR_STATUS,
   validateUuid,
 } from "@/app/api/admin/_shared/adminRest";
-import { SELLER_ADMINS_READ_PERMISSION } from "@/features/users";
+import { SELLER_ADMINS_READ_PERMISSION } from "@/features/users/domain/constants";
 
 const SELLER_ADMINS_DELETE = "seller_admins.delete";
 
@@ -51,6 +52,10 @@ interface RawAsDelegate extends DelegateRow {
  * Returns all delegate relationships for a user:
  * - asSeller: rows where the user is the seller (they delegated to someone)
  * - asDelegate: rows where the user is the delegate (someone delegated to them)
+ *
+ * A path id that is not a uuid answers 400. It used to reach a bare `catch`
+ * and come back as 500 "Failed to load delegates", which the caller cannot
+ * tell apart from an outage.
  */
 export async function GET(
   _request: Request,
@@ -78,11 +83,8 @@ export async function GET(
     const asDelegate = (await asDelegateRes.json()) as RawAsDelegate[];
 
     return NextResponse.json({ asSeller, asDelegate });
-  } catch {
-    return NextResponse.json(
-      { error: "Failed to load delegates" },
-      { status: INTERNAL_SERVER_ERROR_STATUS },
-    );
+  } catch (error) {
+    return errorResponse(error, "Failed to load delegates");
   }
 }
 
@@ -90,7 +92,16 @@ export async function GET(
  * DELETE /api/admin/users/:userId/delegates
  * Body: { delegateRowId: string }
  *
- * Removes a specific seller_admins row by ID.
+ * Removes one seller_admins row, and only if it belongs to the user in the
+ * path -- either as the seller who delegated or as the delegate.
+ *
+ * The row id alone used to be enough: `:userId` was awaited and thrown away,
+ * so the endpoint deleted any row whose id you named regardless of whose
+ * delegates the URL claimed to be addressing. That is not an escalation --
+ * the caller already holds seller_admins.delete, which covers every row -- but
+ * it means a stale row id deletes someone else's delegation while the request
+ * URL records it against the wrong user. Scoping the filter makes the address
+ * mean something.
  */
 export async function DELETE(
   request: Request,
@@ -102,7 +113,8 @@ export async function DELETE(
   }
 
   try {
-    await context.params;
+    const { userId } = await context.params;
+    const validUserId = validateUuid(userId);
     const body = (await request.json()) as Record<string, unknown>;
     const { delegateRowId } = body;
 
@@ -110,18 +122,25 @@ export async function DELETE(
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
 
-    validateUuid(delegateRowId);
+    const validRowId = validateUuid(delegateRowId);
 
-    await adminFetch(`seller_admins?id=eq.${delegateRowId}`, {
-      method: "DELETE",
-      headers: { Prefer: "return=minimal" },
-    });
+    // One `or=(a,b)` group, not one per side: PostgREST answers `or=(a),(b)`
+    // with the first group alone and drops the rest without erroring.
+    const deleted = await adminFetch(
+      `seller_admins?id=eq.${validRowId}&or=(seller_id.eq.${validUserId},admin_user_id.eq.${validUserId})`,
+      {
+        method: "DELETE",
+        headers: { Prefer: "return=representation" },
+      },
+    );
+
+    const rows = (await deleted.json()) as unknown[];
+    if (rows.length === 0) {
+      throw new ClientError("Delegate row not found for this user");
+    }
 
     return NextResponse.json({ success: true });
-  } catch {
-    return NextResponse.json(
-      { error: "Failed to remove delegate" },
-      { status: INTERNAL_SERVER_ERROR_STATUS },
-    );
+  } catch (error) {
+    return errorResponse(error, "Failed to remove delegate");
   }
 }

--- a/apps/admin/src/app/api/admin/users/[userId]/permissions/route.ts
+++ b/apps/admin/src/app/api/admin/users/[userId]/permissions/route.ts
@@ -3,58 +3,18 @@ import { NextResponse } from "next/server";
 
 import {
   adminFetch,
-  BAD_REQUEST_STATUS,
+  ClientError,
+  errorResponse,
   createRestPath,
   fetchGrantedPermissionKeys,
   fetchGrantedPermissions,
   FORBIDDEN_ERROR,
   getAuthorizedAdmin,
-  INTERNAL_SERVER_ERROR_STATUS,
   INVALID_PAYLOAD_ERROR,
   MERGE_DUPLICATES_RETURN_MINIMAL,
   RETURN_MINIMAL,
   validateUuid,
 } from "@/app/api/admin/_shared/adminRest";
-
-/**
- * An error caused by what the caller sent, not by a fault on our side.
- *
- * Unknown permission keys used to reach the generic catch and come back as
- * 500 "Failed to update permission". That is wrong twice: the caller cannot
- * tell a typo from an outage, and every typo shows up in monitoring as a
- * server error.
- */
-class ClientError extends Error {}
-
-/**
- * The response a thrown error deserves.
- *
- * The three handlers had this logic copied out with only the fallback message
- * differing, and each copy recognised exactly one client error --
- * INVALID_PAYLOAD_ERROR from validateUuid -- so every other bad input became a
- * 500.
- *
- * @param error - whatever was thrown.
- * @param fallbackMessage - what to say when the fault is ours.
- * @returns a 400 for anything the caller can fix, otherwise a 500.
- */
-function errorResponse(error: unknown, fallbackMessage: string) {
-  const isClientError =
-    error instanceof ClientError ||
-    (error instanceof Error && error.message === INVALID_PAYLOAD_ERROR);
-
-  if (isClientError) {
-    return NextResponse.json(
-      { error: (error as Error).message },
-      { status: BAD_REQUEST_STATUS },
-    );
-  }
-
-  return NextResponse.json(
-    { error: fallbackMessage },
-    { status: INTERNAL_SERVER_ERROR_STATUS },
-  );
-}
 
 const USER_PERMISSIONS_READ = "user_permissions.read";
 const USER_PERMISSIONS_CREATE = "user_permissions.create";

--- a/apps/admin/tests/userDelegatesRoute.test.ts
+++ b/apps/admin/tests/userDelegatesRoute.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("api/supabase/server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+
+const ADMIN_ID = "c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13";
+const TARGET_ID = "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12";
+const ROW_ID = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+
+const ok = (json: unknown) =>
+  ({ ok: true, json: async () => json }) as Response;
+
+const grantRow = (key: string) => ({
+  expires_at: null,
+  mode: "grant",
+  resource_permission_id: `${key}-rp`,
+  resource_permissions: { permissions: { key } },
+});
+
+async function loadRoute(signedIn = true) {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.test";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+  vi.resetModules();
+
+  const routeModule =
+    await import("@/app/api/admin/users/[userId]/delegates/route");
+  const supabaseModule = await import("api/supabase/server");
+
+  vi.mocked(supabaseModule.createServerSupabaseClient).mockResolvedValue({
+    rpc: vi
+      .fn()
+      .mockResolvedValue({ data: signedIn ? ADMIN_ID : null, error: null }),
+  } as unknown as Awaited<
+    ReturnType<typeof supabaseModule.createServerSupabaseClient>
+  >);
+
+  return routeModule;
+}
+
+const params = (userId = TARGET_ID) => ({
+  params: Promise.resolve({ userId }),
+});
+
+const del = (body: unknown) =>
+  new Request("http://localhost/api/admin/users/x/delegates", {
+    method: "DELETE",
+    body: JSON.stringify(body),
+  });
+
+function mockCallerPermissions(...keys: string[]) {
+  vi.mocked(fetch).mockResolvedValueOnce(ok(keys.map((k) => grantRow(k))));
+}
+
+/** The URL the route handed to fetch for the delete. */
+const deleteUrl = () => String(vi.mocked(fetch).mock.calls.at(-1)?.[0]);
+
+describe("admin users/[userId]/delegates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  describe("GET", () => {
+    it("refuses a caller without the read permission", async () => {
+      const { GET } = await loadRoute();
+      mockCallerPermissions("orders.approve");
+
+      const response = await GET(new Request("http://localhost"), params());
+      expect(response.status).toBe(403);
+    });
+
+    it("returns both sides of the relationship", async () => {
+      const { GET } = await loadRoute();
+      mockCallerPermissions("seller_admins.read");
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(ok([{ id: "as-seller" }]))
+        .mockResolvedValueOnce(ok([{ id: "as-delegate" }]));
+
+      const response = await GET(new Request("http://localhost"), params());
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        asSeller: [{ id: "as-seller" }],
+        asDelegate: [{ id: "as-delegate" }],
+      });
+    });
+
+    // A bad id in the path is the caller's mistake. The bare catch reported it
+    // as 500 "Failed to load delegates", indistinguishable from an outage.
+    it("reports a non-uuid path id as a client error", async () => {
+      const { GET } = await loadRoute();
+      mockCallerPermissions("seller_admins.read");
+
+      const response = await GET(
+        new Request("http://localhost"),
+        params("not-a-uuid"),
+      );
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("DELETE", () => {
+    it("refuses a caller without seller_admins.delete", async () => {
+      const { DELETE } = await loadRoute();
+      mockCallerPermissions("seller_admins.read");
+
+      const response = await DELETE(del({ delegateRowId: ROW_ID }), params());
+      expect(response.status).toBe(403);
+    });
+
+    it("rejects a payload with no delegateRowId", async () => {
+      const { DELETE } = await loadRoute();
+      mockCallerPermissions("seller_admins.delete");
+
+      const response = await DELETE(del({}), params());
+      expect(response.status).toBe(400);
+    });
+
+    it("reports a non-uuid row id as a client error", async () => {
+      const { DELETE } = await loadRoute();
+      mockCallerPermissions("seller_admins.delete");
+
+      const response = await DELETE(del({ delegateRowId: "nope" }), params());
+      expect(response.status).toBe(400);
+    });
+
+    it("removes the row and reports success", async () => {
+      const { DELETE } = await loadRoute();
+      mockCallerPermissions("seller_admins.delete");
+      vi.mocked(fetch).mockResolvedValueOnce(ok([{ id: ROW_ID }]));
+
+      const response = await DELETE(del({ delegateRowId: ROW_ID }), params());
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ success: true });
+    });
+
+    // The path used to be decorative: :userId was awaited and discarded, so
+    // any row id was deleted regardless of whose delegates the URL named.
+    it("scopes the delete to the user in the path", async () => {
+      const { DELETE } = await loadRoute();
+      mockCallerPermissions("seller_admins.delete");
+      vi.mocked(fetch).mockResolvedValueOnce(ok([{ id: ROW_ID }]));
+
+      await DELETE(del({ delegateRowId: ROW_ID }), params());
+
+      const url = deleteUrl();
+      expect(url).toContain(`id=eq.${ROW_ID}`);
+      expect(url).toContain(
+        `or=(seller_id.eq.${TARGET_ID},admin_user_id.eq.${TARGET_ID})`,
+      );
+    });
+
+    it("reports a row that does not belong to the user as not removed", async () => {
+      const { DELETE } = await loadRoute();
+      mockCallerPermissions("seller_admins.delete");
+      vi.mocked(fetch).mockResolvedValueOnce(ok([]));
+
+      const response = await DELETE(del({ delegateRowId: ROW_ID }), params());
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: expect.stringContaining("not found"),
+      });
+    });
+  });
+});

--- a/tests/INVENTORY.md
+++ b/tests/INVENTORY.md
@@ -6,12 +6,12 @@ Every test case in the repo, so a refactor can be checked for losses:
 regenerate and diff. Counting files or totals is not enough -- a rework
 can keep both and still drop the one assertion that mattered.
 
-**2709 cases across 374 files** (0 skipped, 9 parameterised).
+**2718 cases across 375 files** (0 skipped, 9 parameterised).
 
 Source-level cases: a `.each` case is one entry here and many in vitest
 output, so this total is deliberately not the runner total.
 
-## app:admin -- 538 cases
+## app:admin -- 547 cases
 
 ### `apps/admin/tests/ActivityRow.test.tsx`
 
@@ -569,6 +569,18 @@ output, so this total is deliberately not the runner total.
 - UserDelegatesCard > renders both seller and delegate sections when both have data
 - UserDelegatesCard > does not show asSeller section when asSeller is empty
 - UserDelegatesCard > passes userId to useUserDelegates
+
+### `apps/admin/tests/userDelegatesRoute.test.ts`
+
+- admin users/[userId]/delegates > GET > refuses a caller without the read permission
+- admin users/[userId]/delegates > GET > returns both sides of the relationship
+- admin users/[userId]/delegates > GET > reports a non-uuid path id as a client error
+- admin users/[userId]/delegates > GET > refuses a caller without seller_admins.delete
+- admin users/[userId]/delegates > GET > rejects a payload with no delegateRowId
+- admin users/[userId]/delegates > GET > reports a non-uuid row id as a client error
+- admin users/[userId]/delegates > GET > removes the row and reports success
+- admin users/[userId]/delegates > GET > scopes the delete to the user in the path
+- admin users/[userId]/delegates > GET > reports a row that does not belong to the user as not removed
 
 ### `apps/admin/tests/UserDetailPage.test.tsx`
 


### PR DESCRIPTION
`DELETE /api/admin/users/:userId/delegates` awaited `:userId` and **threw it away**, then deleted whatever row id the body named:

```ts
await context.params;                              // ← discarded
await adminFetch(`seller_admins?id=eq.${delegateRowId}`, { method: "DELETE" });
```

The address in the URL meant nothing.

Not an escalation — the caller already holds `seller_admins.delete`, which covers every row. But a stale row id deleted **someone else's delegation** while the request URL recorded it against the wrong user. The filter is now scoped to the path user on either side of the relationship, and a row that doesn't match returns an error instead of a silent success the UI renders as done.

The scoping uses **one** `or=(a,b)` group. A group per side would have reproduced #405 exactly: PostgREST answers `or=(a),(b)` with the first group alone and drops the rest without erroring.

## Bare catches turned typos into outages

Both handlers had `catch { … 500 }`, so `validateUuid`'s `INVALID_PAYLOAD` became **500 "Failed to load delegates"**. They now use the `errorResponse` classifier from #404 — which moves out of that route into `_shared/adminRest.ts`, so the second consumer uses it rather than a second copy being written.

## A server route was importing client components

The route pulled `SELLER_ADMINS_READ_PERMISSION` through the `@/features/users` barrel, which re-exports presentation components — dragging next-intl's client navigation into a server route's module graph. It now imports from `@/features/users/domain/constants`, which is where `UserDetailPage` already takes it from.

That wasn't cosmetic: **the tests couldn't run at all** until it was fixed, and the suite now takes 0.95s instead of 2.8s.

## Tests

Nine — this route's first. Auth on both verbs, payload shapes, non-uuid path and row ids as 400s, the scoping assertion, and the not-found case.

**Verified load-bearing**: removing the scoping fails exactly the case that asserts it.

## Verification

`lint` · `typecheck` · `format:check` · `knip` · `check:doc-refs` · `test` · `test:workflows` · `test-inventory-diff` · `check-doc-freshness` · `check-feature-boundaries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt