### PR TITLE
fix(payments): the receipt upload actions authorized nobody [GH-000]

### DIFF
--- a/apps/payments/src/shared/infrastructure/receiptActions.ts
+++ b/apps/payments/src/shared/infrastructure/receiptActions.ts
@@ -2,6 +2,9 @@
 
 /* eslint-disable i18next/no-literal-string -- server action: Supabase env var names and storage paths are not user-facing */
 
+import { getCurrentUserId } from "api/supabase";
+import { createServerSupabaseClient } from "api/supabase/server";
+
 import { RECEIPTS_BUCKET } from "@/shared/domain/constants";
 import {
   sanitizeReceiptFilename,
@@ -57,15 +60,49 @@ async function uploadToStorage(storagePath: string, file: File): Promise<void> {
 }
 
 /**
+ * The signed-in user, or null.
+ *
+ * A server action is a public POST endpoint: Next.js routes it by a generated
+ * id and authenticates nothing. These two upload with the service role key,
+ * which bypasses the storage policies, so without this anybody who could reach
+ * the app could write into the receipts bucket. The checkout route these
+ * actions belong to already demands a session plus orders.create and
+ * receipts.create; the upload beside it demanded nothing.
+ *
+ * @returns the caller's user id, or null when there is no session.
+ */
+async function getCallerId(): Promise<string | null> {
+  try {
+    return await getCurrentUserId(await createServerSupabaseClient());
+  } catch (error) {
+    console.error(
+      "[receiptActions] could not resolve the caller:",
+      error instanceof Error ? error.message : String(error),
+    );
+    return null;
+  }
+}
+
+/**
  * Upload a receipt during checkout.
- * Returns a typed result instead of throwing so callers can map error codes
- * to user-facing messages. (Next.js server action errors are replaced with a
- * generic message in production, hiding the real cause from users.)
+ *
+ * Requires a session. Returns a typed result instead of throwing so callers
+ * can map error codes to user-facing messages. (Next.js server action errors
+ * are replaced with a generic message in production, hiding the real cause
+ * from users.) An unauthenticated call comes back as `upload_failed` rather
+ * than a code of its own, so a caller learns nothing about what exists.
  */
 export async function uploadCheckoutReceipt(
   checkoutSessionId: string,
   file: File,
 ): Promise<ReceiptUploadResult> {
+  // The session id is chosen by the client before any order exists, so there
+  // is nothing to check it against yet; a session is the bar this can hold.
+  if (!(await getCallerId())) {
+    console.error("[receiptActions] uploadCheckoutReceipt: no session");
+    return { ok: false, code: "upload_failed" };
+  }
+
   const validation = validateReceiptFile(file);
   if (!validation.isValid) {
     return {
@@ -93,21 +130,37 @@ export async function uploadCheckoutReceipt(
 
 /**
  * Upload a receipt when resubmitting evidence for an existing order.
- * Looks up the order's checkoutSessionId so the receipt is stored under
- * the checkout session prefix, keeping `is_receipt_delegate` working.
+ *
+ * Looks up the order's checkoutSessionId so the receipt is stored under the
+ * checkout session prefix, keeping `is_receipt_delegate` working -- and looks
+ * it up **scoped to the caller**, so an order id alone no longer opens another
+ * buyer's prefix for writing. An order that is not theirs is indistinguishable
+ * from one that does not exist.
  */
 export async function uploadOrderReceipt(
   orderId: string,
   file: File,
 ): Promise<ReceiptUploadResult> {
+  const callerId = await getCallerId();
+  if (!callerId) {
+    console.error("[receiptActions] uploadOrderReceipt: no session");
+    return { ok: false, code: "upload_failed" };
+  }
+
+  // Scoped to the caller's own order. This is the buyer resubmitting evidence
+  // from their orders page; delegates read receipts through
+  // is_receipt_delegate, they do not upload. Without the scope the order id
+  // alone was enough to write into any order's prefix.
   const rows = await adminFetchJson<
     Array<{ checkout_session_id: string | null }>
-  >(`orders?id=eq.${encodeURIComponent(orderId)}&select=checkout_session_id`);
+  >(
+    `orders?id=eq.${encodeURIComponent(orderId)}&user_id=eq.${encodeURIComponent(callerId)}&select=checkout_session_id`,
+  );
 
   const checkoutSessionId = rows[0]?.checkout_session_id;
   if (!checkoutSessionId) {
     console.error(
-      `[receiptActions] order ${orderId} missing checkout_session_id`,
+      `[receiptActions] order ${orderId} is not the caller's, or has no checkout_session_id`,
     );
     return { ok: false, code: "upload_failed" };
   }

--- a/apps/payments/tests/receiptActions.test.ts
+++ b/apps/payments/tests/receiptActions.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("api/supabase/server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+
+const USER_ID = "c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13";
+const OTHER_ORDER = "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12";
+const SESSION_ID = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+
+const ok = (json: unknown) =>
+  ({ ok: true, json: async () => json }) as Response;
+
+/** A receipt the validator accepts. */
+const receipt = () =>
+  new File([new Uint8Array([1, 2, 3])], "proof.png", { type: "image/png" });
+
+async function loadActions(signedIn = true) {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.test";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+  vi.resetModules();
+
+  const actions = await import("@/shared/infrastructure/receiptActions");
+  const supabaseModule = await import("api/supabase/server");
+
+  vi.mocked(supabaseModule.createServerSupabaseClient).mockResolvedValue({
+    rpc: vi
+      .fn()
+      .mockResolvedValue({ data: signedIn ? USER_ID : null, error: null }),
+  } as unknown as Awaited<
+    ReturnType<typeof supabaseModule.createServerSupabaseClient>
+  >);
+
+  return actions;
+}
+
+const lastUrl = () => String(vi.mocked(fetch).mock.calls.at(-1)?.[0]);
+
+describe("receipt upload actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  // A server action is a public POST endpoint that Next.js authenticates for
+  // nobody, and these upload with the service role key, which bypasses the
+  // storage policies.
+  describe("uploadCheckoutReceipt", () => {
+    it("refuses a caller with no session, before touching storage", async () => {
+      const { uploadCheckoutReceipt } = await loadActions(false);
+
+      const result = await uploadCheckoutReceipt(SESSION_ID, receipt());
+
+      expect(result).toEqual({ ok: false, code: "upload_failed" });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("uploads for a signed-in caller", async () => {
+      const { uploadCheckoutReceipt } = await loadActions();
+      vi.mocked(fetch).mockResolvedValueOnce(ok({}));
+
+      const result = await uploadCheckoutReceipt(SESSION_ID, receipt());
+
+      expect(result.ok).toBe(true);
+      expect(lastUrl()).toContain(`/receipts/${SESSION_ID}/`);
+    });
+
+    it("rejects a file of the wrong type without uploading", async () => {
+      const { uploadCheckoutReceipt } = await loadActions();
+
+      const result = await uploadCheckoutReceipt(
+        SESSION_ID,
+        new File(["x"], "notes.exe", { type: "application/x-msdownload" }),
+      );
+
+      expect(result).toEqual({ ok: false, code: "invalid_receipt_type" });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("reports a storage failure as upload_failed", async () => {
+      const { uploadCheckoutReceipt } = await loadActions();
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => "boom",
+      } as Response);
+
+      const result = await uploadCheckoutReceipt(SESSION_ID, receipt());
+      expect(result).toEqual({ ok: false, code: "upload_failed" });
+    });
+  });
+
+  describe("uploadOrderReceipt", () => {
+    it("refuses a caller with no session", async () => {
+      const { uploadOrderReceipt } = await loadActions(false);
+
+      const result = await uploadOrderReceipt(OTHER_ORDER, receipt());
+
+      expect(result).toEqual({ ok: false, code: "upload_failed" });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    // The order id alone used to be enough to write into any order's prefix.
+    it("scopes the order lookup to the caller", async () => {
+      const { uploadOrderReceipt } = await loadActions();
+      vi.mocked(fetch).mockResolvedValueOnce(ok([]));
+
+      await uploadOrderReceipt(OTHER_ORDER, receipt());
+
+      const url = String(vi.mocked(fetch).mock.calls[0]?.[0]);
+      expect(url).toContain(`id=eq.${OTHER_ORDER}`);
+      expect(url).toContain(`user_id=eq.${USER_ID}`);
+    });
+
+    it("refuses an order that is not the caller's", async () => {
+      const { uploadOrderReceipt } = await loadActions();
+      vi.mocked(fetch).mockResolvedValueOnce(ok([]));
+
+      const result = await uploadOrderReceipt(OTHER_ORDER, receipt());
+
+      expect(result).toEqual({ ok: false, code: "upload_failed" });
+      // The lookup happened; the upload did not.
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("uploads under the order's checkout session", async () => {
+      const { uploadOrderReceipt } = await loadActions();
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(ok([{ checkout_session_id: SESSION_ID }]))
+        .mockResolvedValueOnce(ok({}));
+
+      const result = await uploadOrderReceipt(OTHER_ORDER, receipt());
+
+      expect(result.ok).toBe(true);
+      expect(lastUrl()).toContain(`/receipts/${SESSION_ID}/`);
+    });
+  });
+});

--- a/apps/payments/tests/receiptActions.test.ts
+++ b/apps/payments/tests/receiptActions.test.ts
@@ -70,7 +70,7 @@ describe("receipt upload actions", () => {
 
       const result = await uploadCheckoutReceipt(
         SESSION_ID,
-        new File(["x"], "notes.exe", { type: "application/x-msdownload" }),
+        new File(["x"], "notes.txt", { type: "text/plain" }),
       );
 
       expect(result).toEqual({ ok: false, code: "invalid_receipt_type" });

--- a/tests/INVENTORY.md
+++ b/tests/INVENTORY.md
@@ -6,7 +6,7 @@ Every test case in the repo, so a refactor can be checked for losses:
 regenerate and diff. Counting files or totals is not enough -- a rework
 can keep both and still drop the one assertion that mattered.
 
-**2741 cases across 378 files** (0 skipped, 9 parameterised).
+**2749 cases across 379 files** (0 skipped, 9 parameterised).
 
 Source-level cases: a `.each` case is one entry here and many in vitest
 output, so this total is deliberately not the runner total.
@@ -962,7 +962,7 @@ output, so this total is deliberately not the runner total.
 - TermsPage > renders a last-updated line
 - TermsPage > renders all 10 section headings
 
-## app:payments -- 565 cases
+## app:payments -- 573 cases
 
 ### `apps/payments/tests/ActionButtons.test.tsx`
 
@@ -1372,6 +1372,17 @@ output, so this total is deliberately not the runner total.
 - receipt helpers > toSafeStoragePath returns reconstructed path for valid input
 - receipt helpers > toSafeStoragePath throws for path traversal
 - receipt helpers > only allows safe receipt hrefs
+
+### `apps/payments/tests/receiptActions.test.ts`
+
+- receipt upload actions > uploadCheckoutReceipt > refuses a caller with no session, before touching storage
+- receipt upload actions > uploadCheckoutReceipt > uploads for a signed-in caller
+- receipt upload actions > uploadCheckoutReceipt > rejects a file of the wrong type without uploading
+- receipt upload actions > uploadCheckoutReceipt > reports a storage failure as upload_failed
+- receipt upload actions > uploadOrderReceipt > refuses a caller with no session
+- receipt upload actions > uploadOrderReceipt > scopes the order lookup to the caller
+- receipt upload actions > uploadOrderReceipt > refuses an order that is not the caller's
+- receipt upload actions > uploadOrderReceipt > uploads under the order's checkout session
 
 ### `apps/payments/tests/receiptStorage.test.ts`
 


### PR DESCRIPTION
`uploadCheckoutReceipt` and `uploadOrderReceipt` are **server actions**. Next.js routes those by a generated id and authenticates nothing — they are public POST endpoints — and both upload with `SUPABASE_SERVICE_ROLE_KEY`, which **bypasses the storage policies** on the receipts bucket.

Neither read a session. The file had no auth import at all.

The checkout route beside them, in the same flow, requires a signed-in user holding `orders.create` **and** `receipts.create` before it will even name a payment method. The upload next to it required nothing.

## `uploadOrderReceipt` was the sharper half

It took an order id, looked that order up **with the admin key**, and uploaded into its checkout-session prefix. The id alone was enough to write into any buyer's prefix.

The lookup is now scoped to the caller's own orders, so an order that isn't theirs is indistinguishable from one that doesn't exist. That flow is the buyer resubmitting evidence from their orders page; delegates *read* receipts through `is_receipt_delegate`, they don't upload — so the scope narrows nothing that worked.

## `uploadCheckoutReceipt` now requires a session

It can't do better. The checkout session id is chosen by the client *before any order exists*, so there's nothing yet to check it against. A session is the bar available at that point.

An unauthenticated call returns `upload_failed` rather than a code of its own — the caller learns nothing about what exists, and the result type is unchanged for the hooks that map codes to messages.

## How it was found

By asking what server-side surfaces had no tests once the API routes were done. Both existing test files that mention this module **mock** it, so the real one had never executed in a test.

## Verification

Eight tests. **Verified load-bearing**: removing the two guards and the ownership scope fails exactly the three cases that encode them.

`lint` · `typecheck` · `format:check` · `knip` · `check:doc-refs` · `test` · `test:workflows` · `check-doc-freshness` · `test-inventory-diff` · `check-feature-boundaries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt