### PR TITLE
fix(ci): three diff gates asked the wrong question on a release PR [GH-000]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,16 @@ jobs:
       # Needs the base branch present, hence fetch-depth: 0 is required on the
       # checkout above for this job.
       - name: Check no applied migration was edited
+        # Skipped on a release PR. These three compare the head against the
+        # PR's base, which is the right question for a feature branch and the
+        # wrong one for `develop` -> `main`: the base is the last release, so
+        # the diff is every change since it, and each of those changes already
+        # answered this check when it merged to develop. Asking again at
+        # release time re-reports settled work -- the v2026.09.05.1 release PR
+        # failed on the migration squash that #386 had already justified and
+        # merged. Skipping is stated in the log; pointing the check at develop
+        # instead would pass vacuously, since develop IS the head.
+        if: github.base_ref != 'main'
         run: node scripts/check-migration-edits.mjs "origin/${{ github.base_ref || 'develop' }}"
 
       # These ran in no workflow — only in the husky precommit hook, which any
@@ -243,6 +253,16 @@ jobs:
       # one: the way past it is to touch the doc, so under the gate authors do,
       # and the rate falls toward zero. Needs fetch-depth: 0, above.
       - name: Check documentation moved with the code
+        # Skipped on a release PR. These three compare the head against the
+        # PR's base, which is the right question for a feature branch and the
+        # wrong one for `develop` -> `main`: the base is the last release, so
+        # the diff is every change since it, and each of those changes already
+        # answered this check when it merged to develop. Asking again at
+        # release time re-reports settled work -- the v2026.09.05.1 release PR
+        # failed on the migration squash that #386 had already justified and
+        # merged. Skipping is stated in the log; pointing the check at develop
+        # instead would pass vacuously, since develop IS the head.
+        if: github.base_ref != 'main'
         run: node scripts/check-doc-freshness.mjs "origin/${{ github.base_ref || 'develop' }}"
 
       # The fourth gate in this series found running in no workflow and no hook.
@@ -258,6 +278,16 @@ jobs:
       # which is how a real loss gets buried -- only regenerate after checking
       # each reported name against the live tree, and say what you checked.
       - name: Check no test case was dropped
+        # Skipped on a release PR. These three compare the head against the
+        # PR's base, which is the right question for a feature branch and the
+        # wrong one for `develop` -> `main`: the base is the last release, so
+        # the diff is every change since it, and each of those changes already
+        # answered this check when it merged to develop. Asking again at
+        # release time re-reports settled work -- the v2026.09.05.1 release PR
+        # failed on the migration squash that #386 had already justified and
+        # merged. Skipping is stated in the log; pointing the check at develop
+        # instead would pass vacuously, since develop IS the head.
+        if: github.base_ref != 'main'
         run: bash scripts/test-inventory-diff.sh "origin/${{ github.base_ref || 'develop' }}"
 
       - name: Lint (scoped)

--- a/docs/standards/quality-gates.md
+++ b/docs/standards/quality-gates.md
@@ -789,6 +789,28 @@ secrets remain valid there. See
 
 ---
 
+## Three gates that ask the wrong question on a release PR
+
+`check-migration-edits`, `check-doc-freshness` and `test-inventory-diff` all
+compare the head against the **PR's base**. For a feature branch that is
+exactly right. For `develop` → `main` it is exactly wrong: the base is the last
+release, so the diff is everything merged since it, and each of those changes
+already answered the check when it went into `develop`.
+
+The v2026.09.05.1 release PR is where this surfaced. `check-migration-edits`
+failed on thirteen deleted migration files — the squash into
+`20260902120000_baseline.sql`, which had been justified, reviewed and merged
+weeks earlier. The gate was not wrong about what it saw; it was answering a
+question that had already been settled, and answering it as though it were new.
+
+All three now skip when `github.base_ref` is `main`. Pointing them at `develop`
+instead would have been worse: on a release PR `develop` **is** the head, so
+every one of them would pass while comparing a branch to itself — a vacuous
+pass, which is the failure this whole document is about. A skip says so in the
+log.
+
+---
+
 ## Instructions that point at things that are not there
 
 `.claude/**` and `CLAUDE.md` are loaded into every session. A wrong instruction


### PR DESCRIPTION
`check-migration-edits`, `check-doc-freshness` and `test-inventory-diff` compare the head against the **PR's base**. For a feature branch that's right. For `develop` → `main` it isn't: the base is the *last release*, so the diff is everything merged since it — and each of those changes already answered the check when it went into `develop`.

## Where it surfaced

The `v2026.09.05.1` release PR (#410) failed Quality Checks on **thirteen deleted migration files** — the squash into `20260902120000_baseline.sql`, which was justified, reviewed and merged weeks earlier.

The gate wasn't wrong about what it saw. It was answering a settled question as though it were new.

## Why skip rather than retarget

All three now skip when `github.base_ref` is `main`.

Pointing them at `develop` instead would have been **worse**: on a release PR `develop` *is* the head, so all three would pass while comparing a branch to itself. That's a vacuous pass — the exact failure this repo has spent a dozen commits removing. A skip is visible in the log; a comparison against itself is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBKSx44EDre8dgQQFJJrRt