### PR TITLE
fix(admin): sales reports failed above roughly two hundred orders [GH-000]

### DIFF
--- a/apps/admin/src/app/api/admin/_shared/reportsData.ts
+++ b/apps/admin/src/app/api/admin/_shared/reportsData.ts
@@ -1,0 +1,113 @@
+/* eslint-disable i18next/no-literal-string -- PostgREST query operators, not user-facing text */
+import { adminFetch, createRestPath } from "./adminRest";
+
+/** An order line, as both report routes select it. */
+export interface OrderItemRow {
+  id: string;
+  order_id: string;
+  product_id: string;
+  quantity: number;
+  unit_price: number;
+  currency: string;
+  products: { name_en: string } | null;
+}
+
+/** The buyer or seller behind an order. */
+export interface UserProfileRow {
+  id: string;
+  email: string;
+  display_name: string | null;
+}
+
+const ITEMS_SELECT =
+  "id,order_id,product_id,quantity,unit_price,currency,products(name_en)";
+
+/**
+ * How many ids go into one `in.(...)` filter.
+ *
+ * The reports fetched every order's lines in a single request, so the URL grew
+ * by 37 bytes per order and the gateway rejected it. Measured against this
+ * project's own stack: 200 ids is 7,466 bytes and answers 200; 250 ids is
+ * 9,316 bytes and answers **414 URI Too Long**. Both report routes cap their
+ * order query at 10,000 rows, so they intended to serve fifty times what they
+ * could, and any report covering more than roughly two hundred orders came
+ * back as a 500.
+ *
+ * 100 keeps a batch near 3.9KB, which leaves room for the select list and the
+ * rest of the query on the same line.
+ */
+const ID_BATCH_SIZE = 100;
+
+/**
+ * Splits ids into batches small enough for a URL.
+ *
+ * @param items - the ids to split.
+ * @param size - the maximum batch length.
+ * @returns batches in the original order, or none for an empty input.
+ */
+export function batchIds<T>(items: readonly T[], size = ID_BATCH_SIZE): T[][] {
+  const batches: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    batches.push(items.slice(index, index + size));
+  }
+  return batches;
+}
+
+/**
+ * The order lines for a set of orders, optionally narrowed to one product.
+ *
+ * @param orderIds - the orders whose lines are wanted.
+ * @param productId - a product to filter to, or null for all.
+ * @returns every matching line, across as many requests as the ids need.
+ */
+export async function fetchOrderItems(
+  orderIds: readonly string[],
+  productId: string | null,
+): Promise<OrderItemRow[]> {
+  const batches = batchIds(orderIds);
+  const responses = await Promise.all(
+    batches.map((batch) => {
+      const itemsQuery: Record<string, string> = {
+        select: ITEMS_SELECT,
+        order_id: `in.(${batch.join(",")})`,
+      };
+      if (productId) {
+        itemsQuery["product_id"] = `eq.${productId}`;
+      }
+      return adminFetch(createRestPath("order_items", itemsQuery));
+    }),
+  );
+
+  const pages = await Promise.all(
+    responses.map((response) => response.json() as Promise<OrderItemRow[]>),
+  );
+  return pages.flat();
+}
+
+/**
+ * The profiles for a set of users, keyed by id.
+ *
+ * @param userIds - the users to look up.
+ * @returns a map of id to profile; empty when no ids are given.
+ */
+export async function fetchProfileMap(
+  userIds: readonly string[],
+): Promise<Map<string, UserProfileRow>> {
+  if (userIds.length === 0) return new Map();
+
+  const responses = await Promise.all(
+    batchIds(userIds).map((batch) =>
+      adminFetch(
+        createRestPath("user_profiles", {
+          select: "id,email,display_name",
+          id: `in.(${batch.join(",")})`,
+        }),
+      ),
+    ),
+  );
+
+  const pages = await Promise.all(
+    responses.map((response) => response.json() as Promise<UserProfileRow[]>),
+  );
+  return new Map(pages.flat().map((profile) => [profile.id, profile]));
+}

--- a/apps/admin/src/app/api/admin/reports/export/route.ts
+++ b/apps/admin/src/app/api/admin/reports/export/route.ts
@@ -5,9 +5,7 @@ import { NextResponse } from "next/server";
 import {
   buildSalesWorkbook,
   CONTENT_TYPE_XLSX,
-  type OrderItemRow,
   type OrderRow,
-  type UserProfileRow,
 } from "./buildSalesWorkbook";
 
 import {
@@ -17,6 +15,11 @@ import {
   getAuthorizedAdmin,
   INTERNAL_SERVER_ERROR_STATUS,
 } from "@/app/api/admin/_shared/adminRest";
+import {
+  fetchOrderItems,
+  fetchProfileMap,
+  type OrderItemRow,
+} from "@/app/api/admin/_shared/reportsData";
 import { buildAdminOrderFilters } from "@/app/api/admin/_shared/reportsFilters";
 
 const ADMIN_REPORTS = "admin.reports";
@@ -24,35 +27,6 @@ const MAX_LIMIT = 10_000;
 const ISO_DATE_LENGTH = 10;
 const ORDERS_SELECT =
   "id,created_at,payment_status,total,currency,transfer_number,receipt_url,user_id,seller_id,buyer_info";
-const ITEMS_SELECT =
-  "id,order_id,product_id,quantity,unit_price,currency,products(name_en)";
-
-async function fetchOrderItems(
-  orderIds: string[],
-  productId: string | null,
-): Promise<OrderItemRow[]> {
-  const itemsQuery: Record<string, string> = {
-    select: ITEMS_SELECT,
-    order_id: `in.(${orderIds.join(",")})`,
-  };
-  if (productId) itemsQuery["product_id"] = `eq.${productId}`;
-  const response = await adminFetch(createRestPath("order_items", itemsQuery));
-  return response.json() as Promise<OrderItemRow[]>;
-}
-
-async function fetchProfileMap(
-  userIds: string[],
-): Promise<Map<string, UserProfileRow>> {
-  if (userIds.length === 0) return new Map();
-  const response = await adminFetch(
-    createRestPath("user_profiles", {
-      select: "id,email,display_name",
-      id: `in.(${userIds.join(",")})`,
-    }),
-  );
-  const profiles = (await response.json()) as UserProfileRow[];
-  return new Map(profiles.map((p) => [p.id, p]));
-}
 
 function buildXlsxResponse(buffer: ExcelJS.Buffer, date: string): Response {
   return new Response(buffer, {

--- a/apps/admin/src/app/api/admin/reports/orders/route.ts
+++ b/apps/admin/src/app/api/admin/reports/orders/route.ts
@@ -9,24 +9,17 @@ import {
   INTERNAL_SERVER_ERROR_STATUS,
 } from "@/app/api/admin/_shared/adminRest";
 import { signReceiptPath } from "@/app/api/admin/_shared/receiptSignedUrls";
+import {
+  fetchOrderItems,
+  fetchProfileMap,
+  type OrderItemRow,
+} from "@/app/api/admin/_shared/reportsData";
 import { buildAdminOrderFilters } from "@/app/api/admin/_shared/reportsFilters";
 
 const ADMIN_REPORTS = "admin.reports";
 const MAX_LIMIT = 10_000;
 const ORDERS_SELECT =
   "id,created_at,payment_status,total,currency,transfer_number,receipt_url,user_id,seller_id";
-const ITEMS_SELECT =
-  "id,order_id,product_id,quantity,unit_price,currency,products(name_en)";
-
-interface OrderItemRow {
-  id: string;
-  order_id: string;
-  product_id: string;
-  quantity: number;
-  unit_price: number;
-  currency: string;
-  products: { name_en: string } | null;
-}
 
 interface OrderRow {
   id: string;
@@ -38,41 +31,6 @@ interface OrderRow {
   receipt_url: string | null;
   user_id: string;
   seller_id: string | null;
-}
-
-interface UserProfileRow {
-  id: string;
-  email: string;
-  display_name: string | null;
-}
-
-async function fetchOrderItems(
-  orderIds: string[],
-  productId: string | null,
-): Promise<OrderItemRow[]> {
-  const itemsQuery: Record<string, string> = {
-    select: ITEMS_SELECT,
-    order_id: `in.(${orderIds.join(",")})`,
-  };
-  if (productId) {
-    itemsQuery["product_id"] = `eq.${productId}`;
-  }
-  const response = await adminFetch(createRestPath("order_items", itemsQuery));
-  return response.json() as Promise<OrderItemRow[]>;
-}
-
-async function fetchProfileMap(
-  userIds: string[],
-): Promise<Map<string, UserProfileRow>> {
-  if (userIds.length === 0) return new Map();
-  const response = await adminFetch(
-    createRestPath("user_profiles", {
-      select: "id,email,display_name",
-      id: `in.(${userIds.join(",")})`,
-    }),
-  );
-  const profiles = (await response.json()) as UserProfileRow[];
-  return new Map(profiles.map((p) => [p.id, p]));
 }
 
 export async function GET(request: Request) {

--- a/apps/admin/tests/adminReportsRoutes.test.ts
+++ b/apps/admin/tests/adminReportsRoutes.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("api/supabase/server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+
+const ADMIN_ID = "c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13";
+const ok = (json: unknown) =>
+  ({ ok: true, json: async () => json }) as Response;
+
+const grantRow = (key: string) => ({
+  expires_at: null,
+  mode: "grant",
+  resource_permission_id: `${key}-rp`,
+  resource_permissions: { permissions: { key } },
+});
+
+async function loadRoutes(signedIn = true) {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.test";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+  vi.resetModules();
+
+  const orders = await import("@/app/api/admin/reports/orders/route");
+  const exportRoute = await import("@/app/api/admin/reports/export/route");
+  const supabaseModule = await import("api/supabase/server");
+
+  vi.mocked(supabaseModule.createServerSupabaseClient).mockResolvedValue({
+    rpc: vi
+      .fn()
+      .mockResolvedValue({ data: signedIn ? ADMIN_ID : null, error: null }),
+  } as unknown as Awaited<
+    ReturnType<typeof supabaseModule.createServerSupabaseClient>
+  >);
+
+  return { orders: orders.GET, exportReport: exportRoute.GET };
+}
+
+const request = (qs = "") =>
+  new Request(`http://localhost/api/admin/reports/orders?${qs}`);
+
+function mockCallerPermissions(...keys: string[]) {
+  vi.mocked(fetch).mockResolvedValueOnce(ok(keys.map((k) => grantRow(k))));
+}
+
+describe("admin report routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  describe("reports/orders", () => {
+    it("refuses a caller without admin.reports", async () => {
+      const { orders } = await loadRoutes();
+      mockCallerPermissions("orders.approve");
+
+      expect((await orders(request())).status).toBe(403);
+    });
+
+    it("refuses a caller with no session", async () => {
+      const { orders } = await loadRoutes(false);
+      expect((await orders(request())).status).toBe(403);
+    });
+
+    it("returns an empty result without asking for order lines", async () => {
+      const { orders } = await loadRoutes();
+      mockCallerPermissions("admin.reports");
+      vi.mocked(fetch).mockResolvedValueOnce(ok([]));
+
+      const response = await orders(request());
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ orders: [], total: 0 });
+      // permissions + orders only: no follow-up for items or profiles.
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("passes validated filters through to the query", async () => {
+      const { orders } = await loadRoutes();
+      mockCallerPermissions("admin.reports");
+      vi.mocked(fetch).mockResolvedValueOnce(ok([]));
+
+      await orders(
+        request(
+          "dateFrom=2026-01-01&dateTo=2026-01-31&amountMin=10&amountMax=100",
+        ),
+      );
+
+      const url = String(vi.mocked(fetch).mock.calls.at(-1)?.[0]);
+      expect(url).toContain("created_at=gte.2026-01-01");
+      expect(url).toContain("total=gte.10");
+      // Both ceilings ride in ONE and= group. Emitting a group each -- the bug
+      // fixed in #405 -- makes PostgREST keep the first and silently drop the
+      // rest, which dropped the amount ceiling.
+      expect(url).toContain(
+        "and=%28created_at.lt.2026-02-01%2Ctotal.lte.100%29",
+      );
+    });
+  });
+
+  describe("reports/export", () => {
+    it("refuses a caller without admin.reports", async () => {
+      const { exportReport } = await loadRoutes();
+      mockCallerPermissions("orders.approve");
+
+      expect((await exportReport(request())).status).toBe(403);
+    });
+
+    it("returns a spreadsheet when there are no orders", async () => {
+      const { exportReport } = await loadRoutes();
+      mockCallerPermissions("admin.reports");
+      vi.mocked(fetch).mockResolvedValueOnce(ok([]));
+
+      const response = await exportReport(request());
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toContain("spreadsheet");
+      expect(response.headers.get("Content-Disposition")).toContain(".xlsx");
+    });
+  });
+});

--- a/apps/admin/tests/reportsData.test.ts
+++ b/apps/admin/tests/reportsData.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ok = (json: unknown) =>
+  ({ ok: true, json: async () => json }) as Response;
+
+async function loadModule() {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.test";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+  vi.resetModules();
+  return import("@/app/api/admin/_shared/reportsData");
+}
+
+const ids = (n: number, prefix = "id") =>
+  Array.from({ length: n }, (_, i) => `${prefix}-${i}`);
+
+/** Every URL the module handed to fetch. */
+const urls = () => vi.mocked(fetch).mock.calls.map((c) => String(c[0]));
+
+describe("reports data fetching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  describe("batchIds", () => {
+    it("returns nothing for an empty list", async () => {
+      const { batchIds } = await loadModule();
+      expect(batchIds([])).toEqual([]);
+    });
+
+    it("keeps a short list in one batch", async () => {
+      const { batchIds } = await loadModule();
+      expect(batchIds(ids(10))).toHaveLength(1);
+    });
+
+    it("splits at the batch size and preserves order", async () => {
+      const { batchIds } = await loadModule();
+      const batches = batchIds(ids(250));
+
+      expect(batches).toHaveLength(3);
+      expect(batches[0]).toHaveLength(100);
+      expect(batches[2]).toHaveLength(50);
+      expect(batches.flat()).toEqual(ids(250));
+    });
+  });
+
+  // The reports asked for every order's lines in one `in.(...)`, so the URL
+  // grew 37 bytes per order. Measured against this project's own stack: 200
+  // ids is 7,466 bytes and answers 200; 250 ids is 9,316 bytes and answers
+  // 414 URI Too Long. Both routes cap the order query at 10,000 rows.
+  describe("fetchOrderItems", () => {
+    it("uses one request for a small set of orders", async () => {
+      const { fetchOrderItems } = await loadModule();
+      vi.mocked(fetch).mockResolvedValue(ok([]));
+
+      await fetchOrderItems(ids(100), null);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("splits a set too long for one URL, and merges the results", async () => {
+      const { fetchOrderItems } = await loadModule();
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(ok([{ id: "a" }]))
+        .mockResolvedValueOnce(ok([{ id: "b" }]))
+        .mockResolvedValueOnce(ok([{ id: "c" }]));
+
+      const items = await fetchOrderItems(ids(250), null);
+
+      expect(fetch).toHaveBeenCalledTimes(3);
+      expect(items.map((i) => i.id)).toEqual(["a", "b", "c"]);
+    });
+
+    it("keeps every batch well under the length that returned 414", async () => {
+      const { fetchOrderItems } = await loadModule();
+      vi.mocked(fetch).mockResolvedValue(ok([]));
+
+      // Real uuids, so the measured byte counts apply.
+      const uuids = Array.from(
+        { length: 500 },
+        (_, i) => `a0eebc99-9c0b-4ef8-bb6d-${String(i).padStart(12, "0")}`,
+      );
+      await fetchOrderItems(uuids, null);
+
+      for (const url of urls()) {
+        expect(url.length).toBeLessThan(7466);
+      }
+    });
+
+    it("applies the product filter to every batch", async () => {
+      const { fetchOrderItems } = await loadModule();
+      vi.mocked(fetch).mockResolvedValue(ok([]));
+
+      await fetchOrderItems(ids(250), "product-1");
+
+      expect(urls()).toHaveLength(3);
+      for (const url of urls()) {
+        expect(url).toContain("product_id=eq.product-1");
+      }
+    });
+  });
+
+  describe("fetchProfileMap", () => {
+    it("makes no request for an empty list", async () => {
+      const { fetchProfileMap } = await loadModule();
+      const map = await fetchProfileMap([]);
+
+      expect(map.size).toBe(0);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("splits and merges into one map keyed by id", async () => {
+      const { fetchProfileMap } = await loadModule();
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(
+          ok([{ id: "u1", email: "a@b.c", display_name: null }]),
+        )
+        .mockResolvedValueOnce(
+          ok([{ id: "u2", email: "d@e.f", display_name: "Dee" }]),
+        );
+
+      const map = await fetchProfileMap(ids(150));
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(map.size).toBe(2);
+      expect(map.get("u2")?.display_name).toBe("Dee");
+    });
+  });
+});

--- a/tests/INVENTORY.md
+++ b/tests/INVENTORY.md
@@ -6,12 +6,12 @@ Every test case in the repo, so a refactor can be checked for losses:
 regenerate and diff. Counting files or totals is not enough -- a rework
 can keep both and still drop the one assertion that mattered.
 
-**2718 cases across 375 files** (0 skipped, 9 parameterised).
+**2733 cases across 377 files** (0 skipped, 9 parameterised).
 
 Source-level cases: a `.each` case is one entry here and many in vitest
 output, so this total is deliberately not the runner total.
 
-## app:admin -- 547 cases
+## app:admin -- 562 cases
 
 ### `apps/admin/tests/ActivityRow.test.tsx`
 
@@ -21,6 +21,15 @@ output, so this total is deliberately not the runner total.
 - ActivityRow > renders the time
 - ActivityRow > renders UPDATE action
 - ActivityRow > renders DELETE action
+
+### `apps/admin/tests/adminReportsRoutes.test.ts`
+
+- admin report routes > reports/orders > refuses a caller without admin.reports
+- admin report routes > reports/orders > refuses a caller with no session
+- admin report routes > reports/orders > returns an empty result without asking for order lines
+- admin report routes > reports/orders > passes validated filters through to the query
+- admin report routes > reports/export > refuses a caller without admin.reports
+- admin report routes > reports/export > returns a spreadsheet when there are no orders
 
 ### `apps/admin/tests/AdminSidebar.test.tsx`
 
@@ -330,6 +339,18 @@ output, so this total is deliberately not the runner total.
 - fetchReportOrders > returns parsed JSON on success
 - fetchReportOrders > throws when response is not ok
 - fetchReportOrders > builds URL with ? separator when query string is non-empty
+
+### `apps/admin/tests/reportsData.test.ts`
+
+- reports data fetching > batchIds > returns nothing for an empty list
+- reports data fetching > batchIds > keeps a short list in one batch
+- reports data fetching > batchIds > splits at the batch size and preserves order
+- reports data fetching > fetchOrderItems > uses one request for a small set of orders
+- reports data fetching > fetchOrderItems > splits a set too long for one URL, and merges the results
+- reports data fetching > fetchOrderItems > keeps every batch well under the length that returned 414
+- reports data fetching > fetchOrderItems > applies the product filter to every batch
+- reports data fetching > fetchProfileMap > makes no request for an empty list
+- reports data fetching > fetchProfileMap > splits and merges into one map keyed by id
 
 ### `apps/admin/tests/reportsFilters.test.ts`
 


### PR DESCRIPTION
Both report routes fetched every order's lines in **one** request, putting all the order ids in a single `in.(...)` filter. Each uuid adds 37 bytes to the URL, so the query grew with the result set until the gateway refused it.

## Measured, not guessed

Against this project's own running stack:

| ids | URL bytes | response |
| ---: | ---: | --- |
| 200 | 7,466 | `200` |
| **250** | **9,316** | **`414 URI Too Long`** |

Both routes cap the order query at `MAX_LIMIT = 10_000`, so they were written to serve **fifty times** what they could deliver. Any report covering more than roughly two hundred orders came back as 500 *"Failed to load orders"* / *"Failed to generate sales report"*.

It needs real data to appear, which is why it was still here.

## Fix

Ids go in batches of 100 — about 3.9KB, leaving room for the select list on the same line — and the pages are merged. The same applied to the buyer/seller profile lookup, which grew the same way.

`fetchOrderItems` and `fetchProfileMap` were **duplicated across the two routes**, identical but for brace style, along with the `OrderItemRow` and `UserProfileRow` types. They now live in `_shared/reportsData.ts`, so the fix landed once instead of twice.

## Tests — these routes' first

**Nine** cover the batching directly, including one asserting every emitted URL stays under the 7,466 bytes that still answered 200.

**Six** cover the routes: both require `admin.reports`, a caller with no session is refused, an empty result skips the follow-up queries entirely, and a date + amount range still reaches the query as the single `and=` group #405 established.

**Verified load-bearing**: raising the batch size to 100,000 — the old single-request behaviour — fails five of the nine.

## One of my tests was wrong and the code was right

I asserted `amountMax` alone should land in the `and=` group. It shouldn't: without `amountMin` it becomes `total=lte.100` directly, and the group is only needed when a column already has a filter. Corrected to pass both bounds, which is what actually exercises #405.

## Verification

`lint` · `typecheck` · `format:check` · `knip` · `check:doc-refs` · `test` · `test:workflows` · `check-doc-freshness` · `test-inventory-diff` · `check-feature-boundaries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt