### PR TITLE
feat(scripts): kebab-case filename codemod [GH-000]

### DIFF
--- a/docs/superpowers/plans/2026-09-06-kebab-migration.md
+++ b/docs/superpowers/plans/2026-09-06-kebab-migration.md
@@ -30,10 +30,10 @@
   specifiers, pass 3 rewrites them); nothing manual is required, but do not assume
   `pnpm typecheck` alone would have caught it on Windows.
 - Zero `.stories.tsx` and zero `.module.css` files repo-wide, so no sibling file must rename in lockstep.
-- The CLI refuses to run against a dirty working tree (non-zero exit). Pass 2 performs
+- The CLI refuses to apply against a dirty working tree (non-zero exit). Pass 2 performs
   irreversible `git mv` calls before the first `saveSync`, so `git checkout` is the only
-  recovery from a mid-run failure — it must be a complete undo. Commit or stash first,
-  including before a `--dry-run`.
+  recovery from a mid-run failure — it must be a complete undo. Commit or stash first.
+  `--dry-run` writes nothing, so it warns about a dirty tree and continues.
 - Enforcement must not be switched on until every workspace is migrated, or CI reddens for the duration.
 - Identifier casing (variables, functions, constants, enum-like objects) is **out of scope**. Only file names change.
 

--- a/docs/superpowers/plans/2026-09-06-kebab-migration.md
+++ b/docs/superpowers/plans/2026-09-06-kebab-migration.md
@@ -1,0 +1,1081 @@
+# Kebab-case File Naming Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename all 694 non-kebab-case TypeScript files in libra to kebab-case, rewriting every import, and turn on three layers of enforcement so the convention cannot drift again.
+
+**Architecture:** A purpose-built codemod in `scripts/` does the work in three separable pieces — a pure `toKebab` string function, a rename-plan builder that also detects collisions, and a `ts-morph` engine that performs the moves while rewriting import specifiers across the module graph. The codemod runs one workspace at a time, producing eleven reviewable pull requests, and enforcement lands in a twelfth once every workspace is compliant.
+
+**Tech Stack:** Node 24, pnpm 10.32.1, ts-morph (new devDependency), vitest (`vitest.config.scripts.js`), ESLint 9 flat config with `eslint-plugin-unicorn`, `@ls-lint/ls-lint`.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-kebab-migration-design.md`
+**Decision record:** `../../../orrery/docs/decisions/0001-file-naming.md`
+**Parent design:** `../../../orrery/docs/specs/2026-09-06-orrery-design.md`
+
+## Global Constraints
+
+- Node `>=24` (`.nvmrc` pins `24`); pnpm `10.32.1`.
+- Scripts in `scripts/` are ESM `.mjs`. Their tests live in `scripts/__tests__/*.test.mjs` and run under `vitest.config.scripts.js` via `pnpm test:workflows`.
+- `forceConsistentCasingInFileNames: true` is already set in `tsconfig.base.json`. It is the migration's safety net: any import left at an old casing fails `pnpm typecheck`.
+- `git config core.ignorecase` is `true` in this repository. Case-only renames must go through a temporary filename.
+- The kebab conversion **must split acronym boundaries**: `MSWProvider` → `msw-provider`, `useAIData` → `use-ai-data`, `graphqlFetch` → `graphql-fetch`, `AIOptimization` → `ai-optimization`.
+- Verified 2026-09-06 across all 1,067 `.ts`/`.tsx` files in `apps/*/{src,tests,test,e2e}` and `packages/*/{src,tests}`: **zero collisions** after conversion. No manual disambiguation is required.
+- Verified 2026-09-06: **exactly one** true case-only rename exists — `apps/admin/src/features/users/presentation/components/Pagination.tsx`.
+- Zero `.stories.tsx` and zero `.module.css` files repo-wide, so no sibling file must rename in lockstep.
+- Enforcement must not be switched on until every workspace is migrated, or CI reddens for the duration.
+- Identifier casing (variables, functions, constants, enum-like objects) is **out of scope**. Only file names change.
+
+## Scope
+
+| Location | Files | To rename |
+|---|---|---|
+| `apps/*/src`, `packages/*/src` | 677 | 396 |
+| `apps/*/tests`, `apps/*/test`, `packages/*/tests`, `apps/*/e2e` | 390 | 298 |
+| **Total** | **1,067** | **694** |
+
+---
+
+### Task 1: Rename-plan builder (pure logic, no filesystem writes)
+
+Produces the analysis layer: what would be renamed, and whether anything collides. Dependency-free and fully unit-testable, so the risky part (Task 3) can be reviewed against a known-good plan.
+
+**Files:**
+- Create: `scripts/lib/kebab-rename-plan.mjs`
+- Test: `scripts/__tests__/kebab-rename-plan.test.mjs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `toKebab(stem: string) => string`
+  - `buildRenamePlan(files: string[]) => { plan: Array<{from: string, to: string, caseOnly: boolean}>, collisions: Array<{target: string, sources: string[]}> }`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// scripts/__tests__/kebab-rename-plan.test.mjs
+import { describe, it, expect } from "vitest";
+import { toKebab, buildRenamePlan } from "../lib/kebab-rename-plan.mjs";
+
+describe("toKebab", () => {
+  it("splits camelCase", () => {
+    expect(toKebab("loginForm")).toBe("login-form");
+  });
+
+  it("splits PascalCase", () => {
+    expect(toKebab("LoginForm")).toBe("login-form");
+  });
+
+  it("splits acronym boundaries", () => {
+    expect(toKebab("MSWProvider")).toBe("msw-provider");
+    expect(toKebab("useAIData")).toBe("use-ai-data");
+    expect(toKebab("AIOptimization")).toBe("ai-optimization");
+  });
+
+  it("handles lowercase acronyms already joined", () => {
+    expect(toKebab("graphqlFetch")).toBe("graphql-fetch");
+    expect(toKebab("currentUserId")).toBe("current-user-id");
+  });
+
+  it("splits before a capital that follows a digit", () => {
+    expect(toKebab("h2Heading")).toBe("h2-heading");
+  });
+
+  it("leaves already-kebab and single-word names alone", () => {
+    expect(toKebab("already-kebab")).toBe("already-kebab");
+    expect(toKebab("utils")).toBe("utils");
+  });
+
+  it("lowercases a single-word PascalCase name", () => {
+    expect(toKebab("Pagination")).toBe("pagination");
+  });
+});
+
+describe("buildRenamePlan", () => {
+  it("preserves compound extensions", () => {
+    const { plan } = buildRenamePlan(["src/LoginForm.test.tsx"]);
+    expect(plan).toEqual([
+      { from: "src/LoginForm.test.tsx", to: "src/login-form.test.tsx", caseOnly: false },
+    ]);
+  });
+
+  it("omits files that are already compliant", () => {
+    const { plan } = buildRenamePlan(["src/login-form.tsx", "src/utils.ts"]);
+    expect(plan).toEqual([]);
+  });
+
+  it("flags a case-only rename", () => {
+    const { plan } = buildRenamePlan(["src/Pagination.tsx"]);
+    expect(plan[0]).toEqual({
+      from: "src/Pagination.tsx",
+      to: "src/pagination.tsx",
+      caseOnly: true,
+    });
+  });
+
+  it("does not flag an acronym rename as case-only", () => {
+    const { plan } = buildRenamePlan(["src/MSWProvider.tsx"]);
+    expect(plan[0].to).toBe("src/msw-provider.tsx");
+    expect(plan[0].caseOnly).toBe(false);
+  });
+
+  it("reports collisions instead of silently overwriting", () => {
+    const { collisions } = buildRenamePlan(["src/userApi.ts", "src/UserAPI.ts"]);
+    expect(collisions).toEqual([
+      { target: "src/user-api.ts", sources: ["src/userApi.ts", "src/UserAPI.ts"] },
+    ]);
+  });
+
+  it("reports no collisions when targets are distinct", () => {
+    const { collisions } = buildRenamePlan(["src/userApi.ts", "src/userDb.ts"]);
+    expect(collisions).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run -c vitest.config.scripts.js scripts/__tests__/kebab-rename-plan.test.mjs`
+Expected: FAIL — `Failed to load ../lib/kebab-rename-plan.mjs`
+
+- [ ] **Step 3: Write the implementation**
+
+```javascript
+// scripts/lib/kebab-rename-plan.mjs
+import path from "node:path";
+
+/**
+ * Convert a filename stem to kebab-case.
+ *
+ * Two passes are needed. The first splits a lowercase-or-digit followed by an
+ * uppercase letter (`loginForm` -> `login-Form`). The second splits a run of
+ * capitals followed by a capital-then-lowercase, which is what separates an
+ * acronym from the word after it (`MSWProvider` -> `MSW-Provider`). Without
+ * the second pass, `MSWProvider` would collapse to `mswprovider`.
+ */
+export function toKebab(stem) {
+  return stem
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+    .toLowerCase();
+}
+
+/**
+ * Split a basename into its stem and the whole remaining suffix, so compound
+ * extensions survive: `LoginForm.test.tsx` -> `LoginForm` + `.test.tsx`.
+ * The search starts at index 1 so a leading dot is never treated as the
+ * separator.
+ */
+function splitBasename(base) {
+  const dot = base.indexOf(".", 1);
+  return dot === -1 ? [base, ""] : [base.slice(0, dot), base.slice(dot)];
+}
+
+export function buildRenamePlan(files) {
+  const plan = [];
+  const byTarget = new Map();
+
+  for (const file of files) {
+    const dir = path.dirname(file);
+    const [stem, suffix] = splitBasename(path.basename(file));
+    const target = path.posix.join(dir, toKebab(stem) + suffix);
+
+    byTarget.set(target, [...(byTarget.get(target) ?? []), file]);
+
+    if (target !== file) {
+      plan.push({
+        from: file,
+        to: target,
+        caseOnly: target.toLowerCase() === file.toLowerCase(),
+      });
+    }
+  }
+
+  const collisions = [...byTarget]
+    .filter(([, sources]) => sources.length > 1)
+    .map(([target, sources]) => ({ target, sources }));
+
+  return { plan, collisions };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run -c vitest.config.scripts.js scripts/__tests__/kebab-rename-plan.test.mjs`
+Expected: PASS — 13 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/kebab-rename-plan.mjs scripts/__tests__/kebab-rename-plan.test.mjs
+git commit -m "feat(scripts): add kebab rename-plan builder with collision detection"
+```
+
+---
+
+### Task 2: Dynamic-import auditor
+
+Eleven `import()` call sites exist in the repository. ts-morph rewrites static string specifiers reliably and computed ones not at all, so those must be found and reported before any file moves.
+
+**Files:**
+- Create: `scripts/lib/dynamic-import-audit.mjs`
+- Test: `scripts/__tests__/dynamic-import-audit.test.mjs`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `auditDynamicImports(project: Project) => Array<{file: string, line: number, text: string, static: boolean}>` — takes a ts-morph `Project`, returns every `import()` call with whether its specifier is a plain string literal.
+
+- [ ] **Step 1: Add ts-morph as a devDependency**
+
+```bash
+pnpm add -Dw ts-morph
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```javascript
+// scripts/__tests__/dynamic-import-audit.test.mjs
+import { describe, it, expect } from "vitest";
+import { Project } from "ts-morph";
+import { auditDynamicImports } from "../lib/dynamic-import-audit.mjs";
+
+function projectWith(source) {
+  const project = new Project({ useInMemoryFileSystem: true });
+  project.createSourceFile("a.ts", source);
+  return project;
+}
+
+describe("auditDynamicImports", () => {
+  it("marks a string-literal specifier as static", () => {
+    const found = auditDynamicImports(projectWith(`const m = import("./login-form");`));
+    expect(found).toHaveLength(1);
+    expect(found[0].static).toBe(true);
+  });
+
+  it("marks a template-literal specifier as not static", () => {
+    const found = auditDynamicImports(
+      projectWith("const n = 'x';\nconst m = import(`./${n}`);")
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].static).toBe(false);
+  });
+
+  it("marks an identifier specifier as not static", () => {
+    const found = auditDynamicImports(
+      projectWith(`const p = "./x"; const m = import(p);`)
+    );
+    expect(found[0].static).toBe(false);
+  });
+
+  it("reports the line number", () => {
+    const found = auditDynamicImports(projectWith(`\n\nconst m = import("./x");`));
+    expect(found[0].line).toBe(3);
+  });
+
+  it("ignores static import declarations", () => {
+    const found = auditDynamicImports(projectWith(`import x from "./x";`));
+    expect(found).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm vitest run -c vitest.config.scripts.js scripts/__tests__/dynamic-import-audit.test.mjs`
+Expected: FAIL — `Failed to load ../lib/dynamic-import-audit.mjs`
+
+- [ ] **Step 4: Write the implementation**
+
+```javascript
+// scripts/lib/dynamic-import-audit.mjs
+import { SyntaxKind } from "ts-morph";
+
+/**
+ * Find every `import(...)` expression in the project.
+ *
+ * ts-morph rewrites a specifier that is a plain string literal when the target
+ * file moves. Anything computed — a template literal, an identifier, a
+ * concatenation — is invisible to it and must be checked by hand.
+ */
+export function auditDynamicImports(project) {
+  const found = [];
+
+  for (const sourceFile of project.getSourceFiles()) {
+    for (const call of sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+      if (call.getExpression().getKind() !== SyntaxKind.ImportKeyword) continue;
+
+      const [argument] = call.getArguments();
+      found.push({
+        file: sourceFile.getFilePath(),
+        line: call.getStartLineNumber(),
+        text: call.getText(),
+        static: argument?.getKind() === SyntaxKind.StringLiteral,
+      });
+    }
+  }
+
+  return found;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm vitest run -c vitest.config.scripts.js scripts/__tests__/dynamic-import-audit.test.mjs`
+Expected: PASS — 5 tests
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/dynamic-import-audit.mjs scripts/__tests__/dynamic-import-audit.test.mjs package.json pnpm-lock.yaml
+git commit -m "feat(scripts): add dynamic-import auditor for the kebab migration"
+```
+
+---
+
+### Task 3: Rename engine
+
+Performs the moves and rewrites imports. `SourceFile.move()` in ts-morph updates every referencing import specifier across the module graph, including barrel `index.ts` re-exports and `@/` path aliases resolved through the tsconfig.
+
+**Files:**
+- Create: `scripts/lib/kebab-rename-engine.mjs`
+- Test: `scripts/__tests__/kebab-rename-engine.test.mjs`
+
+**Interfaces:**
+- Consumes: `buildRenamePlan` from Task 1 (`scripts/lib/kebab-rename-plan.mjs`).
+- Produces: `applyRenames(project: Project, plan: Array<{from, to, caseOnly}>, options?: {gitMove?: (from: string, to: string) => void}) => void` — moves each file in the project and saves. When an entry has `caseOnly: true` and `options.gitMove` is supplied, the move is delegated to it so git sees the rename on a case-insensitive filesystem.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// scripts/__tests__/kebab-rename-engine.test.mjs
+import { describe, it, expect, vi } from "vitest";
+import { Project } from "ts-morph";
+import { buildRenamePlan } from "../lib/kebab-rename-plan.mjs";
+import { applyRenames } from "../lib/kebab-rename-engine.mjs";
+
+function project(files) {
+  const p = new Project({ useInMemoryFileSystem: true });
+  for (const [name, text] of Object.entries(files)) p.createSourceFile(name, text);
+  return p;
+}
+
+describe("applyRenames", () => {
+  it("renames the file and rewrites a direct import", () => {
+    const p = project({
+      "/src/LoginForm.tsx": `export const LoginForm = () => null;`,
+      "/src/page.tsx": `import { LoginForm } from "./LoginForm";\nexport default LoginForm;`,
+    });
+    applyRenames(p, buildRenamePlan(["/src/LoginForm.tsx"]).plan);
+
+    expect(p.getSourceFile("/src/login-form.tsx")).toBeDefined();
+    expect(p.getSourceFile("/src/LoginForm.tsx")).toBeUndefined();
+    expect(p.getSourceFileOrThrow("/src/page.tsx").getFullText())
+      .toContain(`from "./login-form"`);
+  });
+
+  it("rewrites a barrel re-export", () => {
+    const p = project({
+      "/src/MSWProvider.tsx": `export const MSWProvider = () => null;`,
+      "/src/index.ts": `export { MSWProvider } from "./MSWProvider";`,
+    });
+    applyRenames(p, buildRenamePlan(["/src/MSWProvider.tsx"]).plan);
+
+    expect(p.getSourceFileOrThrow("/src/index.ts").getFullText())
+      .toContain(`from "./msw-provider"`);
+  });
+
+  it("rewrites a static dynamic-import specifier", () => {
+    const p = project({
+      "/src/StatusCard.tsx": `export const StatusCard = () => null;`,
+      "/src/lazy.ts": `export const Lazy = () => import("./StatusCard");`,
+    });
+    applyRenames(p, buildRenamePlan(["/src/StatusCard.tsx"]).plan);
+
+    expect(p.getSourceFileOrThrow("/src/lazy.ts").getFullText())
+      .toContain(`import("./status-card")`);
+  });
+
+  it("delegates a case-only rename to gitMove", () => {
+    const gitMove = vi.fn();
+    const p = project({ "/src/Pagination.tsx": `export const Pagination = () => null;` });
+    applyRenames(p, buildRenamePlan(["/src/Pagination.tsx"]).plan, { gitMove });
+
+    expect(gitMove).toHaveBeenCalledWith("/src/Pagination.tsx", "/src/pagination.tsx");
+  });
+
+  it("does not delegate a structural rename to gitMove", () => {
+    const gitMove = vi.fn();
+    const p = project({ "/src/MSWProvider.tsx": `export const MSWProvider = () => null;` });
+    applyRenames(p, buildRenamePlan(["/src/MSWProvider.tsx"]).plan, { gitMove });
+
+    expect(gitMove).not.toHaveBeenCalled();
+  });
+
+  it("rewrites an import that goes through a @/ path alias", () => {
+    const p = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: { baseUrl: "/", paths: { "@/*": ["src/*"] } },
+    });
+    p.createSourceFile("/src/components/StatusCard.tsx", `export const StatusCard = () => null;`);
+    p.createSourceFile("/src/app/page.tsx", `import { StatusCard } from "@/components/StatusCard";\nexport default StatusCard;`);
+
+    applyRenames(p, buildRenamePlan(["/src/components/StatusCard.tsx"]).plan);
+
+    expect(p.getSourceFileOrThrow("/src/app/page.tsx").getFullText())
+      .toContain(`from "@/components/status-card"`);
+  });
+
+  it("rewrites a test file importing across the src/tests boundary", () => {
+    const p = project({
+      "/src/LoginForm.tsx": `export const LoginForm = () => null;`,
+      "/tests/LoginForm.test.tsx": `import { LoginForm } from "../src/LoginForm";\nit("renders", () => LoginForm());`,
+    });
+    applyRenames(p, buildRenamePlan(["/src/LoginForm.tsx", "/tests/LoginForm.test.tsx"]).plan);
+
+    expect(p.getSourceFile("/tests/login-form.test.tsx")).toBeDefined();
+    expect(p.getSourceFileOrThrow("/tests/login-form.test.tsx").getFullText())
+      .toContain(`from "../src/login-form"`);
+  });
+
+  it("throws when a planned file is not part of the project", () => {
+    const p = project({ "/src/a.ts": `export const a = 1;` });
+    expect(() => applyRenames(p, [{ from: "/src/Ghost.ts", to: "/src/ghost.ts", caseOnly: false }]))
+      .toThrow("not in project: /src/Ghost.ts");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run -c vitest.config.scripts.js scripts/__tests__/kebab-rename-engine.test.mjs`
+Expected: FAIL — `Failed to load ../lib/kebab-rename-engine.mjs`
+
+- [ ] **Step 3: Write the implementation**
+
+```javascript
+// scripts/lib/kebab-rename-engine.mjs
+import { execFileSync } from "node:child_process";
+
+/**
+ * Move a file through a temporary name so git records the rename on a
+ * case-insensitive filesystem. `core.ignorecase` is true in this repository,
+ * which makes a direct `git mv Pagination.tsx pagination.tsx` a silent no-op.
+ */
+export function gitMoveCaseOnly(from, to) {
+  const temporary = `${from}.casetmp`;
+  execFileSync("git", ["mv", from, temporary]);
+  execFileSync("git", ["mv", temporary, to]);
+}
+
+/**
+ * Apply a rename plan to a ts-morph project.
+ *
+ * `SourceFile.move()` rewrites every import specifier that references the file,
+ * including barrel re-exports and static `import()` calls. Case-only renames
+ * are additionally staged through git so the rename is not lost.
+ */
+export function applyRenames(project, plan, options = {}) {
+  for (const { from, to, caseOnly } of plan) {
+    const sourceFile = project.getSourceFile(from);
+    if (!sourceFile) throw new Error(`not in project: ${from}`);
+
+    if (caseOnly && options.gitMove) options.gitMove(from, to);
+    sourceFile.move(to, { overwrite: false });
+  }
+
+  project.saveSync();
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run -c vitest.config.scripts.js scripts/__tests__/kebab-rename-engine.test.mjs`
+Expected: PASS — 8 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/kebab-rename-engine.mjs scripts/__tests__/kebab-rename-engine.test.mjs
+git commit -m "feat(scripts): add ts-morph rename engine for the kebab migration"
+```
+
+---
+
+### Task 4: Codemod CLI
+
+Wires Tasks 1–3 into one command that operates on a single workspace, with a dry run that prints the plan and refuses to proceed on a collision.
+
+**Files:**
+- Create: `scripts/codemod-kebab-filenames.mjs`
+- Modify: `package.json` (add the `codemod:kebab` script)
+- Test: `scripts/__tests__/codemod-kebab-filenames.test.mjs`
+
+**Interfaces:**
+- Consumes: `buildRenamePlan` (Task 1), `auditDynamicImports` (Task 2), `applyRenames` and `gitMoveCaseOnly` (Task 3).
+- Produces: `collectFiles(workspaceDir: string, fs?: typeof import("node:fs")) => string[]` — every `.ts`/`.tsx` path under a workspace's `src`, `tests`, `test`, and `e2e` directories, excluding `node_modules`, `.next`, and any `generated` directory.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// scripts/__tests__/codemod-kebab-filenames.test.mjs
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { collectFiles } from "../codemod-kebab-filenames.mjs";
+
+let root;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "kebab-"));
+  const write = (rel) => {
+    fs.mkdirSync(path.join(root, path.dirname(rel)), { recursive: true });
+    fs.writeFileSync(path.join(root, rel), "export const x = 1;");
+  };
+  write("src/LoginForm.tsx");
+  write("src/nested/deep/StatusCard.tsx");
+  write("tests/LoginForm.test.tsx");
+  write("e2e/checkout.spec.ts");
+  write("src/generated/Types.ts");
+  write("node_modules/pkg/Index.ts");
+  write("src/styles.css");
+});
+
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe("collectFiles", () => {
+  it("collects ts and tsx under src, tests and e2e", () => {
+    const found = collectFiles(root).map((f) => path.relative(root, f).split(path.sep).join("/"));
+    expect(found.sort()).toEqual([
+      "e2e/checkout.spec.ts",
+      "src/LoginForm.tsx",
+      "src/nested/deep/StatusCard.tsx",
+      "tests/LoginForm.test.tsx",
+    ]);
+  });
+
+  it("excludes node_modules and generated directories", () => {
+    const found = collectFiles(root).join("|");
+    expect(found).not.toContain("node_modules");
+    expect(found).not.toContain("generated");
+  });
+
+  it("excludes non-TypeScript files", () => {
+    expect(collectFiles(root).join("|")).not.toContain("styles.css");
+  });
+
+  it("returns an empty array for a workspace with no source directories", () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), "kebab-empty-"));
+    expect(collectFiles(empty)).toEqual([]);
+    fs.rmSync(empty, { recursive: true, force: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run -c vitest.config.scripts.js scripts/__tests__/codemod-kebab-filenames.test.mjs`
+Expected: FAIL — `Failed to load ../codemod-kebab-filenames.mjs`
+
+- [ ] **Step 3: Write the implementation**
+
+```javascript
+// scripts/codemod-kebab-filenames.mjs
+import fs from "node:fs";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { Project } from "ts-morph";
+import { buildRenamePlan } from "./lib/kebab-rename-plan.mjs";
+import { auditDynamicImports } from "./lib/dynamic-import-audit.mjs";
+import { applyRenames, gitMoveCaseOnly } from "./lib/kebab-rename-engine.mjs";
+
+const SOURCE_DIRECTORIES = ["src", "tests", "test", "e2e"];
+const EXCLUDED = new Set(["node_modules", ".next", "generated"]);
+
+export function collectFiles(workspaceDirectory, fileSystem = fs) {
+  const files = [];
+
+  const walk = (directory) => {
+    for (const entry of fileSystem.readdirSync(directory, { withFileTypes: true })) {
+      const full = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!EXCLUDED.has(entry.name)) walk(full);
+      } else if (/\.tsx?$/.test(entry.name)) {
+        files.push(full);
+      }
+    }
+  };
+
+  for (const sub of SOURCE_DIRECTORIES) {
+    const directory = path.join(workspaceDirectory, sub);
+    if (fileSystem.existsSync(directory)) walk(directory);
+  }
+
+  return files;
+}
+
+function main() {
+  const { values } = parseArgs({
+    options: {
+      workspace: { type: "string" },
+      "dry-run": { type: "boolean", default: false },
+    },
+  });
+
+  if (!values.workspace) {
+    console.error("usage: codemod-kebab-filenames.mjs --workspace <dir> [--dry-run]");
+    process.exit(2);
+  }
+
+  const workspace = path.resolve(values.workspace);
+  const tsConfigFilePath = path.join(workspace, "tsconfig.json");
+  if (!fs.existsSync(tsConfigFilePath)) {
+    console.error(`no tsconfig.json in ${workspace}`);
+    process.exit(2);
+  }
+
+  const files = collectFiles(workspace);
+  const { plan, collisions } = buildRenamePlan(
+    files.map((f) => f.split(path.sep).join("/"))
+  );
+
+  if (collisions.length > 0) {
+    console.error(`${collisions.length} collision(s) — refusing to proceed:`);
+    for (const { target, sources } of collisions) {
+      console.error(`  ${target} <= ${sources.join(", ")}`);
+    }
+    process.exit(1);
+  }
+
+  const project = new Project({ tsConfigFilePath });
+
+  const computed = auditDynamicImports(project).filter((entry) => !entry.static);
+  if (computed.length > 0) {
+    console.warn(`${computed.length} computed import() call(s) need manual review:`);
+    for (const entry of computed) {
+      console.warn(`  ${entry.file}:${entry.line}  ${entry.text}`);
+    }
+  }
+
+  console.log(`${plan.length} file(s) to rename in ${values.workspace}`);
+  for (const { from, to, caseOnly } of plan) {
+    console.log(`  ${from} -> ${to}${caseOnly ? "  (case-only)" : ""}`);
+  }
+
+  if (values["dry-run"]) {
+    console.log("dry run — nothing written");
+    return;
+  }
+
+  applyRenames(project, plan, { gitMove: gitMoveCaseOnly });
+  console.log(`renamed ${plan.length} file(s)`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run -c vitest.config.scripts.js scripts/__tests__/codemod-kebab-filenames.test.mjs`
+Expected: PASS — 4 tests
+
+- [ ] **Step 5: Add the package script**
+
+In `package.json`, alongside the other `scripts` entries:
+
+```json
+"codemod:kebab": "node scripts/codemod-kebab-filenames.mjs"
+```
+
+- [ ] **Step 6: Verify the dry run works against a real workspace**
+
+Run: `pnpm codemod:kebab --workspace packages/api --dry-run`
+Expected: prints exactly 3 renames and `dry run — nothing written`:
+
+```
+packages/api/src/graphql/mutator/graphqlFetch.ts -> packages/api/src/graphql/mutator/graphql-fetch.ts
+packages/api/src/rest/mutator/customFetch.ts -> packages/api/src/rest/mutator/custom-fetch.ts
+packages/api/src/supabase/currentUserId.ts -> packages/api/src/supabase/current-user-id.ts
+```
+
+- [ ] **Step 7: Run the whole script suite**
+
+Run: `pnpm test:workflows`
+Expected: PASS — all pre-existing script tests plus the 30 new ones
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/codemod-kebab-filenames.mjs scripts/__tests__/codemod-kebab-filenames.test.mjs package.json
+git commit -m "feat(scripts): add kebab-filenames codemod CLI"
+```
+
+---
+
+### Task 5: Pilot migration — `packages/api`
+
+The smallest workspace (3 files), migrated on its own so the codemod is proven end-to-end against real code before it touches anything larger. This task's review gate is the decision point for the whole migration.
+
+**Files:**
+- Modify: 3 files in `packages/api/src` (renamed), plus any file importing them.
+
+**Interfaces:**
+- Consumes: `pnpm codemod:kebab` from Task 4.
+- Produces: nothing consumed by later tasks — this is a proving run.
+
+- [ ] **Step 1: Branch from develop**
+
+```bash
+git checkout develop && git pull
+git checkout -b refactor/kebab-packages-api
+```
+
+- [ ] **Step 2: Dry run and read the output**
+
+Run: `pnpm codemod:kebab --workspace packages/api --dry-run`
+Expected: 3 renames, no collisions, no computed-import warnings.
+
+- [ ] **Step 3: Apply**
+
+Run: `pnpm codemod:kebab --workspace packages/api`
+Expected: `renamed 3 file(s)`
+
+- [ ] **Step 4: Confirm git recorded renames rather than delete-plus-add**
+
+Run: `git status --porcelain`
+Expected: `R` entries for the three files, plus `M` for any importer.
+
+- [ ] **Step 5: Grep for path references the codemod cannot see**
+
+Run:
+
+```bash
+grep -rn "graphqlFetch\|customFetch\|currentUserId" \
+  --include="*.json" --include="*.mjs" --include="*.ts" --include="*.yml" \
+  --exclude-dir=node_modules . | grep -v "packages/api/src"
+```
+
+Expected: no results referring to a file path. Identifier matches are fine — only file paths matter here.
+
+- [ ] **Step 6: Verify**
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test
+pnpm build
+```
+
+Expected: all pass. `forceConsistentCasingInFileNames` makes `typecheck` the authoritative gate on missed imports.
+
+- [ ] **Step 7: Commit and open the PR**
+
+```bash
+git add -A
+git commit -m "refactor(api): rename source files to kebab-case"
+git push -u origin refactor/kebab-packages-api
+gh pr create --base develop \
+  --title "refactor(api): kebab-case filenames" \
+  --body "Phase 0 pilot, 3 files. Codemod: \`pnpm codemod:kebab --workspace packages/api\`. Spec: docs/superpowers/specs/2026-09-06-kebab-migration-design.md"
+```
+
+- [ ] **Step 8: STOP for review**
+
+Do not begin Task 6 until this PR is reviewed and merged. If the codemod produced anything unexpected, fix it in Tasks 1–4 and re-run the pilot.
+
+---
+
+### Task 6: Remaining ten workspaces
+
+The same procedure per workspace, one PR each, ordered smallest blast radius first so the largest workspaces run last against the most-proven codemod.
+
+**Files:**
+- Modify: source, test, and e2e files across the ten remaining workspaces.
+
+**Interfaces:**
+- Consumes: `pnpm codemod:kebab` (Task 4), the procedure validated in Task 5.
+- Produces: a fully compliant repository, which Task 7 then locks down.
+
+For **each** workspace in this order, run the full step sequence below before moving to the next:
+
+| # | Workspace | `src` renames |
+|---|---|---|
+| 1 | `packages/ui` | 10 |
+| 2 | `packages/auth` | 10 |
+| 3 | `packages/app-components` | 12 |
+| 4 | `apps/landing` | 11 |
+| 5 | `apps/auth` | 13 |
+| 6 | `packages/shared` | 29 |
+| 7 | `apps/store` | 58 |
+| 8 | `apps/studio` | 64 |
+| 9 | `apps/admin` | 89 |
+| 10 | `apps/payments` | 97 |
+
+Counts are `src` only; each run also covers that workspace's `tests`, `test`, and `e2e` directories, which hold a further 298 renames in total.
+
+Per workspace, substituting `<workspace>` (e.g. `packages/ui`) and `<slug>` (e.g. `packages-ui`):
+
+- [ ] **Step 1: Branch**
+
+```bash
+git checkout develop && git pull
+git checkout -b refactor/kebab-<slug>
+```
+
+- [ ] **Step 2: Dry run**
+
+Run: `pnpm codemod:kebab --workspace <workspace> --dry-run`
+Expected: a rename list, zero collisions. Stop and investigate if any collision appears — none exist as of 2026-09-06, so one means the tree has changed.
+
+- [ ] **Step 3: Review any computed-import warnings**
+
+If the dry run reports computed `import()` calls, open each at the reported line and confirm whether the specifier resolves to a renamed file. Note each in the PR description.
+
+- [ ] **Step 4: Apply**
+
+Run: `pnpm codemod:kebab --workspace <workspace>`
+
+- [ ] **Step 5: Confirm git recorded renames**
+
+Run: `git status --porcelain | grep -c "^R"`
+Expected: a count matching the rename total from Step 2.
+
+For `apps/admin` specifically, confirm the one case-only rename landed:
+
+```bash
+git status --porcelain | grep -i pagination
+```
+
+Expected: an `R` entry showing `Pagination.tsx -> pagination.tsx`. An empty result means the two-step `git mv` failed and must be fixed before committing.
+
+- [ ] **Step 6: Grep for non-TypeScript path references**
+
+```bash
+grep -rn "<workspace>" --include="*.json" --include="*.mjs" --include="*.yml" \
+  --include="Dockerfile*" --exclude-dir=node_modules . \
+  | grep -iE "[A-Z][a-z]+\.tsx?"
+```
+
+Expected: no results. Any hit is a hardcoded path to a renamed file in a config, Docker file, or package script.
+
+- [ ] **Step 7: Verify**
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test
+pnpm build
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Run e2e where the workspace has it**
+
+For `apps/store`, `apps/admin`, `apps/auth`, `apps/landing`, `apps/payments`:
+
+Run: `pnpm e2e:ci`
+Expected: pass.
+
+- [ ] **Step 9: Commit and open the PR**
+
+```bash
+git add -A
+git commit -m "refactor(<slug>): rename source files to kebab-case"
+git push -u origin refactor/kebab-<slug>
+gh pr create --base develop \
+  --title "refactor(<slug>): kebab-case filenames" \
+  --body "Phase 0. Codemod: \`pnpm codemod:kebab --workspace <workspace>\`. Spec: docs/superpowers/specs/2026-09-06-kebab-migration-design.md"
+```
+
+- [ ] **Step 10: Merge before starting the next workspace**
+
+Sequential merges keep each diff reviewable against a clean `develop` and avoid rename-versus-rename conflicts between open branches.
+
+---
+
+### Task 7: Enforcement
+
+Lands only after all eleven workspaces are merged and the repository is at zero violations. Turning any of this on earlier reddens CI for the duration of the migration.
+
+**Files:**
+- Modify: `eslint.config.mjs:916`
+- Modify: `.ls-lint.yml`
+- Modify: `.claude/rules/naming-conventions.md`
+
+**Interfaces:**
+- Consumes: a fully migrated repository (Tasks 5–6).
+- Produces: nothing consumed by later tasks. This is the terminal task of Phase 0.
+
+- [ ] **Step 1: Confirm the repository is actually at zero violations**
+
+```bash
+node -e '
+const fs=require("fs"),p=require("path");
+const kebab=s=>s.replace(/([a-z0-9])([A-Z])/g,"$1-$2").replace(/([A-Z]+)([A-Z][a-z])/g,"$1-$2").toLowerCase();
+const files=[];const walk=d=>{for(const e of fs.readdirSync(d,{withFileTypes:true})){const f=p.join(d,e.name);
+if(e.isDirectory()){if(!/node_modules|\.next|generated/.test(e.name))walk(f);}else if(/\.tsx?$/.test(e.name))files.push(f);}};
+for(const g of ["apps","packages"])for(const w of fs.readdirSync(g))for(const s of ["src","tests","test","e2e"]){const d=p.join(g,w,s);if(fs.existsSync(d))walk(d);}
+const bad=files.filter(f=>{const b=p.basename(f),st=b.slice(0,b.indexOf(".",1));return kebab(st)!==st;});
+console.log("scanned",files.length,"violations",bad.length);bad.slice(0,20).forEach(f=>console.log("  "+f));
+'
+```
+
+Expected: `scanned 1067 violations 0` (file count may differ if the tree changed since 2026-09-06).
+
+- [ ] **Step 2: Branch**
+
+```bash
+git checkout develop && git pull
+git checkout -b chore/kebab-enforcement
+```
+
+- [ ] **Step 3: Turn on the ESLint rule**
+
+In `eslint.config.mjs`, in the block commented `// Unicorn overrides for existing code patterns` (line 916), replace:
+
+```js
+      "unicorn/filename-case": "off",
+```
+
+with:
+
+```js
+      "unicorn/filename-case": ["error", { case: "kebabCase" }],
+```
+
+Leave the four sibling `unicorn/*` overrides unchanged.
+
+- [ ] **Step 4: Verify the rule fires and the repo is clean**
+
+Run: `pnpm lint`
+Expected: PASS with zero `unicorn/filename-case` errors.
+
+Then prove the rule is live rather than silently inert:
+
+```bash
+cp packages/ui/src/components/info-badge.tsx packages/ui/src/components/TempCheck.tsx
+pnpm lint 2>&1 | grep "filename-case"
+rm packages/ui/src/components/TempCheck.tsx
+```
+
+Expected: the grep prints a `filename-case` error for `TempCheck.tsx`. If it prints nothing, the rule is not being applied to that path and the config change is wrong.
+
+- [ ] **Step 5: Replace the ls-lint rules**
+
+Replace the whole `ls:` block in `.ls-lint.yml` with:
+
+```yaml
+ls:
+  apps/*/src:
+    .ts: kebab-case
+    .tsx: kebab-case
+    .js: kebab-case
+    .css: kebab-case
+    .json: kebab-case
+
+  apps/*/tests:
+    .ts: kebab-case
+    .tsx: kebab-case
+
+  apps/*/test:
+    .ts: kebab-case
+    .tsx: kebab-case
+
+  apps/*/e2e:
+    .ts: kebab-case
+    .spec.ts: kebab-case
+
+  packages/*/src:
+    .ts: kebab-case
+    .tsx: kebab-case
+
+  packages/*/tests:
+    .ts: kebab-case
+    .tsx: kebab-case
+```
+
+Leave the `ignore:` block unchanged. Replace the file's leading comment block — which currently documents the camelCase and PascalCase allowances — with:
+
+```yaml
+# ls-lint configuration
+# Enforces kebab-case file naming across the monorepo.
+# Rationale and alternatives considered: orrery/docs/decisions/0001-file-naming.md
+```
+
+- [ ] **Step 6: Verify ls-lint passes with the extended coverage**
+
+Run: `pnpm ls-lint`
+Expected: PASS. This is the first time `apps/*/tests`, `apps/*/test`, and `packages/*/tests` have ever been checked for naming.
+
+- [ ] **Step 7: Rewrite the naming-conventions rule document**
+
+In `.claude/rules/naming-conventions.md`, replace the `### Files` table (lines 13–26, ending with the shadcn/ui exception paragraph) with:
+
+```markdown
+### Files
+
+All files are **kebab-case**, without exception.
+
+| Type             | Example                  |
+|------------------|--------------------------|
+| React Components | `login-form.tsx`         |
+| Hooks            | `use-auth.ts`            |
+| Utilities        | `format-date.ts`         |
+| Types/Interfaces | `user-types.ts`          |
+| Constants        | `api-endpoints.ts`       |
+| Services         | `auth-service.ts`        |
+| Repositories     | `user-repository.ts`     |
+| Test files       | Same as source + `.test` |
+
+Acronyms are split like any other word boundary: `MSWProvider` becomes
+`msw-provider`, `useAIData` becomes `use-ai-data`.
+
+Enforced by `unicorn/filename-case` in `eslint.config.mjs` and by `.ls-lint.yml`.
+Reasoning and the alternatives considered:
+`orrery/docs/decisions/0001-file-naming.md`.
+```
+
+Leave the **Folders** table and every identifier-casing section (variables, functions, constants, enum-like objects) unchanged — those are out of scope.
+
+- [ ] **Step 8: Full verification**
+
+```bash
+pnpm lint
+pnpm ls-lint
+pnpm typecheck
+pnpm test
+pnpm build
+pnpm check:tools
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Commit and open the PR**
+
+```bash
+git add eslint.config.mjs .ls-lint.yml .claude/rules/naming-conventions.md
+git commit -m "chore: enforce kebab-case filenames
+
+Turns on unicorn/filename-case, replaces the permissive ls-lint regexes,
+and extends ls-lint coverage to apps/*/tests, apps/*/test and
+packages/*/tests, which were previously unchecked for naming.
+
+Ref: orrery/docs/decisions/0001-file-naming.md"
+git push -u origin chore/kebab-enforcement
+gh pr create --base develop \
+  --title "chore: enforce kebab-case filenames" \
+  --body "Phase 0 final. Closes the enforcement gap that allowed 694 files to drift. Spec: docs/superpowers/specs/2026-09-06-kebab-migration-design.md"
+```
+
+---
+
+## Done when
+
+- `pnpm ls-lint` passes with coverage over `apps/*/{src,tests,test,e2e}` and `packages/*/{src,tests}`.
+- `pnpm lint` passes with `unicorn/filename-case` set to `error`.
+- A deliberately mis-named file causes `pnpm lint` to fail (verified in Task 7, Step 4).
+- `.claude/rules/naming-conventions.md` documents one rule, and the shadcn/ui exception is gone.
+- `pnpm typecheck`, `pnpm test`, `pnpm build`, and `pnpm e2e:ci` all pass on `develop`.
+
+## Next
+
+Phase 1 (aeleos: add `forceConsistentCasingInFileNames`, zero renames) and Phase 2 (build orrery) are separate plans. Phase 2 begins with `orrery diff-eslint`, because it sizes the reconciliation work.

--- a/docs/superpowers/plans/2026-09-06-kebab-migration.md
+++ b/docs/superpowers/plans/2026-09-06-kebab-migration.md
@@ -20,18 +20,30 @@
 - `git config core.ignorecase` is `true` in this repository. Case-only renames must go through a temporary filename.
 - The kebab conversion **must split acronym boundaries**: `MSWProvider` → `msw-provider`, `useAIData` → `use-ai-data`, `graphqlFetch` → `graphql-fetch`, `AIOptimization` → `ai-optimization`.
 - Verified 2026-09-06 across all 1,067 `.ts`/`.tsx` files in `apps/*/{src,tests,test,e2e}` and `packages/*/{src,tests}`: **zero collisions** after conversion. No manual disambiguation is required.
-- Verified 2026-09-06: **exactly one** true case-only rename exists — `apps/admin/src/features/users/presentation/components/Pagination.tsx`.
+- Verified 2026-09-06 (corrected): **exactly two** true case-only renames exist, both in `apps/admin` —
+  `apps/admin/src/features/users/presentation/components/Pagination.tsx` and
+  `apps/admin/tests/Pagination.test.tsx`. The original count of one scanned only `src`
+  directories and missed the test file.
+- Relative importers of a case-only rename are **not** fixed by ts-morph's `SourceFile.move()`:
+  with `useCaseSensitiveFileNames === false` TypeScript treats the old and new path as the
+  same file and emits no edits. The codemod handles this itself (pass 1 records those
+  specifiers, pass 3 rewrites them); nothing manual is required, but do not assume
+  `pnpm typecheck` alone would have caught it on Windows.
 - Zero `.stories.tsx` and zero `.module.css` files repo-wide, so no sibling file must rename in lockstep.
+- The CLI refuses to run against a dirty working tree (non-zero exit). Pass 2 performs
+  irreversible `git mv` calls before the first `saveSync`, so `git checkout` is the only
+  recovery from a mid-run failure — it must be a complete undo. Commit or stash first,
+  including before a `--dry-run`.
 - Enforcement must not be switched on until every workspace is migrated, or CI reddens for the duration.
 - Identifier casing (variables, functions, constants, enum-like objects) is **out of scope**. Only file names change.
 
 ## Scope
 
-| Location | Files | To rename |
-|---|---|---|
-| `apps/*/src`, `packages/*/src` | 677 | 396 |
-| `apps/*/tests`, `apps/*/test`, `packages/*/tests`, `apps/*/e2e` | 390 | 298 |
-| **Total** | **1,067** | **694** |
+| Location                                                        | Files     | To rename |
+| --------------------------------------------------------------- | --------- | --------- |
+| `apps/*/src`, `packages/*/src`                                  | 677       | 396       |
+| `apps/*/tests`, `apps/*/test`, `packages/*/tests`, `apps/*/e2e` | 390       | 298       |
+| **Total**                                                       | **1,067** | **694**   |
 
 ---
 
@@ -40,10 +52,12 @@
 Produces the analysis layer: what would be renamed, and whether anything collides. Dependency-free and fully unit-testable, so the risky part (Task 3) can be reviewed against a known-good plan.
 
 **Files:**
+
 - Create: `scripts/lib/kebab-rename-plan.mjs`
 - Test: `scripts/__tests__/kebab-rename-plan.test.mjs`
 
 **Interfaces:**
+
 - Consumes: nothing.
 - Produces:
   - `toKebab(stem: string) => string`
@@ -94,7 +108,11 @@ describe("buildRenamePlan", () => {
   it("preserves compound extensions", () => {
     const { plan } = buildRenamePlan(["src/LoginForm.test.tsx"]);
     expect(plan).toEqual([
-      { from: "src/LoginForm.test.tsx", to: "src/login-form.test.tsx", caseOnly: false },
+      {
+        from: "src/LoginForm.test.tsx",
+        to: "src/login-form.test.tsx",
+        caseOnly: false,
+      },
     ]);
   });
 
@@ -119,9 +137,15 @@ describe("buildRenamePlan", () => {
   });
 
   it("reports collisions instead of silently overwriting", () => {
-    const { collisions } = buildRenamePlan(["src/userApi.ts", "src/UserAPI.ts"]);
+    const { collisions } = buildRenamePlan([
+      "src/userApi.ts",
+      "src/UserAPI.ts",
+    ]);
     expect(collisions).toEqual([
-      { target: "src/user-api.ts", sources: ["src/userApi.ts", "src/UserAPI.ts"] },
+      {
+        target: "src/user-api.ts",
+        sources: ["src/userApi.ts", "src/UserAPI.ts"],
+      },
     ]);
   });
 
@@ -217,10 +241,12 @@ git commit -m "feat(scripts): add kebab rename-plan builder with collision detec
 Eleven `import()` call sites exist in the repository. ts-morph rewrites static string specifiers reliably and computed ones not at all, so those must be found and reported before any file moves.
 
 **Files:**
+
 - Create: `scripts/lib/dynamic-import-audit.mjs`
 - Test: `scripts/__tests__/dynamic-import-audit.test.mjs`
 
 **Interfaces:**
+
 - Consumes: nothing from Task 1.
 - Produces: `auditDynamicImports(project: Project) => Array<{file: string, line: number, text: string, static: boolean}>` — takes a ts-morph `Project`, returns every `import()` call with whether its specifier is a plain string literal.
 
@@ -246,14 +272,16 @@ function projectWith(source) {
 
 describe("auditDynamicImports", () => {
   it("marks a string-literal specifier as static", () => {
-    const found = auditDynamicImports(projectWith(`const m = import("./login-form");`));
+    const found = auditDynamicImports(
+      projectWith(`const m = import("./login-form");`),
+    );
     expect(found).toHaveLength(1);
     expect(found[0].static).toBe(true);
   });
 
   it("marks a template-literal specifier as not static", () => {
     const found = auditDynamicImports(
-      projectWith("const n = 'x';\nconst m = import(`./${n}`);")
+      projectWith("const n = 'x';\nconst m = import(`./${n}`);"),
     );
     expect(found).toHaveLength(1);
     expect(found[0].static).toBe(false);
@@ -261,13 +289,15 @@ describe("auditDynamicImports", () => {
 
   it("marks an identifier specifier as not static", () => {
     const found = auditDynamicImports(
-      projectWith(`const p = "./x"; const m = import(p);`)
+      projectWith(`const p = "./x"; const m = import(p);`),
     );
     expect(found[0].static).toBe(false);
   });
 
   it("reports the line number", () => {
-    const found = auditDynamicImports(projectWith(`\n\nconst m = import("./x");`));
+    const found = auditDynamicImports(
+      projectWith(`\n\nconst m = import("./x");`),
+    );
     expect(found[0].line).toBe(3);
   });
 
@@ -300,7 +330,9 @@ export function auditDynamicImports(project) {
   const found = [];
 
   for (const sourceFile of project.getSourceFiles()) {
-    for (const call of sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+    for (const call of sourceFile.getDescendantsOfKind(
+      SyntaxKind.CallExpression,
+    )) {
       if (call.getExpression().getKind() !== SyntaxKind.ImportKeyword) continue;
 
       const [argument] = call.getArguments();
@@ -336,10 +368,12 @@ git commit -m "feat(scripts): add dynamic-import auditor for the kebab migration
 Performs the moves and rewrites imports. `SourceFile.move()` in ts-morph updates every referencing import specifier across the module graph, including barrel `index.ts` re-exports and `@/` path aliases resolved through the tsconfig.
 
 **Files:**
+
 - Create: `scripts/lib/kebab-rename-engine.mjs`
 - Test: `scripts/__tests__/kebab-rename-engine.test.mjs`
 
 **Interfaces:**
+
 - Consumes: `buildRenamePlan` from Task 1 (`scripts/lib/kebab-rename-plan.mjs`).
 - Produces: `applyRenames(project: Project, plan: Array<{from, to, caseOnly}>, options?: {gitMove?: (from: string, to: string) => void}) => void` — moves each file in the project and saves. When an entry has `caseOnly: true` and `options.gitMove` is supplied, the move is delegated to it so git sees the rename on a case-insensitive filesystem.
 
@@ -354,7 +388,8 @@ import { applyRenames } from "../lib/kebab-rename-engine.mjs";
 
 function project(files) {
   const p = new Project({ useInMemoryFileSystem: true });
-  for (const [name, text] of Object.entries(files)) p.createSourceFile(name, text);
+  for (const [name, text] of Object.entries(files))
+    p.createSourceFile(name, text);
   return p;
 }
 
@@ -368,8 +403,9 @@ describe("applyRenames", () => {
 
     expect(p.getSourceFile("/src/login-form.tsx")).toBeDefined();
     expect(p.getSourceFile("/src/LoginForm.tsx")).toBeUndefined();
-    expect(p.getSourceFileOrThrow("/src/page.tsx").getFullText())
-      .toContain(`from "./login-form"`);
+    expect(p.getSourceFileOrThrow("/src/page.tsx").getFullText()).toContain(
+      `from "./login-form"`,
+    );
   });
 
   it("rewrites a barrel re-export", () => {
@@ -379,8 +415,9 @@ describe("applyRenames", () => {
     });
     applyRenames(p, buildRenamePlan(["/src/MSWProvider.tsx"]).plan);
 
-    expect(p.getSourceFileOrThrow("/src/index.ts").getFullText())
-      .toContain(`from "./msw-provider"`);
+    expect(p.getSourceFileOrThrow("/src/index.ts").getFullText()).toContain(
+      `from "./msw-provider"`,
+    );
   });
 
   it("rewrites a static dynamic-import specifier", () => {
@@ -390,22 +427,32 @@ describe("applyRenames", () => {
     });
     applyRenames(p, buildRenamePlan(["/src/StatusCard.tsx"]).plan);
 
-    expect(p.getSourceFileOrThrow("/src/lazy.ts").getFullText())
-      .toContain(`import("./status-card")`);
+    expect(p.getSourceFileOrThrow("/src/lazy.ts").getFullText()).toContain(
+      `import("./status-card")`,
+    );
   });
 
   it("delegates a case-only rename to gitMove", () => {
     const gitMove = vi.fn();
-    const p = project({ "/src/Pagination.tsx": `export const Pagination = () => null;` });
+    const p = project({
+      "/src/Pagination.tsx": `export const Pagination = () => null;`,
+    });
     applyRenames(p, buildRenamePlan(["/src/Pagination.tsx"]).plan, { gitMove });
 
-    expect(gitMove).toHaveBeenCalledWith("/src/Pagination.tsx", "/src/pagination.tsx");
+    expect(gitMove).toHaveBeenCalledWith(
+      "/src/Pagination.tsx",
+      "/src/pagination.tsx",
+    );
   });
 
   it("does not delegate a structural rename to gitMove", () => {
     const gitMove = vi.fn();
-    const p = project({ "/src/MSWProvider.tsx": `export const MSWProvider = () => null;` });
-    applyRenames(p, buildRenamePlan(["/src/MSWProvider.tsx"]).plan, { gitMove });
+    const p = project({
+      "/src/MSWProvider.tsx": `export const MSWProvider = () => null;`,
+    });
+    applyRenames(p, buildRenamePlan(["/src/MSWProvider.tsx"]).plan, {
+      gitMove,
+    });
 
     expect(gitMove).not.toHaveBeenCalled();
   });
@@ -415,13 +462,20 @@ describe("applyRenames", () => {
       useInMemoryFileSystem: true,
       compilerOptions: { baseUrl: "/", paths: { "@/*": ["src/*"] } },
     });
-    p.createSourceFile("/src/components/StatusCard.tsx", `export const StatusCard = () => null;`);
-    p.createSourceFile("/src/app/page.tsx", `import { StatusCard } from "@/components/StatusCard";\nexport default StatusCard;`);
+    p.createSourceFile(
+      "/src/components/StatusCard.tsx",
+      `export const StatusCard = () => null;`,
+    );
+    p.createSourceFile(
+      "/src/app/page.tsx",
+      `import { StatusCard } from "@/components/StatusCard";\nexport default StatusCard;`,
+    );
 
     applyRenames(p, buildRenamePlan(["/src/components/StatusCard.tsx"]).plan);
 
-    expect(p.getSourceFileOrThrow("/src/app/page.tsx").getFullText())
-      .toContain(`from "@/components/status-card"`);
+    expect(p.getSourceFileOrThrow("/src/app/page.tsx").getFullText()).toContain(
+      `from "@/components/status-card"`,
+    );
   });
 
   it("rewrites a test file importing across the src/tests boundary", () => {
@@ -429,17 +483,24 @@ describe("applyRenames", () => {
       "/src/LoginForm.tsx": `export const LoginForm = () => null;`,
       "/tests/LoginForm.test.tsx": `import { LoginForm } from "../src/LoginForm";\nit("renders", () => LoginForm());`,
     });
-    applyRenames(p, buildRenamePlan(["/src/LoginForm.tsx", "/tests/LoginForm.test.tsx"]).plan);
+    applyRenames(
+      p,
+      buildRenamePlan(["/src/LoginForm.tsx", "/tests/LoginForm.test.tsx"]).plan,
+    );
 
     expect(p.getSourceFile("/tests/login-form.test.tsx")).toBeDefined();
-    expect(p.getSourceFileOrThrow("/tests/login-form.test.tsx").getFullText())
-      .toContain(`from "../src/login-form"`);
+    expect(
+      p.getSourceFileOrThrow("/tests/login-form.test.tsx").getFullText(),
+    ).toContain(`from "../src/login-form"`);
   });
 
   it("throws when a planned file is not part of the project", () => {
     const p = project({ "/src/a.ts": `export const a = 1;` });
-    expect(() => applyRenames(p, [{ from: "/src/Ghost.ts", to: "/src/ghost.ts", caseOnly: false }]))
-      .toThrow("not in project: /src/Ghost.ts");
+    expect(() =>
+      applyRenames(p, [
+        { from: "/src/Ghost.ts", to: "/src/ghost.ts", caseOnly: false },
+      ]),
+    ).toThrow("not in project: /src/Ghost.ts");
   });
 });
 ```
@@ -505,11 +566,13 @@ git commit -m "feat(scripts): add ts-morph rename engine for the kebab migration
 Wires Tasks 1–3 into one command that operates on a single workspace, with a dry run that prints the plan and refuses to proceed on a collision.
 
 **Files:**
+
 - Create: `scripts/codemod-kebab-filenames.mjs`
 - Modify: `package.json` (add the `codemod:kebab` script)
 - Test: `scripts/__tests__/codemod-kebab-filenames.test.mjs`
 
 **Interfaces:**
+
 - Consumes: `buildRenamePlan` (Task 1), `auditDynamicImports` (Task 2), `applyRenames` and `gitMoveCaseOnly` (Task 3).
 - Produces: `collectFiles(workspaceDir: string, fs?: typeof import("node:fs")) => string[]` — every `.ts`/`.tsx` path under a workspace's `src`, `tests`, `test`, and `e2e` directories, excluding `node_modules`, `.next`, and any `generated` directory.
 
@@ -544,7 +607,9 @@ afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
 
 describe("collectFiles", () => {
   it("collects ts and tsx under src, tests and e2e", () => {
-    const found = collectFiles(root).map((f) => path.relative(root, f).split(path.sep).join("/"));
+    const found = collectFiles(root).map((f) =>
+      path.relative(root, f).split(path.sep).join("/"),
+    );
     expect(found.sort()).toEqual([
       "e2e/checkout.spec.ts",
       "src/LoginForm.tsx",
@@ -595,7 +660,9 @@ export function collectFiles(workspaceDirectory, fileSystem = fs) {
   const files = [];
 
   const walk = (directory) => {
-    for (const entry of fileSystem.readdirSync(directory, { withFileTypes: true })) {
+    for (const entry of fileSystem.readdirSync(directory, {
+      withFileTypes: true,
+    })) {
       const full = path.join(directory, entry.name);
       if (entry.isDirectory()) {
         if (!EXCLUDED.has(entry.name)) walk(full);
@@ -622,7 +689,9 @@ function main() {
   });
 
   if (!values.workspace) {
-    console.error("usage: codemod-kebab-filenames.mjs --workspace <dir> [--dry-run]");
+    console.error(
+      "usage: codemod-kebab-filenames.mjs --workspace <dir> [--dry-run]",
+    );
     process.exit(2);
   }
 
@@ -635,7 +704,7 @@ function main() {
 
   const files = collectFiles(workspace);
   const { plan, collisions } = buildRenamePlan(
-    files.map((f) => f.split(path.sep).join("/"))
+    files.map((f) => f.split(path.sep).join("/")),
   );
 
   if (collisions.length > 0) {
@@ -648,9 +717,13 @@ function main() {
 
   const project = new Project({ tsConfigFilePath });
 
-  const computed = auditDynamicImports(project).filter((entry) => !entry.static);
+  const computed = auditDynamicImports(project).filter(
+    (entry) => !entry.static,
+  );
   if (computed.length > 0) {
-    console.warn(`${computed.length} computed import() call(s) need manual review:`);
+    console.warn(
+      `${computed.length} computed import() call(s) need manual review:`,
+    );
     for (const entry of computed) {
       console.warn(`  ${entry.file}:${entry.line}  ${entry.text}`);
     }
@@ -716,9 +789,11 @@ git commit -m "feat(scripts): add kebab-filenames codemod CLI"
 The smallest workspace (3 files), migrated on its own so the codemod is proven end-to-end against real code before it touches anything larger. This task's review gate is the decision point for the whole migration.
 
 **Files:**
+
 - Modify: 3 files in `packages/api/src` (renamed), plus any file importing them.
 
 **Interfaces:**
+
 - Consumes: `pnpm codemod:kebab` from Task 4.
 - Produces: nothing consumed by later tasks — this is a proving run.
 
@@ -789,26 +864,28 @@ Do not begin Task 6 until this PR is reviewed and merged. If the codemod produce
 The same procedure per workspace, one PR each, ordered smallest blast radius first so the largest workspaces run last against the most-proven codemod.
 
 **Files:**
+
 - Modify: source, test, and e2e files across the ten remaining workspaces.
 
 **Interfaces:**
+
 - Consumes: `pnpm codemod:kebab` (Task 4), the procedure validated in Task 5.
 - Produces: a fully compliant repository, which Task 7 then locks down.
 
 For **each** workspace in this order, run the full step sequence below before moving to the next:
 
-| # | Workspace | `src` renames |
-|---|---|---|
-| 1 | `packages/ui` | 10 |
-| 2 | `packages/auth` | 10 |
-| 3 | `packages/app-components` | 12 |
-| 4 | `apps/landing` | 11 |
-| 5 | `apps/auth` | 13 |
-| 6 | `packages/shared` | 29 |
-| 7 | `apps/store` | 58 |
-| 8 | `apps/studio` | 64 |
-| 9 | `apps/admin` | 89 |
-| 10 | `apps/payments` | 97 |
+| #   | Workspace                 | `src` renames |
+| --- | ------------------------- | ------------- |
+| 1   | `packages/ui`             | 10            |
+| 2   | `packages/auth`           | 10            |
+| 3   | `packages/app-components` | 12            |
+| 4   | `apps/landing`            | 11            |
+| 5   | `apps/auth`               | 13            |
+| 6   | `packages/shared`         | 29            |
+| 7   | `apps/store`              | 58            |
+| 8   | `apps/studio`             | 64            |
+| 9   | `apps/admin`              | 89            |
+| 10  | `apps/payments`           | 97            |
 
 Counts are `src` only; each run also covers that workspace's `tests`, `test`, and `e2e` directories, which hold a further 298 renames in total.
 
@@ -826,9 +903,24 @@ git checkout -b refactor/kebab-<slug>
 Run: `pnpm codemod:kebab --workspace <workspace> --dry-run`
 Expected: a rename list, zero collisions. Stop and investigate if any collision appears — none exist as of 2026-09-06, so one means the tree has changed.
 
-- [ ] **Step 3: Review any computed-import warnings**
+- [ ] **Step 3: Review every warning the dry run prints**
 
-If the dry run reports computed `import()` calls, open each at the reported line and confirm whether the specifier resolves to a renamed file. Note each in the PR description.
+The dry run prints four things that need a human, none of which `pnpm typecheck` can catch:
+
+1. **computed `import()` calls** — a template literal or identifier specifier. Open each at
+   the reported line and confirm whether it resolves to a renamed file.
+2. **non-relative dynamic `import()` specifiers** — path-aliased dynamic imports and
+   `import("...")` type nodes. The codemod does not rewrite these (resolving them needs
+   guesswork; `MSWProvider.tsx` exists in five workspaces). Twelve aliased dynamic imports
+   and one aliased import-type node exist repo-wide as of 2026-09-06.
+3. **`vi.mock` / `require` specifiers that would be rewritten** — a count. Sanity-check it
+   against `grep -rc "vi\.mock" <workspace>`.
+4. **`vi.mock` specifiers needing manual attention** — every one the codemod could not
+   resolve. These are the dangerous ones: vitest treats a mock path that resolves to
+   nothing as a **silent no-op**, so the suite stays green while exercising the real module.
+   There is no compiler backstop — the argument is a `string`. Fix each by hand.
+
+Note each in the PR description.
 
 - [ ] **Step 4: Apply**
 
@@ -839,13 +931,15 @@ Run: `pnpm codemod:kebab --workspace <workspace>`
 Run: `git status --porcelain | grep -c "^R"`
 Expected: a count matching the rename total from Step 2.
 
-For `apps/admin` specifically, confirm the one case-only rename landed:
+For `apps/admin` specifically, confirm **both** case-only renames landed:
 
 ```bash
 git status --porcelain | grep -i pagination
 ```
 
-Expected: an `R` entry showing `Pagination.tsx -> pagination.tsx`. An empty result means the two-step `git mv` failed and must be fixed before committing.
+Expected: two `R` entries — `src/features/users/presentation/components/Pagination.tsx -> .../pagination.tsx`
+and `tests/Pagination.test.tsx -> tests/pagination.test.tsx`. Fewer than two means the two-step
+`git mv` failed for one of them and must be fixed before committing.
 
 - [ ] **Step 6: Grep for non-TypeScript path references**
 
@@ -856,6 +950,62 @@ grep -rn "<workspace>" --include="*.json" --include="*.mjs" --include="*.yml" \
 ```
 
 Expected: no results. Any hit is a hardcoded path to a renamed file in a config, Docker file, or package script.
+
+- [ ] **Step 6a: Fix stale config globs the codemod cannot see**
+
+The codemod only rewrites TypeScript module specifiers. Two config files match source
+files by **path glob**, and a glob that no longer matches fails **silently** — coverage
+exclusions lapse (thresholds may then fail, or worse, quietly pass on newly-included
+files) and per-file lint exemptions vanish, re-enabling rules that were deliberately
+switched off.
+
+1. `apps/{studio,payments,admin,auth,store}/vitest.config.mts` — the `coverage.exclude`
+   arrays reference roughly 30 PascalCase/camelCase paths, e.g.
+   `**/auth/application/hooks/useSupabaseAuth.ts`,
+   `**/auth/presentation/components/ProtectedRoute.tsx`,
+   `**/payment-methods/presentation/components/BlockEditor.tsx`,
+   `**/shared/infrastructure/receiptActions.ts`, `**/domain/searchParams.ts`.
+2. `eslint.config.mjs` — per-file overrides keyed on a path, notably
+   `packages/shared/src/components/ThemeScript.tsx` (line ~1597),
+   `${APP_SRC}/shared/infrastructure/providers/MSWProvider.tsx` (line ~1611),
+   `${APP_SRC}/shared/application/utils/exportUtils.ts` (line ~1002), plus the
+   `**/…/MSWProvider.tsx`, `**/…/exportUtils.ts` and `**/…/chartColors.ts` entries
+   around line 1122.
+
+Find every stale glob for the workspace being migrated by taking the old stem of each
+rename git recorded and grepping the config files for it:
+
+```bash
+git status --porcelain |
+  sed -n 's#^R[ M]* \(.*\) -> .*#\1#p' |
+  xargs -n1 basename | cut -d. -f1 | sort -u |
+  while read -r stem; do
+    grep -rn "/$stem\." --include="*.mts" --include="*.mjs" --include="*.json" \
+      --exclude-dir=node_modules apps packages eslint.config.mjs
+  done
+```
+
+Update every hit by hand in the same PR. Expected after the edits: no hit refers to a
+name that no longer exists on disk.
+
+- [ ] **Step 6b (`packages/shared` only): update the `exports` map in `packages/shared/package.json`**
+
+`packages/shared/package.json` hard-codes five subpath targets the codemod renames, and the
+codemod never touches `package.json`:
+
+| Subpath key                     | Current target                         | New target                                |
+| ------------------------------- | -------------------------------------- | ----------------------------------------- |
+| `./app-root-layout`             | `./src/components/AppRootLayout.tsx`   | `./src/components/app-root-layout.tsx`    |
+| `./i18n/createAppI18n`          | `./src/i18n/createAppI18n.ts`          | `./src/i18n/create-app-i18n.ts`           |
+| `./i18n/createAppRouting`       | `./src/i18n/createAppRouting.ts`       | `./src/i18n/create-app-routing.ts`        |
+| `./i18n/createAppRequestConfig` | `./src/i18n/createAppRequestConfig.ts` | `./src/i18n/create-app-request-config.ts` |
+| `./i18n/createIntlProxy`        | `./src/i18n/createIntlProxy.ts`        | `./src/i18n/create-intl-proxy.ts`         |
+
+This **must** be done by hand in the `packages/shared` PR. Node resolves these paths
+case-insensitively on Windows, so a local `pnpm build` will keep passing while Linux CI
+and every Docker image break. Change only the target paths; leaving the subpath **keys**
+alone keeps every existing `shared/i18n/createAppI18n` importer resolving through the
+exports map.
 
 - [ ] **Step 7: Verify**
 
@@ -890,6 +1040,38 @@ gh pr create --base develop \
 
 Sequential merges keep each diff reviewable against a clean `develop` and avoid rename-versus-rename conflicts between open branches.
 
+#### Expected cross-workspace breakage in the `packages/shared` PR
+
+The codemod builds its `ts-morph` project from **one** workspace's `tsconfig.json`, so deep
+imports living in _other_ workspaces are invisible to it and are never rewritten. Measured
+2026-09-06: **44** such sites, all of them pointing into `packages/shared`, all from
+`apps/*/src`.
+
+| Target (after rename)                                                    | Sites  |
+| ------------------------------------------------------------------------ | ------ |
+| `createIntlProxy` → `create-intl-proxy`                                  | 7      |
+| `AppRootLayout` → `app-root-layout` (via the `exports` map, see Step 6b) | 7      |
+| `appUrls` → `app-urls`                                                   | 7      |
+| `createAppI18n` → `create-app-i18n`                                      | 7      |
+| `createAppRequestConfig` → `create-app-request-config`                   | 7      |
+| `createAppRouting` → `create-app-routing`                                | 7      |
+| `receiptPath` → `receipt-path`                                           | 2      |
+| **Total**                                                                | **44** |
+
+The earlier figure of 37 omitted the seven `shared/app-root-layout` sites, which resolve
+through `packages/shared/package.json`'s `exports` map rather than a tsconfig path alias.
+
+This is **not** silent: Step 7's repo-wide `pnpm typecheck` enumerates every broken site by
+file and line. Fix them in the same PR. `packages/ui`, `packages/api` and `packages/auth`
+are unaffected — their cross-package imports are either barrel-only or already kebab-case.
+
+#### Cross-app relative import
+
+`apps/admin/e2e/reports.spec.ts` imports `../../auth/e2e/helpers/receiptFixtures`, which
+lives in the **`apps/auth`** rename plan, not `apps/admin`'s. Whichever of the two PRs runs
+second must fix this by hand — the `apps/auth` run cannot see the admin importer, and the
+`apps/admin` run cannot see the auth file. `pnpm typecheck` catches it.
+
 ---
 
 ### Task 7: Enforcement
@@ -897,11 +1079,13 @@ Sequential merges keep each diff reviewable against a clean `develop` and avoid 
 Lands only after all eleven workspaces are merged and the repository is at zero violations. Turning any of this on earlier reddens CI for the duration of the migration.
 
 **Files:**
+
 - Modify: `eslint.config.mjs:916`
 - Modify: `.ls-lint.yml`
 - Modify: `.claude/rules/naming-conventions.md`
 
 **Interfaces:**
+
 - Consumes: a fully migrated repository (Tasks 5–6).
 - Produces: nothing consumed by later tasks. This is the terminal task of Phase 0.
 
@@ -1016,7 +1200,7 @@ In `.claude/rules/naming-conventions.md`, replace the `### Files` table (lines 1
 All files are **kebab-case**, without exception.
 
 | Type             | Example                  |
-|------------------|--------------------------|
+| ---------------- | ------------------------ |
 | React Components | `login-form.tsx`         |
 | Hooks            | `use-auth.ts`            |
 | Utilities        | `format-date.ts`         |

--- a/docs/superpowers/plans/2026-09-06-kebab-migration.md
+++ b/docs/superpowers/plans/2026-09-06-kebab-migration.md
@@ -31,9 +31,14 @@
   `pnpm typecheck` alone would have caught it on Windows.
 - Zero `.stories.tsx` and zero `.module.css` files repo-wide, so no sibling file must rename in lockstep.
 - The CLI refuses to apply against a dirty working tree (non-zero exit). Pass 2 performs
-  irreversible `git mv` calls before the first `saveSync`, so `git checkout` is the only
-  recovery from a mid-run failure — it must be a complete undo. Commit or stash first.
-  `--dry-run` writes nothing, so it warns about a dirty tree and continues.
+  irreversible `git mv` calls before the first `saveSync`, so
+  `git reset --hard HEAD && git clean -fd` is the only recovery from a mid-run failure —
+  it must be a complete undo. Commit or stash first. `--dry-run` writes nothing, so it
+  warns about a dirty tree and continues. `git checkout` is **not** a recovery: `git mv`
+  _stages_ the rename, and pass 2's new kebab-named files are untracked, so it reverts
+  neither. Warning: a case-only rename may still need a manual two-step rename back
+  (through a temporary name) — with `core.ignorecase` git cannot see a case-only
+  difference and reports a clean tree while the file is still renamed on disk.
 - Enforcement must not be switched on until every workspace is migrated, or CI reddens for the duration.
 - Identifier casing (variables, functions, constants, enum-like objects) is **out of scope**. Only file names change.
 
@@ -910,9 +915,11 @@ The dry run prints four things that need a human, none of which `pnpm typecheck`
 1. **computed `import()` calls** — a template literal or identifier specifier. Open each at
    the reported line and confirm whether it resolves to a renamed file.
 2. **non-relative dynamic `import()` specifiers** — path-aliased dynamic imports and
-   `import("...")` type nodes. The codemod does not rewrite these (resolving them needs
-   guesswork; `MSWProvider.tsx` exists in five workspaces). Twelve aliased dynamic imports
-   and one aliased import-type node exist repo-wide as of 2026-09-06.
+   `import("...")` type nodes. The codemod now resolves and rewrites these, using the same
+   resolver and last-segment guard as the `vi.mock` rewrites. Sixteen such sites resolve
+   into a rename plan repo-wide as of 2026-09-06 (`apps/admin` 7, `apps/payments` 3,
+   `apps/store` 2, `apps/studio` 1, `packages/shared` 3); the dry run reports only those
+   plus any the guard refuses, not every non-relative `import()` in the workspace.
 3. **`vi.mock` / `require` specifiers that would be rewritten** — a count. Sanity-check it
    against `grep -rc "vi\.mock" <workspace>`.
 4. **`vi.mock` specifiers needing manual attention** — every one the codemod could not
@@ -925,6 +932,21 @@ Note each in the PR description.
 - [ ] **Step 4: Apply**
 
 Run: `pnpm codemod:kebab --workspace <workspace>`
+
+**Recovery if the run fails part-way.** Pass 2 performs irreversible `git mv` calls before
+the first `saveSync`, so a failure can leave correct filenames with stale specifiers. Undo
+with:
+
+```bash
+git reset --hard HEAD && git clean -fd
+```
+
+`git checkout` does **not** work: `git mv` _stages_ the rename, and the new kebab-named
+files pass 2 writes are untracked, so `git checkout` reverts neither.
+
+Warning: a case-only rename may still need a manual two-step rename back (rename to a
+temporary name, then to the original), because with `core.ignorecase` git cannot see a
+case-only difference and will report a clean tree while the file is still renamed on disk.
 
 - [ ] **Step 5: Confirm git recorded renames**
 

--- a/docs/superpowers/specs/2026-09-06-kebab-migration-design.md
+++ b/docs/superpowers/specs/2026-09-06-kebab-migration-design.md
@@ -1,0 +1,166 @@
+# Kebab-case file naming migration
+
+**Status:** approved design, not yet implemented
+**Date:** 2026-09-06
+**Phase:** 0 of the orrery programme
+**Decision record:** `orrery/docs/decisions/0001-file-naming.md`
+**Parent design:** `orrery/docs/specs/2026-09-06-orrery-design.md`
+
+Rename every source, test, and e2e file in this repository to kebab-case, and
+close the enforcement gaps that let the current convention drift unobserved.
+
+## Why
+
+libra's documented file-naming convention cannot be enforced by its own linter.
+`.claude/rules/naming-conventions.md` specifies PascalCase components, camelCase
+hooks and utilities, PascalCase services and repositories. The ls-lint rule that
+is supposed to hold it is:
+
+```
+.ts: kebab-case | regex:^[a-z][a-zA-Z0-9]*$ | regex:^[A-Z][A-Za-z0-9]*$
+```
+
+That accepts all three forms in every location. `FormatDate.ts` passes lint while
+violating the documented rule. The rule is aspirational; the enforcement is
+permissive. kebab-case is the only convention where the rule and the enforcement
+are the same artifact. Full reasoning, including what was weighed against it, is
+in ADR 0001.
+
+## Scope
+
+| Location | Files | To rename |
+|---|---|---|
+| `apps/*/src`, `packages/*/src` | 677 | 396 |
+| `apps/*/tests`, `apps/*/test`, `packages/*/tests`, `apps/*/e2e` | 390 | 298 |
+| **Total** | **1,067** | **694** |
+
+Per workspace, in `src` only:
+
+```
+apps/payments  97    packages/shared          29
+apps/admin     89    apps/auth                13
+apps/studio    64    packages/app-components  12
+apps/store     58    apps/landing             11
+                     packages/ui              10
+                     packages/auth            10
+                     packages/api              3
+```
+
+Of the 396 `src` violations, 244 are PascalCase and 152 are camelCase. None fall
+outside those two forms.
+
+**No lockstep collateral.** The repository has zero `.stories.tsx` and zero
+`.module.css` files, so no sibling files must rename in step with a component.
+
+**Not in scope:** identifier casing (variables, functions, constants, enum-like
+objects). `naming-conventions.md` keeps that guidance unchanged. Only the
+file-naming table is rewritten.
+
+## Enforcement — three layers
+
+All three land with the migration, not after it.
+
+**1. ESLint.** `unicorn/filename-case` is currently `"off"` at
+`eslint.config.mjs:916`. `eslint-plugin-unicorn` is already a dependency.
+
+```js
+"unicorn/filename-case": ["error", { case: "kebabCase" }]
+```
+
+**2. ls-lint.** The permissive triple-regex is replaced, and coverage extends to
+directories that are currently unlinted for naming — `apps/*/tests`,
+`apps/*/test`, and `packages/*/tests`, where 298 of the violations accumulated
+unobserved.
+
+```yaml
+ls:
+  apps/*/src:        { .ts: kebab-case, .tsx: kebab-case, .js: kebab-case, .css: kebab-case, .json: kebab-case }
+  apps/*/tests:      { .ts: kebab-case, .tsx: kebab-case }
+  apps/*/test:       { .ts: kebab-case, .tsx: kebab-case }
+  apps/*/e2e:        { .ts: kebab-case, .spec.ts: kebab-case }
+  packages/*/src:    { .ts: kebab-case, .tsx: kebab-case }
+  packages/*/tests:  { .ts: kebab-case, .tsx: kebab-case }
+```
+
+The documented shadcn/ui exception is deleted. Those files are already lowercase
+and become compliant by default.
+
+**3. tsconfig.** `forceConsistentCasingInFileNames: true` is already set in
+`tsconfig.base.json` and stays. It is the verification gate for the migration:
+any import left pointing at an old casing fails typecheck.
+
+## Procedure
+
+**Use a TypeScript-aware codemod, not `git mv` plus find-and-replace.** A
+`ts-morph` script walks the module graph and rewrites every import specifier,
+including barrel `index.ts` re-exports. A regex approach misses re-exports and
+leaves 694 files to debug by hand.
+
+Three hazards, each handled explicitly:
+
+**Case-only renames.** Six files are single-word PascalCase (`Button.tsx` ->
+`button.tsx`). `git config core.ignorecase` is `true` in this repository, so
+`git mv Button.tsx button.tsx` silently no-ops. These route through a temporary
+name — `Button.tsx` -> `Button.tsx.tmp` -> `button.tsx` — as two commits' worth
+of index operations in one commit. This is a silent failure if missed, not a
+loud one.
+
+**Dynamic imports.** Eleven `import()` call sites exist. Codemods rewrite static
+specifiers reliably and computed ones not at all. Each is reviewed by hand and
+listed in the PR description.
+
+**Non-TypeScript references.** Any file path appearing in `next.config.ts`,
+Playwright configs, Docker build files, or `package.json` scripts is grepped for
+after the codemod runs and before typecheck.
+
+### Sequencing
+
+One PR per workspace — 11 reviewable diffs rather than a single 694-file diff
+nobody can read. Order runs smallest-blast-radius first so the codemod is proven
+on low-risk workspaces before it touches the largest:
+
+```
+packages/api (3)  ->  packages/ui (10)  ->  packages/auth (10)
+  ->  packages/app-components (12)  ->  apps/landing (11)  ->  apps/auth (13)
+  ->  packages/shared (29)  ->  apps/store (58)  ->  apps/studio (64)
+  ->  apps/admin (89)  ->  apps/payments (97)
+```
+
+Enforcement lands in a final twelfth PR, once every workspace is compliant.
+Turning it on earlier would redden CI for the duration.
+
+### Verification, per PR
+
+```
+pnpm typecheck     # forceConsistentCasingInFileNames catches any missed import
+pnpm lint
+pnpm test
+pnpm build
+```
+
+Plus `pnpm e2e:ci` on the workspaces that have e2e coverage, and `pnpm ls-lint`
+on the final enforcement PR.
+
+## Codemod tests
+
+The codemod runs against 694 real files, so it gets fixtures first:
+
+- a barrel `index.ts` re-exporting a renamed module
+- a case-only rename on a case-insensitive filesystem
+- a dynamic `import()` with a static specifier (rewritten) and one with a
+  computed specifier (flagged, not rewritten)
+- a file imported through a `@/` path alias
+- a test file importing a renamed source file across the `src`/`tests` boundary
+
+## Consequences
+
+- `naming-conventions.md`'s file-naming table is rewritten to a single rule.
+  Its identifier-casing guidance is untouched.
+- The shadcn/ui exception disappears.
+- `git blame` gains a rename boundary on 694 files. `git log --follow` continues
+  to work; reviewers should use `--find-renames` on the migration commits.
+- aeleos requires no changes — it is already at 0 violations of 173 files — but
+  gains `forceConsistentCasingInFileNames`, which it currently lacks, in Phase 1.
+- After this phase, ls-lint reconciliation between the two repos becomes a
+  superset merge rather than a conflict, which is why this runs before the
+  orrery extraction.

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "supabase": "^2.95.5",
     "syncpack": "^14.3.1",
     "tailwindcss": "^4.2.4",
+    "ts-morph": "^28.0.0",
     "turbo": "^2.9.6",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "check:a11y-patterns": "node scripts/check-a11y-patterns.mjs",
     "check:boundaries": "node scripts/check-feature-boundaries.mjs",
     "check:doc-refs": "node scripts/check-doc-references.mjs",
-    "check:docs": "node scripts/check-doc-freshness.mjs"
+    "check:docs": "node scripts/check-doc-freshness.mjs",
+    "codemod:kebab": "node scripts/codemod-kebab-filenames.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
+      ts-morph:
+        specifier: ^28.0.0
+        version: 28.0.0
       turbo:
         specifier: ^2.9.6
         version: 2.9.6
@@ -4101,6 +4104,9 @@ packages:
     resolution: {integrity: sha512-w071DSzP94YfN6XiWhOxnLpYT3uqtxJBDYdh6Jdjzt+Ce6DNspJsPQgpC7rbts/B8tEkq0LHoYuIF/O5Jh5rPg==}
     engines: {node: '>=18'}
 
+  '@ts-morph/common@0.29.0':
+    resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
+
   '@turbo/darwin-64@2.9.6':
     resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
     cpu: [x64]
@@ -5019,6 +5025,9 @@ packages:
   cmd-shim@8.0.0:
     resolution: {integrity: sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -7269,6 +7278,9 @@ packages:
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -8388,6 +8400,9 @@ packages:
   ts-graphviz@2.1.6:
     resolution: {integrity: sha512-XyLVuhBVvdJTJr2FJJV2L1pc4MwSjMhcunRVgDE9k4wbb2ee7ORYnPewxMWUav12vxyfUM686MSGsqnVRIInuw==}
     engines: {node: '>=18'}
+
+  ts-morph@28.0.0:
+    resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -11676,6 +11691,12 @@ snapshots:
       '@ts-graphviz/ast': 2.0.7
       '@ts-graphviz/common': 2.1.5
 
+  '@ts-morph/common@0.29.0':
+    dependencies:
+      minimatch: 10.2.5
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.16
+
   '@turbo/darwin-64@2.9.6':
     optional: true
 
@@ -12660,6 +12681,8 @@ snapshots:
   clsx@2.1.1: {}
 
   cmd-shim@8.0.0: {}
+
+  code-block-writer@13.0.3: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -15391,6 +15414,8 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -16663,6 +16688,11 @@ snapshots:
       '@ts-graphviz/ast': 2.0.7
       '@ts-graphviz/common': 2.1.5
       '@ts-graphviz/core': 2.0.7
+
+  ts-morph@28.0.0:
+    dependencies:
+      '@ts-morph/common': 0.29.0
+      code-block-writer: 13.0.3
 
   tsconfck@3.1.6(typescript@6.0.3):
     optionalDependencies:

--- a/scripts/__tests__/codemod-kebab-filenames.test.mjs
+++ b/scripts/__tests__/codemod-kebab-filenames.test.mjs
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { collectFiles } from "../codemod-kebab-filenames.mjs";
+
+let root;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "kebab-"));
+  const write = (rel) => {
+    fs.mkdirSync(path.join(root, path.dirname(rel)), { recursive: true });
+    fs.writeFileSync(path.join(root, rel), "export const x = 1;");
+  };
+  write("src/LoginForm.tsx");
+  write("src/nested/deep/StatusCard.tsx");
+  write("tests/LoginForm.test.tsx");
+  write("e2e/checkout.spec.ts");
+  write("src/generated/Types.ts");
+  write("node_modules/pkg/Index.ts");
+  write("src/styles.css");
+});
+
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe("collectFiles", () => {
+  it("collects ts and tsx under src, tests and e2e", () => {
+    const found = collectFiles(root).map((f) =>
+      path.relative(root, f).split(path.sep).join("/"),
+    );
+    expect(found.sort()).toEqual([
+      "e2e/checkout.spec.ts",
+      "src/LoginForm.tsx",
+      "src/nested/deep/StatusCard.tsx",
+      "tests/LoginForm.test.tsx",
+    ]);
+  });
+
+  it("excludes node_modules and generated directories", () => {
+    const found = collectFiles(root).join("|");
+    expect(found).not.toContain("node_modules");
+    expect(found).not.toContain("generated");
+  });
+
+  it("excludes non-TypeScript files", () => {
+    expect(collectFiles(root).join("|")).not.toContain("styles.css");
+  });
+
+  it("returns an empty array for a workspace with no source directories", () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), "kebab-empty-"));
+    expect(collectFiles(empty)).toEqual([]);
+    fs.rmSync(empty, { recursive: true, force: true });
+  });
+});

--- a/scripts/__tests__/codemod-kebab-filenames.test.mjs
+++ b/scripts/__tests__/codemod-kebab-filenames.test.mjs
@@ -1,8 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { collectFiles } from "../codemod-kebab-filenames.mjs";
+import {
+  collectFiles,
+  workingTreeStatus,
+} from "../codemod-kebab-filenames.mjs";
 
 let root;
 
@@ -50,5 +53,53 @@ describe("collectFiles", () => {
     const empty = fs.mkdtempSync(path.join(os.tmpdir(), "kebab-empty-"));
     expect(collectFiles(empty)).toEqual([]);
     fs.rmSync(empty, { recursive: true, force: true });
+  });
+});
+
+describe("workingTreeStatus", () => {
+  const gitError = (status, stderr) => {
+    const error = new Error("Command failed");
+    error.status = status;
+    error.stderr = Buffer.from(stderr);
+    return error;
+  };
+
+  it("returns git's porcelain output when git succeeds", () => {
+    const run = vi.fn(() => " M src/a.ts\n");
+    expect(workingTreeStatus("/repo", { run })).toBe(" M src/a.ts\n");
+  });
+
+  it("returns null only when the directory is not a git repository", () => {
+    const run = vi.fn(() => {
+      throw gitError(
+        128,
+        "fatal: not a git repository (or any of the parent directories): .git\n",
+      );
+    });
+    expect(workingTreeStatus("/tmp/plain", { run })).toBeNull();
+  });
+
+  it("throws, naming the error, when git is missing entirely", () => {
+    const run = vi.fn(() => {
+      const error = new Error("spawnSync git ENOENT");
+      error.code = "ENOENT";
+      throw error;
+    });
+
+    // The old behaviour returned null here, which the caller reads as "clean"
+    // — silently disabling the guard on the destructive path.
+    expect(() => workingTreeStatus("/repo", { run })).toThrow(/ENOENT/);
+  });
+
+  it("throws rather than proceeding when the index is locked", () => {
+    const run = vi.fn(() => {
+      throw gitError(
+        128,
+        "fatal: Unable to create '/repo/.git/index.lock': File exists.\n",
+      );
+    });
+    expect(() => workingTreeStatus("/repo", { run })).toThrow(
+      /could not determine the git working tree status/,
+    );
   });
 });

--- a/scripts/__tests__/codemod-kebab-integration.test.mjs
+++ b/scripts/__tests__/codemod-kebab-integration.test.mjs
@@ -3,6 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const CODEMOD_SCRIPT = fileURLToPath(
+  new URL("../codemod-kebab-filenames.mjs", import.meta.url),
+);
 
 let fixtureDir;
 
@@ -13,95 +18,127 @@ afterEach(() => {
   }
 });
 
-describe("codemod CLI integration", () => {
-  it("renames files and updates imports without creating nested directories", () => {
-    // Create temp fixture
-    fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "kebab-integration-"));
-
-    // Write tsconfig.json
-    fs.writeFileSync(
-      path.join(fixtureDir, "tsconfig.json"),
-      JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: {
-            "@/*": ["./src/*"],
-          },
-        },
-      }),
-    );
-
-    // Create directory structure
-    fs.mkdirSync(path.join(fixtureDir, "src", "components"), {
-      recursive: true,
-    });
-    fs.mkdirSync(path.join(fixtureDir, "src", "app"), { recursive: true });
-
-    // Write source files
-    fs.writeFileSync(
-      path.join(fixtureDir, "src", "components", "StatusCard.tsx"),
-      "export function StatusCard() { return null; }",
-    );
-
-    fs.writeFileSync(
-      path.join(fixtureDir, "src", "index.ts"),
-      'export { StatusCard } from "./components/StatusCard";',
-    );
-
-    fs.writeFileSync(
-      path.join(fixtureDir, "src", "app", "page.tsx"),
-      'import { StatusCard } from "@/components/StatusCard";\nexport default StatusCard;',
-    );
-
-    // Run the CLI as a child process from a different directory
-    const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "kebab-run-"));
-    try {
-      const codemodScript = path.resolve(
-        ".",
-        "scripts",
-        "codemod-kebab-filenames.mjs",
-      );
-
-      execFileSync("node", [codemodScript, "--workspace", fixtureDir], {
-        cwd: runDir,
-        stdio: "pipe",
-      });
-    } finally {
-      fs.rmSync(runDir, { recursive: true, force: true });
+/** Every file under `root`, as sorted POSIX paths relative to it. */
+function listFiles(root) {
+  const out = [];
+  const walk = (directory, prefix) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) walk(path.join(directory, entry.name), relative);
+      else out.push(relative);
     }
+  };
+  walk(root, "");
+  return out.sort();
+}
 
-    // Verify: StatusCard was renamed
-    expect(
-      fs.existsSync(
-        path.join(fixtureDir, "src", "components", "status-card.tsx"),
-      ),
-    ).toBe(true);
-    expect(
-      fs.existsSync(
-        path.join(fixtureDir, "src", "components", "StatusCard.tsx"),
-      ),
-    ).toBe(false);
+function writeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "kebab-integration-"));
 
-    // Verify: no nested directory was created
-    expect(
-      fs.existsSync(path.join(fixtureDir, "src", "components", "src")),
-    ).toBe(false);
-    expect(fs.existsSync(path.join(fixtureDir, "src", "src"))).toBe(false);
+  // `include` deliberately covers only `src`, exactly like every packages/*
+  // tsconfig in this repo. The CLI must add the `tests` files to the project
+  // itself or the rename aborts with "not in project".
+  fs.writeFileSync(
+    path.join(root, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: { baseUrl: ".", paths: { "@/*": ["./src/*"] } },
+      include: ["src/**/*.ts", "src/**/*.tsx"],
+    }),
+  );
 
-    // Verify: relative re-export was updated
-    const indexContent = fs.readFileSync(
-      path.join(fixtureDir, "src", "index.ts"),
-      "utf-8",
+  fs.mkdirSync(path.join(root, "src", "components"), { recursive: true });
+  fs.mkdirSync(path.join(root, "src", "app"), { recursive: true });
+  fs.mkdirSync(path.join(root, "tests"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(root, "src", "components", "StatusCard.tsx"),
+    "export function StatusCard() { return null; }",
+  );
+  fs.writeFileSync(
+    path.join(root, "src", "index.ts"),
+    'export { StatusCard } from "./components/StatusCard";',
+  );
+  fs.writeFileSync(
+    path.join(root, "src", "app", "page.tsx"),
+    'import { StatusCard } from "@/components/StatusCard";\nexport default StatusCard;',
+  );
+  fs.writeFileSync(
+    path.join(root, "tests", "StatusCard.test.tsx"),
+    [
+      'import { vi } from "vitest";',
+      'import { StatusCard } from "../src/components/StatusCard";',
+      'vi.mock("@/components/StatusCard");',
+      'vi.mock("../src/components/StatusCard");',
+      'it("renders", () => StatusCard());',
+    ].join("\n"),
+  );
+
+  return root;
+}
+
+function runCodemod(workspace, extraArgs = []) {
+  // Run from a directory that is neither the repo nor the fixture, so any
+  // cwd-relative path handling fails loudly.
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "kebab-run-"));
+  try {
+    return execFileSync(
+      "node",
+      [CODEMOD_SCRIPT, "--workspace", workspace, ...extraArgs],
+      { cwd: runDir, stdio: "pipe", encoding: "utf8" },
     );
-    expect(indexContent).toContain("./components/status-card");
-    expect(indexContent).not.toContain("./components/StatusCard");
+  } finally {
+    fs.rmSync(runDir, { recursive: true, force: true });
+  }
+}
 
-    // Verify: alias import was updated
-    const pageContent = fs.readFileSync(
-      path.join(fixtureDir, "src", "app", "page.tsx"),
-      "utf-8",
+const read = (...segments) =>
+  fs.readFileSync(path.join(fixtureDir, ...segments), "utf-8");
+
+describe("codemod CLI integration", () => {
+  it("renames files and updates every kind of specifier", () => {
+    fixtureDir = writeFixture();
+
+    const output = runCodemod(fixtureDir);
+
+    // The tree ends up in exactly this shape — no file left behind at its old
+    // name, and no directory nested under a source directory.
+    expect(listFiles(fixtureDir)).toEqual([
+      "src/app/page.tsx",
+      "src/components/status-card.tsx",
+      "src/index.ts",
+      "tests/status-card.test.tsx",
+      "tsconfig.json",
+    ]);
+
+    // Relative re-export, rewritten by ts-morph's move.
+    expect(read("src", "index.ts")).toContain("./components/status-card");
+
+    // Alias import, rewritten by pass 3.
+    expect(read("src", "app", "page.tsx")).toContain(
+      "@/components/status-card",
     );
-    expect(pageContent).toContain("@/components/status-card");
-    expect(pageContent).not.toContain("@/components/StatusCard");
+
+    // The test file lives outside the tsconfig `include`, so this only passes
+    // because the CLI adds collected files to the project.
+    const testFile = read("tests", "status-card.test.tsx");
+    expect(testFile).toContain('from "../src/components/status-card"');
+    expect(testFile).toContain('vi.mock("@/components/status-card")');
+    expect(testFile).toContain('vi.mock("../src/components/status-card")');
+    expect(testFile).not.toContain("components/StatusCard");
+
+    expect(output).toContain("rewrote 2 vi.mock/require specifier(s)");
+  });
+
+  it("previews the mock rewrites in a dry run without writing anything", () => {
+    fixtureDir = writeFixture();
+    const before = listFiles(fixtureDir).map((f) => [f, read(f)]);
+
+    const output = runCodemod(fixtureDir, ["--dry-run"]);
+
+    expect(output).toContain(
+      "2 vi.mock/require specifier(s) would be rewritten",
+    );
+    expect(output).toContain("dry run — nothing written");
+    expect(before.map(([file]) => [file, read(file)])).toEqual(before);
   });
 });

--- a/scripts/__tests__/codemod-kebab-integration.test.mjs
+++ b/scripts/__tests__/codemod-kebab-integration.test.mjs
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const CODEMOD_SCRIPT = fileURLToPath(
@@ -62,6 +62,16 @@ function writeFixture() {
     path.join(root, "src", "app", "page.tsx"),
     'import { StatusCard } from "@/components/StatusCard";\nexport default StatusCard;',
   );
+  // A path-aliased dynamic import and an import-type node: ts-morph's move
+  // touches neither, and tsc only catches them after the rename has landed.
+  fs.writeFileSync(
+    path.join(root, "src", "lazy.ts"),
+    [
+      'export const load = () => import("@/components/StatusCard");',
+      'export type Card = typeof import("@/components/StatusCard").StatusCard;',
+      'export const keep = () => import("@/components/StatusCard");',
+    ].join("\n"),
+  );
   fs.writeFileSync(
     path.join(root, "tests", "StatusCard.test.tsx"),
     [
@@ -78,14 +88,21 @@ function writeFixture() {
 
 function runCodemod(workspace, extraArgs = []) {
   // Run from a directory that is neither the repo nor the fixture, so any
-  // cwd-relative path handling fails loudly.
+  // cwd-relative path handling fails loudly. stdout and stderr are joined
+  // because the CLI reports on both — every warning goes to console.warn.
   const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "kebab-run-"));
   try {
-    return execFileSync(
+    const result = spawnSync(
       "node",
       [CODEMOD_SCRIPT, "--workspace", workspace, ...extraArgs],
-      { cwd: runDir, stdio: "pipe", encoding: "utf8" },
+      { cwd: runDir, encoding: "utf8" },
     );
+    if (result.error) throw result.error;
+    const output = `${result.stdout}${result.stderr}`;
+    if (result.status !== 0) {
+      throw new Error(`codemod exited ${result.status}\n${output}`);
+    }
+    return output;
   } finally {
     fs.rmSync(runDir, { recursive: true, force: true });
   }
@@ -106,6 +123,7 @@ describe("codemod CLI integration", () => {
       "src/app/page.tsx",
       "src/components/status-card.tsx",
       "src/index.ts",
+      "src/lazy.ts",
       "tests/status-card.test.tsx",
       "tsconfig.json",
     ]);
@@ -127,6 +145,17 @@ describe("codemod CLI integration", () => {
     expect(testFile).not.toContain("components/StatusCard");
 
     expect(output).toContain("rewrote 2 vi.mock/require specifier(s)");
+
+    // Aliased dynamic import() and import-type nodes, rewritten by pass 3.
+    const lazy = read("src", "lazy.ts");
+    expect(lazy).not.toContain("components/StatusCard");
+    expect(lazy).toContain('import("@/components/status-card")');
+    expect(lazy).toContain(
+      'typeof import("@/components/status-card").StatusCard',
+    );
+    expect(output).toContain(
+      "rewrote 3 aliased dynamic import()/import-type specifier(s)",
+    );
   });
 
   it("previews the mock rewrites in a dry run without writing anything", () => {
@@ -138,6 +167,11 @@ describe("codemod CLI integration", () => {
     expect(output).toContain(
       "2 vi.mock/require specifier(s) would be rewritten",
     );
+    expect(output).toContain(
+      "3 aliased dynamic import()/import-type specifier(s) would be rewritten",
+    );
+    // Filtered: the blanket "not rewritten" list is gone.
+    expect(output).not.toContain("are NOT rewritten");
     expect(output).toContain("dry run — nothing written");
     expect(before.map(([file]) => [file, read(file)])).toEqual(before);
   });
@@ -147,9 +181,12 @@ describe("codemod CLI integration", () => {
     // A fresh repo with untracked fixture files is, by definition, dirty.
     execFileSync("git", ["init", "-q"], { cwd: fixtureDir, stdio: "pipe" });
 
-    expect(runCodemod(fixtureDir, ["--dry-run"])).toContain(
-      "dry run — nothing written",
-    );
+    const dryRun = runCodemod(fixtureDir, ["--dry-run"]);
+    expect(dryRun).toContain("dry run — nothing written");
+    // `git checkout` neither unstages a `git mv` nor deletes the new untracked
+    // kebab-named files, so it must not be the advertised recovery.
+    expect(dryRun).not.toContain("`git checkout`");
+    expect(dryRun).toContain("`git reset --hard HEAD && git clean -fd`");
 
     expect(() => runCodemod(fixtureDir)).toThrow();
     expect(

--- a/scripts/__tests__/codemod-kebab-integration.test.mjs
+++ b/scripts/__tests__/codemod-kebab-integration.test.mjs
@@ -141,4 +141,21 @@ describe("codemod CLI integration", () => {
     expect(output).toContain("dry run — nothing written");
     expect(before.map(([file]) => [file, read(file)])).toEqual(before);
   });
+
+  it("refuses to apply against a dirty working tree, but still dry-runs", () => {
+    fixtureDir = writeFixture();
+    // A fresh repo with untracked fixture files is, by definition, dirty.
+    execFileSync("git", ["init", "-q"], { cwd: fixtureDir, stdio: "pipe" });
+
+    expect(runCodemod(fixtureDir, ["--dry-run"])).toContain(
+      "dry run — nothing written",
+    );
+
+    expect(() => runCodemod(fixtureDir)).toThrow();
+    expect(
+      fs.existsSync(
+        path.join(fixtureDir, "src", "components", "StatusCard.tsx"),
+      ),
+    ).toBe(true);
+  });
 });

--- a/scripts/__tests__/codemod-kebab-integration.test.mjs
+++ b/scripts/__tests__/codemod-kebab-integration.test.mjs
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+let fixtureDir;
+
+afterEach(() => {
+  if (fixtureDir) {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fixtureDir = null;
+  }
+});
+
+describe("codemod CLI integration", () => {
+  it("renames files and updates imports without creating nested directories", () => {
+    // Create temp fixture
+    fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "kebab-integration-"));
+
+    // Write tsconfig.json
+    fs.writeFileSync(
+      path.join(fixtureDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          paths: {
+            "@/*": ["./src/*"],
+          },
+        },
+      }),
+    );
+
+    // Create directory structure
+    fs.mkdirSync(path.join(fixtureDir, "src", "components"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(fixtureDir, "src", "app"), { recursive: true });
+
+    // Write source files
+    fs.writeFileSync(
+      path.join(fixtureDir, "src", "components", "StatusCard.tsx"),
+      "export function StatusCard() { return null; }",
+    );
+
+    fs.writeFileSync(
+      path.join(fixtureDir, "src", "index.ts"),
+      'export { StatusCard } from "./components/StatusCard";',
+    );
+
+    fs.writeFileSync(
+      path.join(fixtureDir, "src", "app", "page.tsx"),
+      'import { StatusCard } from "@/components/StatusCard";\nexport default StatusCard;',
+    );
+
+    // Run the CLI as a child process from a different directory
+    const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "kebab-run-"));
+    try {
+      const codemodScript = path.resolve(
+        ".",
+        "scripts",
+        "codemod-kebab-filenames.mjs",
+      );
+
+      execFileSync("node", [codemodScript, "--workspace", fixtureDir], {
+        cwd: runDir,
+        stdio: "pipe",
+      });
+    } finally {
+      fs.rmSync(runDir, { recursive: true, force: true });
+    }
+
+    // Verify: StatusCard was renamed
+    expect(
+      fs.existsSync(
+        path.join(fixtureDir, "src", "components", "status-card.tsx"),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(fixtureDir, "src", "components", "StatusCard.tsx"),
+      ),
+    ).toBe(false);
+
+    // Verify: no nested directory was created
+    expect(
+      fs.existsSync(path.join(fixtureDir, "src", "components", "src")),
+    ).toBe(false);
+    expect(fs.existsSync(path.join(fixtureDir, "src", "src"))).toBe(false);
+
+    // Verify: relative re-export was updated
+    const indexContent = fs.readFileSync(
+      path.join(fixtureDir, "src", "index.ts"),
+      "utf-8",
+    );
+    expect(indexContent).toContain("./components/status-card");
+    expect(indexContent).not.toContain("./components/StatusCard");
+
+    // Verify: alias import was updated
+    const pageContent = fs.readFileSync(
+      path.join(fixtureDir, "src", "app", "page.tsx"),
+      "utf-8",
+    );
+    expect(pageContent).toContain("@/components/status-card");
+    expect(pageContent).not.toContain("@/components/StatusCard");
+  });
+});

--- a/scripts/__tests__/dynamic-import-audit.test.mjs
+++ b/scripts/__tests__/dynamic-import-audit.test.mjs
@@ -1,7 +1,10 @@
 // scripts/__tests__/dynamic-import-audit.test.mjs
 import { describe, it, expect } from "vitest";
 import { Project } from "ts-morph";
-import { auditDynamicImports } from "../lib/dynamic-import-audit.mjs";
+import {
+  auditDynamicImports,
+  partitionDynamicImports,
+} from "../lib/dynamic-import-audit.mjs";
 
 function projectWith(source) {
   const project = new Project({ useInMemoryFileSystem: true });
@@ -43,5 +46,58 @@ describe("auditDynamicImports", () => {
   it("ignores static import declarations", () => {
     const found = auditDynamicImports(projectWith(`import x from "./x";`));
     expect(found).toEqual([]);
+  });
+
+  it("carries the literal specifier value for a static call", () => {
+    const found = auditDynamicImports(
+      projectWith(`const m = import("@/components/StatusCard");`),
+    );
+    expect(found[0].specifier).toBe("@/components/StatusCard");
+  });
+
+  it("leaves the specifier null for a computed call", () => {
+    const found = auditDynamicImports(
+      projectWith("const n = 'x';\nconst m = import(`./${n}`);"),
+    );
+    expect(found[0].specifier).toBeNull();
+  });
+
+  it("captures an import() type node", () => {
+    const found = auditDynamicImports(
+      projectWith(`type T = import("shared/AppRootLayout").Props;`),
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].kind).toBe("type");
+    expect(found[0].static).toBe(true);
+    expect(found[0].specifier).toBe("shared/AppRootLayout");
+  });
+});
+
+describe("partitionDynamicImports", () => {
+  it("separates computed specifiers from aliased ones", () => {
+    const entries = auditDynamicImports(
+      projectWith(
+        [
+          `const a = import("./relative-one");`,
+          `const b = import("@/components/StatusCard");`,
+          `const n = "x";`,
+          "const c = import(`./${n}`);",
+        ].join("\n"),
+      ),
+    );
+
+    const { computed, aliased } = partitionDynamicImports(entries);
+    expect(computed.map((e) => e.line)).toEqual([4]);
+    expect(aliased.map((e) => e.specifier)).toEqual([
+      "@/components/StatusCard",
+    ]);
+  });
+
+  it("does not discard a static-but-aliased specifier the way !static did", () => {
+    const entries = auditDynamicImports(
+      projectWith(`const b = import("shared/createAppI18n");`),
+    );
+    expect(entries.filter((e) => !e.static)).toEqual([]);
+    expect(partitionDynamicImports(entries).aliased).toHaveLength(1);
   });
 });

--- a/scripts/__tests__/dynamic-import-audit.test.mjs
+++ b/scripts/__tests__/dynamic-import-audit.test.mjs
@@ -1,0 +1,47 @@
+// scripts/__tests__/dynamic-import-audit.test.mjs
+import { describe, it, expect } from "vitest";
+import { Project } from "ts-morph";
+import { auditDynamicImports } from "../lib/dynamic-import-audit.mjs";
+
+function projectWith(source) {
+  const project = new Project({ useInMemoryFileSystem: true });
+  project.createSourceFile("a.ts", source);
+  return project;
+}
+
+describe("auditDynamicImports", () => {
+  it("marks a string-literal specifier as static", () => {
+    const found = auditDynamicImports(
+      projectWith(`const m = import("./login-form");`),
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].static).toBe(true);
+  });
+
+  it("marks a template-literal specifier as not static", () => {
+    const found = auditDynamicImports(
+      projectWith("const n = 'x';\nconst m = import(`./${n}`);"),
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].static).toBe(false);
+  });
+
+  it("marks an identifier specifier as not static", () => {
+    const found = auditDynamicImports(
+      projectWith(`const p = "./x"; const m = import(p);`),
+    );
+    expect(found[0].static).toBe(false);
+  });
+
+  it("reports the line number", () => {
+    const found = auditDynamicImports(
+      projectWith(`\n\nconst m = import("./x");`),
+    );
+    expect(found[0].line).toBe(3);
+  });
+
+  it("ignores static import declarations", () => {
+    const found = auditDynamicImports(projectWith(`import x from "./x";`));
+    expect(found).toEqual([]);
+  });
+});

--- a/scripts/__tests__/kebab-rename-engine.test.mjs
+++ b/scripts/__tests__/kebab-rename-engine.test.mjs
@@ -1,7 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { Project } from "ts-morph";
 import { buildRenamePlan } from "../lib/kebab-rename-plan.mjs";
-import { applyRenames } from "../lib/kebab-rename-engine.mjs";
+import {
+  applyRenames,
+  gitMoveCaseOnly,
+  recordImportSpecifiers,
+} from "../lib/kebab-rename-engine.mjs";
 
 function project(files) {
   const p = new Project({ useInMemoryFileSystem: true });
@@ -146,5 +153,328 @@ describe("applyRenames", () => {
     expect(pageText).toContain(`from "@/components/Button"`);
     // StatusCard import should be updated to the kebab-case name
     expect(pageText).toContain(`from "@/components/status-card"`);
+  });
+});
+
+describe("recordImportSpecifiers", () => {
+  it("records a RELATIVE specifier whose target is a case-only rename", () => {
+    const p = project({
+      "/src/Pagination.tsx": `export const Pagination = () => null;`,
+      "/src/page.tsx": `import { Pagination } from "./Pagination";\nexport default Pagination;`,
+    });
+    const { plan } = buildRenamePlan(["/src/Pagination.tsx"]);
+    const records = recordImportSpecifiers(p, plan);
+
+    expect(records).toHaveLength(1);
+    expect(records[0].relative).toBe(true);
+    expect(records[0].specifier).toBe("./Pagination");
+    expect(records[0].resolvedPath).toBe("/src/Pagination.tsx");
+  });
+
+  it("records a relative re-export of a case-only rename too", () => {
+    const p = project({
+      "/src/Pagination.tsx": `export const Pagination = () => null;`,
+      "/src/index.ts": `export { Pagination } from "./Pagination";`,
+    });
+    const { plan } = buildRenamePlan(["/src/Pagination.tsx"]);
+
+    expect(recordImportSpecifiers(p, plan).map((r) => r.specifier)).toEqual([
+      "./Pagination",
+    ]);
+  });
+
+  it("does NOT record a relative specifier for a structural rename", () => {
+    const p = project({
+      "/src/LoginForm.tsx": `export const LoginForm = () => null;`,
+      "/src/page.tsx": `import { LoginForm } from "./LoginForm";\nexport default LoginForm;`,
+    });
+    const { plan } = buildRenamePlan(["/src/LoginForm.tsx"]);
+
+    // ts-morph's move rewrites these on its own.
+    expect(recordImportSpecifiers(p, plan)).toEqual([]);
+  });
+
+  it("still records non-relative specifiers", () => {
+    const p = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: { baseUrl: "/", paths: { "@/*": ["src/*"] } },
+    });
+    p.createSourceFile(
+      "/src/components/StatusCard.tsx",
+      `export const StatusCard = () => null;`,
+    );
+    p.createSourceFile(
+      "/src/app/page.tsx",
+      `import { StatusCard } from "@/components/StatusCard";\nexport default StatusCard;`,
+    );
+    const { plan } = buildRenamePlan(["/src/components/StatusCard.tsx"]);
+    const records = recordImportSpecifiers(p, plan);
+
+    expect(records).toHaveLength(1);
+    expect(records[0].relative).toBe(false);
+    expect(records[0].specifier).toBe("@/components/StatusCard");
+  });
+});
+
+describe("applyRenames on a case-INSENSITIVE (real) filesystem", () => {
+  let directory;
+
+  afterEach(() => {
+    if (directory) fs.rmSync(directory, { recursive: true, force: true });
+    directory = null;
+  });
+
+  it("rewrites a relative importer of a case-only rename", () => {
+    directory = fs
+      .mkdtempSync(path.join(os.tmpdir(), "kebab-caseonly-"))
+      .split(path.sep)
+      .join("/");
+    fs.mkdirSync(`${directory}/src`, { recursive: true });
+    fs.writeFileSync(
+      `${directory}/src/Pagination.tsx`,
+      "export const Pagination = () => null;\n",
+    );
+    fs.writeFileSync(
+      `${directory}/src/page.tsx`,
+      'import { Pagination } from "./Pagination";\nexport default Pagination;\n',
+    );
+
+    const p = new Project({
+      compilerOptions: { baseUrl: directory, jsx: 4 },
+      skipAddingFilesFromTsConfig: true,
+    });
+    p.addSourceFilesAtPaths(`${directory}/src/**/*.tsx`);
+
+    const { plan } = buildRenamePlan([`${directory}/src/Pagination.tsx`]);
+    expect(plan[0].caseOnly).toBe(true);
+
+    applyRenames(p, plan);
+
+    const page = fs.readFileSync(`${directory}/src/page.tsx`, "utf8");
+    expect(page).toContain('from "./pagination"');
+    expect(page).not.toContain('from "./Pagination"');
+  });
+});
+
+describe("vi.mock specifier rewriting", () => {
+  it("rewrites a relative vi.mock target", () => {
+    const p = project({
+      "/src/LoginForm.tsx": `export const LoginForm = () => null;`,
+      "/src/login.test.ts": `import { vi } from "vitest";\nvi.mock("./LoginForm");`,
+    });
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/LoginForm.tsx"]).plan,
+    );
+
+    expect(report.mockRewrites).toBe(1);
+    expect(
+      p.getSourceFileOrThrow("/src/login.test.ts").getFullText(),
+    ).toContain(`vi.mock("./login-form")`);
+  });
+
+  it("rewrites an aliased vi.mock target", () => {
+    const p = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: { baseUrl: "/", paths: { "@/*": ["src/*"] } },
+    });
+    p.createSourceFile(
+      "/src/components/StatusCard.tsx",
+      `export const StatusCard = () => null;`,
+    );
+    p.createSourceFile(
+      "/tests/status.test.ts",
+      `import { vi } from "vitest";\nvi.mock("@/components/StatusCard");\nvi.doMock("@/components/StatusCard");`,
+    );
+
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/components/StatusCard.tsx"]).plan,
+    );
+
+    expect(report.mockRewrites).toBe(2);
+    const text = p.getSourceFileOrThrow("/tests/status.test.ts").getFullText();
+    expect(text).toContain(`vi.mock("@/components/status-card")`);
+    expect(text).toContain(`vi.doMock("@/components/status-card")`);
+  });
+
+  it("rewrites vi.importActual and require targets", () => {
+    const p = project({
+      "/src/MSWProvider.tsx": `export const MSWProvider = () => null;`,
+      "/src/setup.ts": `import { vi } from "vitest";\nvi.importActual("./MSWProvider");\nconst m = require("./MSWProvider");`,
+    });
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/MSWProvider.tsx"]).plan,
+    );
+
+    expect(report.mockRewrites).toBe(2);
+    const text = p.getSourceFileOrThrow("/src/setup.ts").getFullText();
+    expect(text).toContain(`vi.importActual("./msw-provider")`);
+    expect(text).toContain(`require("./msw-provider")`);
+  });
+
+  it("leaves a mock of a non-renamed module untouched", () => {
+    const p = project({
+      "/src/LoginForm.tsx": `export const LoginForm = () => null;`,
+      "/src/login.test.ts": `import { vi } from "vitest";\nvi.mock("next/navigation");`,
+    });
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/LoginForm.tsx"]).plan,
+    );
+
+    expect(report.mockRewrites).toBe(0);
+    expect(
+      p.getSourceFileOrThrow("/src/login.test.ts").getFullText(),
+    ).toContain(`vi.mock("next/navigation")`);
+  });
+
+  it("reports an unresolvable non-kebab mock target for manual attention", () => {
+    const p = project({
+      "/src/LoginForm.tsx": `export const LoginForm = () => null;`,
+      "/src/login.test.ts": `import { vi } from "vitest";\nvi.mock("@/nowhere/GhostModule");`,
+    });
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/LoginForm.tsx"]).plan,
+    );
+
+    expect(report.mockManual).toHaveLength(1);
+    expect(report.mockManual[0].specifier).toBe("@/nowhere/GhostModule");
+    expect(report.mockManual[0].line).toBe(2);
+  });
+
+  it("reports a computed vi.mock target for manual attention", () => {
+    const p = project({
+      "/src/LoginForm.tsx": `export const LoginForm = () => null;`,
+      "/src/login.test.ts":
+        'import { vi } from "vitest";\nconst n = "LoginForm";\nvi.mock(`./${n}`);',
+    });
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/LoginForm.tsx"]).plan,
+    );
+
+    expect(report.mockManual).toHaveLength(1);
+    expect(report.mockManual[0].reason).toMatch(/computed/);
+  });
+});
+
+describe("last-segment guard", () => {
+  it("skips and reports a specifier whose last segment does not name the file", () => {
+    const p = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: {
+        baseUrl: "/",
+        paths: { "shared/app-root-layout": ["src/AppRootLayout"] },
+      },
+    });
+    p.createSourceFile(
+      "/src/AppRootLayout.tsx",
+      `export const AppRootLayout = () => null;`,
+    );
+    p.createSourceFile(
+      "/app/page.tsx",
+      `import { AppRootLayout } from "shared/app-root-layout";\nexport default AppRootLayout;`,
+    );
+
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/AppRootLayout.tsx"]).plan,
+    );
+
+    expect(report.specifierMismatches).toHaveLength(1);
+    expect(report.specifierMismatches[0].specifier).toBe(
+      "shared/app-root-layout",
+    );
+    // Left exactly as it was, rather than rewritten to a path that resolves
+    // to nothing.
+    expect(p.getSourceFileOrThrow("/app/page.tsx").getFullText()).toContain(
+      `from "shared/app-root-layout"`,
+    );
+  });
+});
+
+describe("gitMoveCaseOnly", () => {
+  it("moves through a temporary name", () => {
+    const run = vi.fn();
+    gitMoveCaseOnly("/a/Pagination.tsx", "/a/pagination.tsx", { run });
+
+    expect(run.mock.calls.map((call) => call[1])).toEqual([
+      ["mv", "/a/Pagination.tsx", "/a/Pagination.tsx.casetmp"],
+      ["mv", "/a/Pagination.tsx.casetmp", "/a/pagination.tsx"],
+    ]);
+  });
+
+  it("surfaces git's stderr as text, not as a decimal byte dump", () => {
+    const run = vi.fn(() => {
+      const error = new Error("Command failed");
+      error.stderr = Buffer.from("fatal: bad source, source=Pagination.tsx\n");
+      throw error;
+    });
+
+    expect(() =>
+      gitMoveCaseOnly("/a/Pagination.tsx", "/a/pagination.tsx", { run }),
+    ).toThrow(/fatal: bad source, source=Pagination\.tsx/);
+  });
+
+  it("restores the .casetmp file when the second move fails", () => {
+    const run = vi.fn((_command, args) => {
+      if (args[2] === "/a/pagination.tsx") {
+        const error = new Error("Command failed");
+        error.stderr = Buffer.from("fatal: destination exists\n");
+        throw error;
+      }
+    });
+
+    expect(() =>
+      gitMoveCaseOnly("/a/Pagination.tsx", "/a/pagination.tsx", { run }),
+    ).toThrow(/restored/);
+
+    expect(run.mock.calls[2][1]).toEqual([
+      "mv",
+      "/a/Pagination.tsx.casetmp",
+      "/a/Pagination.tsx",
+    ]);
+  });
+
+  it("falls back to a filesystem rename when git cannot restore the temp file", () => {
+    const run = vi.fn((_command, args) => {
+      if (args[1].endsWith(".casetmp")) {
+        const error = new Error("Command failed");
+        error.stderr = Buffer.from("fatal: not under version control\n");
+        throw error;
+      }
+    });
+    const rename = vi.fn();
+
+    expect(() =>
+      gitMoveCaseOnly("/a/Pagination.tsx", "/a/pagination.tsx", {
+        run,
+        rename,
+      }),
+    ).toThrow(/restored/);
+
+    expect(rename).toHaveBeenCalledWith(
+      "/a/Pagination.tsx.casetmp",
+      "/a/Pagination.tsx",
+    );
+  });
+
+  it("warns instead of hiding the failure when cleanup is impossible", () => {
+    const run = vi.fn((_command, args) => {
+      if (args[1].endsWith(".casetmp")) throw new Error("git exploded");
+    });
+    const rename = vi.fn(() => {
+      throw new Error("EPERM");
+    });
+
+    expect(() =>
+      gitMoveCaseOnly("/a/Pagination.tsx", "/a/pagination.tsx", {
+        run,
+        rename,
+      }),
+    ).toThrow(/could not clean up/);
   });
 });

--- a/scripts/__tests__/kebab-rename-engine.test.mjs
+++ b/scripts/__tests__/kebab-rename-engine.test.mjs
@@ -56,6 +56,22 @@ describe("applyRenames", () => {
     );
   });
 
+  it("leaves a relative dynamic import to ts-morph, without double-handling it", () => {
+    const p = project({
+      "/src/StatusCard.tsx": `export const StatusCard = () => null;`,
+      "/src/lazy.ts": `export const Lazy = () => import("./StatusCard");`,
+    });
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/StatusCard.tsx"]).plan,
+    );
+
+    expect(report.dynamicRewrites).toBe(0);
+    expect(p.getSourceFileOrThrow("/src/lazy.ts").getFullText()).toContain(
+      `import("./status-card")`,
+    );
+  });
+
   it("delegates a case-only rename to gitMove", () => {
     const gitMove = vi.fn();
     const p = project({
@@ -392,6 +408,173 @@ describe("last-segment guard", () => {
     // to nothing.
     expect(p.getSourceFileOrThrow("/app/page.tsx").getFullText()).toContain(
       `from "shared/app-root-layout"`,
+    );
+  });
+
+  it("reports a refused mock specifier once, not under two headings", () => {
+    const p = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: {
+        baseUrl: "/",
+        paths: { "shared/app-root-layout": ["src/AppRootLayout"] },
+      },
+    });
+    p.createSourceFile(
+      "/src/AppRootLayout.tsx",
+      `export const AppRootLayout = () => null;`,
+    );
+    p.createSourceFile(
+      "/tests/layout.test.ts",
+      `import { vi } from "vitest";\nvi.mock("shared/app-root-layout");`,
+    );
+
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/AppRootLayout.tsx"]).plan,
+    );
+
+    expect(report.specifierMismatches).toHaveLength(1);
+    expect(report.mockManual).toEqual([]);
+  });
+});
+
+describe("report counters", () => {
+  it("counts only import specifiers it actually changed", () => {
+    const p = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: { baseUrl: "/", paths: { "@/*": ["src/*"] } },
+    });
+    p.createSourceFile(
+      "/src/components/StatusCard.tsx",
+      `export const StatusCard = () => null;`,
+    );
+    p.createSourceFile(
+      "/src/components/Button.tsx",
+      `export const Button = () => null;`,
+    );
+    p.createSourceFile(
+      "/src/app/page.tsx",
+      `import { StatusCard } from "@/components/StatusCard";\nimport { Button } from "@/components/Button";\nexport default () => (StatusCard(), Button());`,
+    );
+
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/components/StatusCard.tsx"]).plan,
+    );
+
+    // One planned rename, one aliased importer of it — and nothing else.
+    expect(report.importRewrites).toBe(1);
+  });
+});
+
+describe("aliased dynamic import() and import-type rewriting", () => {
+  const aliasProject = () =>
+    new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: { baseUrl: "/", paths: { "@/*": ["src/*"] } },
+    });
+
+  it("rewrites an aliased dynamic import()", () => {
+    const p = aliasProject();
+    p.createSourceFile(
+      "/src/shared/auditLog.ts",
+      `export const insertAuditLog = () => null;`,
+    );
+    p.createSourceFile(
+      "/src/app/route.ts",
+      `export const load = async () => await import("@/shared/auditLog");`,
+    );
+
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/shared/auditLog.ts"]).plan,
+    );
+
+    expect(report.dynamicRewrites).toBe(1);
+    expect(p.getSourceFileOrThrow("/src/app/route.ts").getFullText()).toContain(
+      `import("@/shared/audit-log")`,
+    );
+  });
+
+  it("rewrites an aliased typeof import(...) type node", () => {
+    const p = aliasProject();
+    p.createSourceFile(
+      "/src/shared/auditLog.ts",
+      `export const insertAuditLog = () => null;`,
+    );
+    p.createSourceFile(
+      "/tests/audit.test.ts",
+      `type Insert = typeof import("@/shared/auditLog").insertAuditLog;\nexport type { Insert };`,
+    );
+
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/shared/auditLog.ts"]).plan,
+    );
+
+    expect(report.dynamicRewrites).toBe(1);
+    expect(
+      p.getSourceFileOrThrow("/tests/audit.test.ts").getFullText(),
+    ).toContain(`typeof import("@/shared/audit-log").insertAuditLog`);
+  });
+
+  it("leaves an aliased dynamic import of a NON-renamed file untouched", () => {
+    const p = aliasProject();
+    p.createSourceFile(
+      "/src/shared/utils.ts",
+      `export const noop = () => null;`,
+    );
+    p.createSourceFile(
+      "/src/shared/auditLog.ts",
+      `export const insertAuditLog = () => null;`,
+    );
+    p.createSourceFile(
+      "/src/app/route.ts",
+      `export const load = async () => await import("@/shared/utils");`,
+    );
+
+    // Only auditLog is planned; utils is already kebab-case.
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/shared/auditLog.ts"]).plan,
+    );
+
+    expect(report.dynamicRewrites).toBe(0);
+    expect(report.specifierMismatches).toEqual([]);
+    expect(p.getSourceFileOrThrow("/src/app/route.ts").getFullText()).toContain(
+      `import("@/shared/utils")`,
+    );
+  });
+
+  it("reports, and does not rewrite, a dynamic import whose last segment does not name the file", () => {
+    const p = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: {
+        baseUrl: "/",
+        paths: { "shared/app-root-layout": ["src/AppRootLayout"] },
+      },
+    });
+    p.createSourceFile(
+      "/src/AppRootLayout.tsx",
+      `export const AppRootLayout = () => null;`,
+    );
+    p.createSourceFile(
+      "/src/app/route.ts",
+      `export const load = async () => await import("shared/app-root-layout");`,
+    );
+
+    const report = applyRenames(
+      p,
+      buildRenamePlan(["/src/AppRootLayout.tsx"]).plan,
+    );
+
+    expect(report.dynamicRewrites).toBe(0);
+    expect(report.specifierMismatches).toHaveLength(1);
+    expect(report.specifierMismatches[0].specifier).toBe(
+      "shared/app-root-layout",
+    );
+    expect(p.getSourceFileOrThrow("/src/app/route.ts").getFullText()).toContain(
+      `import("shared/app-root-layout")`,
     );
   });
 });

--- a/scripts/__tests__/kebab-rename-engine.test.mjs
+++ b/scripts/__tests__/kebab-rename-engine.test.mjs
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from "vitest";
+import { Project } from "ts-morph";
+import { buildRenamePlan } from "../lib/kebab-rename-plan.mjs";
+import { applyRenames } from "../lib/kebab-rename-engine.mjs";
+
+function project(files) {
+  const p = new Project({ useInMemoryFileSystem: true });
+  for (const [name, text] of Object.entries(files))
+    p.createSourceFile(name, text);
+  return p;
+}
+
+describe("applyRenames", () => {
+  it("renames the file and rewrites a direct import", () => {
+    const p = project({
+      "/src/LoginForm.tsx": `export const LoginForm = () => null;`,
+      "/src/page.tsx": `import { LoginForm } from "./LoginForm";\nexport default LoginForm;`,
+    });
+    applyRenames(p, buildRenamePlan(["/src/LoginForm.tsx"]).plan);
+
+    expect(p.getSourceFile("/src/login-form.tsx")).toBeDefined();
+    expect(p.getSourceFile("/src/LoginForm.tsx")).toBeUndefined();
+    expect(p.getSourceFileOrThrow("/src/page.tsx").getFullText()).toContain(
+      `from "./login-form"`,
+    );
+  });
+
+  it("rewrites a barrel re-export", () => {
+    const p = project({
+      "/src/MSWProvider.tsx": `export const MSWProvider = () => null;`,
+      "/src/index.ts": `export { MSWProvider } from "./MSWProvider";`,
+    });
+    applyRenames(p, buildRenamePlan(["/src/MSWProvider.tsx"]).plan);
+
+    expect(p.getSourceFileOrThrow("/src/index.ts").getFullText()).toContain(
+      `from "./msw-provider"`,
+    );
+  });
+
+  it("rewrites a static dynamic-import specifier", () => {
+    const p = project({
+      "/src/StatusCard.tsx": `export const StatusCard = () => null;`,
+      "/src/lazy.ts": `export const Lazy = () => import("./StatusCard");`,
+    });
+    applyRenames(p, buildRenamePlan(["/src/StatusCard.tsx"]).plan);
+
+    expect(p.getSourceFileOrThrow("/src/lazy.ts").getFullText()).toContain(
+      `import("./status-card")`,
+    );
+  });
+
+  it("delegates a case-only rename to gitMove", () => {
+    const gitMove = vi.fn();
+    const p = project({
+      "/src/Pagination.tsx": `export const Pagination = () => null;`,
+    });
+    applyRenames(p, buildRenamePlan(["/src/Pagination.tsx"]).plan, { gitMove });
+
+    expect(gitMove).toHaveBeenCalledWith(
+      "/src/Pagination.tsx",
+      "/src/pagination.tsx",
+    );
+  });
+
+  it("does not delegate a structural rename to gitMove", () => {
+    const gitMove = vi.fn();
+    const p = project({
+      "/src/MSWProvider.tsx": `export const MSWProvider = () => null;`,
+    });
+    applyRenames(p, buildRenamePlan(["/src/MSWProvider.tsx"]).plan, {
+      gitMove,
+    });
+
+    expect(gitMove).not.toHaveBeenCalled();
+  });
+
+  it("rewrites an import that goes through a @/ path alias", () => {
+    const p = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: { baseUrl: "/", paths: { "@/*": ["src/*"] } },
+    });
+    p.createSourceFile(
+      "/src/components/StatusCard.tsx",
+      `export const StatusCard = () => null;`,
+    );
+    p.createSourceFile(
+      "/src/app/page.tsx",
+      `import { StatusCard } from "@/components/StatusCard";\nexport default StatusCard;`,
+    );
+
+    applyRenames(p, buildRenamePlan(["/src/components/StatusCard.tsx"]).plan);
+
+    expect(p.getSourceFileOrThrow("/src/app/page.tsx").getFullText()).toContain(
+      `from "@/components/status-card"`,
+    );
+  });
+
+  it("rewrites a test file importing across the src/tests boundary", () => {
+    const p = project({
+      "/src/LoginForm.tsx": `export const LoginForm = () => null;`,
+      "/tests/LoginForm.test.tsx": `import { LoginForm } from "../src/LoginForm";\nit("renders", () => LoginForm());`,
+    });
+    applyRenames(
+      p,
+      buildRenamePlan(["/src/LoginForm.tsx", "/tests/LoginForm.test.tsx"]).plan,
+    );
+
+    expect(p.getSourceFile("/tests/login-form.test.tsx")).toBeDefined();
+    expect(
+      p.getSourceFileOrThrow("/tests/login-form.test.tsx").getFullText(),
+    ).toContain(`from "../src/login-form"`);
+  });
+
+  it("throws when a planned file is not part of the project", () => {
+    const p = project({ "/src/a.ts": `export const a = 1;` });
+    expect(() =>
+      applyRenames(p, [
+        { from: "/src/Ghost.ts", to: "/src/ghost.ts", caseOnly: false },
+      ]),
+    ).toThrow("not in project: /src/Ghost.ts");
+  });
+});

--- a/scripts/__tests__/kebab-rename-engine.test.mjs
+++ b/scripts/__tests__/kebab-rename-engine.test.mjs
@@ -119,4 +119,32 @@ describe("applyRenames", () => {
       ]),
     ).toThrow("not in project: /src/Ghost.ts");
   });
+
+  it("leaves alias imports of non-renamed files completely unchanged", () => {
+    const p = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: { baseUrl: "/", paths: { "@/*": ["src/*"] } },
+    });
+    p.createSourceFile(
+      "/src/components/Button.tsx",
+      `export const Button = () => null;`,
+    );
+    p.createSourceFile(
+      "/src/components/StatusCard.tsx",
+      `export const StatusCard = () => null;`,
+    );
+    p.createSourceFile(
+      "/src/app/page.tsx",
+      `import { Button } from "@/components/Button";\nimport { StatusCard } from "@/components/StatusCard";\nexport default () => (Button(), StatusCard());`,
+    );
+
+    // Only rename StatusCard, not Button
+    applyRenames(p, buildRenamePlan(["/src/components/StatusCard.tsx"]).plan);
+
+    const pageText = p.getSourceFileOrThrow("/src/app/page.tsx").getFullText();
+    // Button import should not be changed (it's not in the plan)
+    expect(pageText).toContain(`from "@/components/Button"`);
+    // StatusCard import should be updated to the kebab-case name
+    expect(pageText).toContain(`from "@/components/status-card"`);
+  });
 });

--- a/scripts/__tests__/kebab-rename-plan.test.mjs
+++ b/scripts/__tests__/kebab-rename-plan.test.mjs
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { toKebab, buildRenamePlan } from "../lib/kebab-rename-plan.mjs";
+
+describe("toKebab", () => {
+  it("splits camelCase", () => {
+    expect(toKebab("loginForm")).toBe("login-form");
+  });
+
+  it("splits PascalCase", () => {
+    expect(toKebab("LoginForm")).toBe("login-form");
+  });
+
+  it("splits acronym boundaries", () => {
+    expect(toKebab("MSWProvider")).toBe("msw-provider");
+    expect(toKebab("useAIData")).toBe("use-ai-data");
+    expect(toKebab("AIOptimization")).toBe("ai-optimization");
+  });
+
+  it("handles lowercase acronyms already joined", () => {
+    expect(toKebab("graphqlFetch")).toBe("graphql-fetch");
+    expect(toKebab("currentUserId")).toBe("current-user-id");
+  });
+
+  it("splits before a capital that follows a digit", () => {
+    expect(toKebab("h2Heading")).toBe("h2-heading");
+  });
+
+  it("leaves already-kebab and single-word names alone", () => {
+    expect(toKebab("already-kebab")).toBe("already-kebab");
+    expect(toKebab("utils")).toBe("utils");
+  });
+
+  it("lowercases a single-word PascalCase name", () => {
+    expect(toKebab("Pagination")).toBe("pagination");
+  });
+});
+
+describe("buildRenamePlan", () => {
+  it("preserves compound extensions", () => {
+    const { plan } = buildRenamePlan(["src/LoginForm.test.tsx"]);
+    expect(plan).toEqual([
+      { from: "src/LoginForm.test.tsx", to: "src/login-form.test.tsx", caseOnly: false },
+    ]);
+  });
+
+  it("omits files that are already compliant", () => {
+    const { plan } = buildRenamePlan(["src/login-form.tsx", "src/utils.ts"]);
+    expect(plan).toEqual([]);
+  });
+
+  it("flags a case-only rename", () => {
+    const { plan } = buildRenamePlan(["src/Pagination.tsx"]);
+    expect(plan[0]).toEqual({
+      from: "src/Pagination.tsx",
+      to: "src/pagination.tsx",
+      caseOnly: true,
+    });
+  });
+
+  it("does not flag an acronym rename as case-only", () => {
+    const { plan } = buildRenamePlan(["src/MSWProvider.tsx"]);
+    expect(plan[0].to).toBe("src/msw-provider.tsx");
+    expect(plan[0].caseOnly).toBe(false);
+  });
+
+  it("reports collisions instead of silently overwriting", () => {
+    const { collisions } = buildRenamePlan(["src/userApi.ts", "src/UserAPI.ts"]);
+    expect(collisions).toEqual([
+      { target: "src/user-api.ts", sources: ["src/userApi.ts", "src/UserAPI.ts"] },
+    ]);
+  });
+
+  it("reports no collisions when targets are distinct", () => {
+    const { collisions } = buildRenamePlan(["src/userApi.ts", "src/userDb.ts"]);
+    expect(collisions).toEqual([]);
+  });
+});

--- a/scripts/codemod-kebab-filenames.mjs
+++ b/scripts/codemod-kebab-filenames.mjs
@@ -58,13 +58,15 @@ function main() {
   const files = collectFiles(workspace);
   const cwd = process.cwd();
   const { plan, collisions } = buildRenamePlan(
-    files.map((f) => path.relative(cwd, f).split(path.sep).join("/")),
+    files.map((f) => f.split(path.sep).join("/")),
   );
 
   if (collisions.length > 0) {
     console.error(`${collisions.length} collision(s) — refusing to proceed:`);
     for (const { target, sources } of collisions) {
-      console.error(`  ${target} <= ${sources.join(", ")}`);
+      console.error(
+        `  ${path.relative(cwd, target).split(path.sep).join("/")} <= ${sources.map((s) => path.relative(cwd, s).split(path.sep).join("/")).join(", ")}`,
+      );
     }
     process.exit(1);
   }
@@ -79,13 +81,21 @@ function main() {
       `${computed.length} computed import() call(s) need manual review:`,
     );
     for (const entry of computed) {
-      console.warn(`  ${entry.file}:${entry.line}  ${entry.text}`);
+      const displayFile = path
+        .relative(cwd, entry.file)
+        .split(path.sep)
+        .join("/");
+      console.warn(`  ${displayFile}:${entry.line}  ${entry.text}`);
     }
   }
 
   console.log(`${plan.length} file(s) to rename in ${values.workspace}`);
   for (const { from, to, caseOnly } of plan) {
-    console.log(`  ${from} -> ${to}${caseOnly ? "  (case-only)" : ""}`);
+    const displayFrom = path.relative(cwd, from).split(path.sep).join("/");
+    const displayTo = path.relative(cwd, to).split(path.sep).join("/");
+    console.log(
+      `  ${displayFrom} -> ${displayTo}${caseOnly ? "  (case-only)" : ""}`,
+    );
   }
 
   if (values["dry-run"]) {

--- a/scripts/codemod-kebab-filenames.mjs
+++ b/scripts/codemod-kebab-filenames.mjs
@@ -1,0 +1,105 @@
+import fs from "node:fs";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { Project } from "ts-morph";
+import { buildRenamePlan } from "./lib/kebab-rename-plan.mjs";
+import { auditDynamicImports } from "./lib/dynamic-import-audit.mjs";
+import { applyRenames, gitMoveCaseOnly } from "./lib/kebab-rename-engine.mjs";
+
+const SOURCE_DIRECTORIES = ["src", "tests", "test", "e2e"];
+const EXCLUDED = new Set(["node_modules", ".next", "generated"]);
+
+export function collectFiles(workspaceDirectory, fileSystem = fs) {
+  const files = [];
+
+  const walk = (directory) => {
+    for (const entry of fileSystem.readdirSync(directory, {
+      withFileTypes: true,
+    })) {
+      const full = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!EXCLUDED.has(entry.name)) walk(full);
+      } else if (/\.tsx?$/.test(entry.name)) {
+        files.push(full);
+      }
+    }
+  };
+
+  for (const sub of SOURCE_DIRECTORIES) {
+    const directory = path.join(workspaceDirectory, sub);
+    if (fileSystem.existsSync(directory)) walk(directory);
+  }
+
+  return files;
+}
+
+function main() {
+  const { values } = parseArgs({
+    options: {
+      workspace: { type: "string" },
+      "dry-run": { type: "boolean", default: false },
+    },
+  });
+
+  if (!values.workspace) {
+    console.error(
+      "usage: codemod-kebab-filenames.mjs --workspace <dir> [--dry-run]",
+    );
+    process.exit(2);
+  }
+
+  const workspace = path.resolve(values.workspace);
+  const tsConfigFilePath = path.join(workspace, "tsconfig.json");
+  if (!fs.existsSync(tsConfigFilePath)) {
+    console.error(`no tsconfig.json in ${workspace}`);
+    process.exit(2);
+  }
+
+  const files = collectFiles(workspace);
+  const cwd = process.cwd();
+  const { plan, collisions } = buildRenamePlan(
+    files.map((f) => path.relative(cwd, f).split(path.sep).join("/")),
+  );
+
+  if (collisions.length > 0) {
+    console.error(`${collisions.length} collision(s) — refusing to proceed:`);
+    for (const { target, sources } of collisions) {
+      console.error(`  ${target} <= ${sources.join(", ")}`);
+    }
+    process.exit(1);
+  }
+
+  const project = new Project({ tsConfigFilePath });
+
+  const computed = auditDynamicImports(project).filter(
+    (entry) => !entry.static,
+  );
+  if (computed.length > 0) {
+    console.warn(
+      `${computed.length} computed import() call(s) need manual review:`,
+    );
+    for (const entry of computed) {
+      console.warn(`  ${entry.file}:${entry.line}  ${entry.text}`);
+    }
+  }
+
+  console.log(`${plan.length} file(s) to rename in ${values.workspace}`);
+  for (const { from, to, caseOnly } of plan) {
+    console.log(`  ${from} -> ${to}${caseOnly ? "  (case-only)" : ""}`);
+  }
+
+  if (values["dry-run"]) {
+    console.log("dry run — nothing written");
+    return;
+  }
+
+  applyRenames(project, plan, { gitMove: gitMoveCaseOnly });
+  console.log(`renamed ${plan.length} file(s)`);
+}
+
+if (
+  import.meta.url === `file://${process.argv[1].split(path.sep).join("/")}` ||
+  import.meta.url === `file:///${process.argv[1].split(path.sep).join("/")}`
+) {
+  main();
+}

--- a/scripts/codemod-kebab-filenames.mjs
+++ b/scripts/codemod-kebab-filenames.mjs
@@ -11,8 +11,10 @@ import {
 } from "./lib/dynamic-import-audit.mjs";
 import {
   applyRenames,
+  describeExecError,
   gitMoveCaseOnly,
   hasNonKebabLastSegment,
+  recordDynamicImportSpecifiers,
   recordMockSpecifiers,
 } from "./lib/kebab-rename-engine.mjs";
 
@@ -46,20 +48,46 @@ const toPosix = (value) => value.split(path.sep).join("/");
 /**
  * Report whether the git working tree that contains `directory` is dirty.
  *
- * Returns `null` when the directory is not inside a git repository, in which
- * case the caller has nothing to protect and proceeds.
+ * Returns `null` only for the one failure that genuinely means "there is
+ * nothing to protect": the directory is not inside a git repository, which git
+ * signals with exit status 128 and `not a git repository` on stderr.
+ *
+ * Every other failure — git not installed, a broken index, an index lock held
+ * by another process — leaves the tree state *unknown*, and treating unknown as
+ * clean silently disables the guard and lets the destructive path run against a
+ * dirty tree. Those throw instead, naming the underlying error.
  */
-export function workingTreeStatus(directory) {
+export function workingTreeStatus(directory, options = {}) {
+  const run = options.run ?? execFileSync;
   try {
-    return execFileSync("git", ["status", "--porcelain"], {
+    return run("git", ["status", "--porcelain"], {
       cwd: directory,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     });
-  } catch {
-    return null;
+  } catch (error) {
+    const detail = describeExecError(error);
+    if (error?.status === 128 && /not a git repository/i.test(detail)) {
+      return null;
+    }
+    throw new Error(
+      `could not determine the git working tree status of ${directory}: ${detail}`,
+    );
   }
 }
+
+/**
+ * How to undo a run. `git checkout` is wrong on both counts: `gitMoveCaseOnly`
+ * uses `git mv`, which *stages* the rename, and pass 2 writes new kebab-named
+ * files that are untracked — `git checkout` reverts neither.
+ */
+const RECOVERY = "`git reset --hard HEAD && git clean -fd`";
+
+const CASE_ONLY_WARNING =
+  "Note: a case-only rename may still need a manual two-step rename back\n" +
+  "(through a temporary name) — with core.ignorecase git cannot see a\n" +
+  "case-only difference and reports a clean tree while the file is still\n" +
+  "renamed on disk.";
 
 function main() {
   const { values } = parseArgs({
@@ -85,15 +113,22 @@ function main() {
 
   // The engine performs irreversible `git mv` calls in the same pass that can
   // throw, and a pass-3 failure leaves renamed files with stale specifiers.
-  // Insisting on a clean tree keeps `git checkout .` a complete undo. A dry
+  // Insisting on a clean tree keeps the recovery command a complete undo. A dry
   // run writes nothing, so it warns and continues rather than refusing.
-  const status = workingTreeStatus(workspace);
+  let status;
+  try {
+    status = workingTreeStatus(workspace);
+  } catch (error) {
+    console.error(`${error.message}\n\nrefusing to run.`);
+    process.exit(1);
+  }
   if (status !== null && status.trim() !== "") {
     const message =
       "working tree is not clean.\n" +
       "This codemod moves files with `git mv` and rewrites imports in two\n" +
       "separate save steps; a failure part-way is only recoverable with\n" +
-      "`git checkout`. Commit or stash your changes first.\n\n" +
+      `${RECOVERY}. Commit or stash your changes first.\n` +
+      `${CASE_ONLY_WARNING}\n\n` +
       status.trimEnd();
 
     if (!values["dry-run"]) {
@@ -129,24 +164,13 @@ function main() {
     if (!project.getSourceFile(file)) project.addSourceFileAtPath(file);
   }
 
-  const { computed, aliased } = partitionDynamicImports(
-    auditDynamicImports(project),
-  );
+  const { computed } = partitionDynamicImports(auditDynamicImports(project));
 
   if (computed.length > 0) {
     console.warn(
       `${computed.length} computed import() call(s) need manual review:`,
     );
     for (const entry of computed) {
-      console.warn(`  ${display(entry.file)}:${entry.line}  ${entry.text}`);
-    }
-  }
-
-  if (aliased.length > 0) {
-    console.warn(
-      `${aliased.length} non-relative dynamic import() specifier(s) are NOT rewritten — review each:`,
-    );
-    for (const entry of aliased) {
       console.warn(`  ${display(entry.file)}:${entry.line}  ${entry.text}`);
     }
   }
@@ -180,6 +204,25 @@ function main() {
         `  ${display(entry.file)}:${entry.line}  ${entry.specifier}`,
       );
     }
+
+    // Only the aliased dynamic imports that actually point into the rename
+    // plan, plus the ones the last-segment guard refuses. Listing every
+    // non-relative import() (~106 repo-wide, ~43 of them bare packages like
+    // `react`) buries the handful that matter and gets skipped.
+    const dynamic = recordDynamicImportSpecifiers(project, plan).filter(
+      (entry) => entry.renamed,
+    );
+    const dynamicManual = dynamic.filter((entry) => entry.rewritten === null);
+    console.log(
+      `${dynamic.length - dynamicManual.length} aliased dynamic import()/import-type ` +
+        `specifier(s) would be rewritten; ${dynamicManual.length} would need manual attention`,
+    );
+    for (const entry of dynamicManual) {
+      console.warn(
+        `  ${display(entry.file)}:${entry.line}  ${entry.specifier}  -> ${display(entry.resolvedPath)}`,
+      );
+    }
+
     console.log("dry run — nothing written");
     return;
   }
@@ -195,6 +238,9 @@ function main() {
     `rewrote ${report.mockRewrites} vi.mock/require specifier(s); ` +
       `${report.mockManual.length} need manual attention`,
   );
+  console.log(
+    `rewrote ${report.dynamicRewrites} aliased dynamic import()/import-type specifier(s)`,
+  );
 
   if (report.mockManual.length > 0) {
     console.warn("mock specifiers needing manual attention:");
@@ -207,11 +253,11 @@ function main() {
 
   if (report.specifierMismatches.length > 0) {
     console.warn(
-      `${report.specifierMismatches.length} specifier(s) were left untouched because their last segment does not name the renamed file:`,
+      `${report.specifierMismatches.length} specifier(s) point at a renamed file but were left untouched — fix each by hand:`,
     );
     for (const entry of report.specifierMismatches) {
       console.warn(
-        `  ${display(entry.file)}:${entry.line}  ${entry.specifier}  -> ${display(entry.target)}`,
+        `  ${display(entry.file)}:${entry.line}  ${entry.specifier}  -> ${display(entry.target)}  — ${entry.reason}`,
       );
     }
   }

--- a/scripts/codemod-kebab-filenames.mjs
+++ b/scripts/codemod-kebab-filenames.mjs
@@ -85,17 +85,22 @@ function main() {
 
   // The engine performs irreversible `git mv` calls in the same pass that can
   // throw, and a pass-3 failure leaves renamed files with stale specifiers.
-  // Insisting on a clean tree keeps `git checkout .` a complete undo.
+  // Insisting on a clean tree keeps `git checkout .` a complete undo. A dry
+  // run writes nothing, so it warns and continues rather than refusing.
   const status = workingTreeStatus(workspace);
   if (status !== null && status.trim() !== "") {
-    console.error(
-      "working tree is not clean — refusing to run.\n" +
-        "This codemod moves files with `git mv` and rewrites imports in two\n" +
-        "separate save steps; a failure part-way is only recoverable with\n" +
-        "`git checkout`. Commit or stash your changes first.\n\n" +
-        status.trimEnd(),
-    );
-    process.exit(1);
+    const message =
+      "working tree is not clean.\n" +
+      "This codemod moves files with `git mv` and rewrites imports in two\n" +
+      "separate save steps; a failure part-way is only recoverable with\n" +
+      "`git checkout`. Commit or stash your changes first.\n\n" +
+      status.trimEnd();
+
+    if (!values["dry-run"]) {
+      console.error(`${message}\n\nrefusing to run.`);
+      process.exit(1);
+    }
+    console.warn(`${message}\n\ncontinuing — a dry run writes nothing.\n`);
   }
 
   const files = collectFiles(workspace).map(toPosix);

--- a/scripts/codemod-kebab-filenames.mjs
+++ b/scripts/codemod-kebab-filenames.mjs
@@ -1,21 +1,29 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
 import { Project } from "ts-morph";
 import { buildRenamePlan } from "./lib/kebab-rename-plan.mjs";
-import { auditDynamicImports } from "./lib/dynamic-import-audit.mjs";
-import { applyRenames, gitMoveCaseOnly } from "./lib/kebab-rename-engine.mjs";
+import {
+  auditDynamicImports,
+  partitionDynamicImports,
+} from "./lib/dynamic-import-audit.mjs";
+import {
+  applyRenames,
+  gitMoveCaseOnly,
+  hasNonKebabLastSegment,
+  recordMockSpecifiers,
+} from "./lib/kebab-rename-engine.mjs";
 
 const SOURCE_DIRECTORIES = ["src", "tests", "test", "e2e"];
 const EXCLUDED = new Set(["node_modules", ".next", "generated"]);
 
-export function collectFiles(workspaceDirectory, fileSystem = fs) {
+export function collectFiles(workspaceDirectory) {
   const files = [];
 
   const walk = (directory) => {
-    for (const entry of fileSystem.readdirSync(directory, {
-      withFileTypes: true,
-    })) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
       const full = path.join(directory, entry.name);
       if (entry.isDirectory()) {
         if (!EXCLUDED.has(entry.name)) walk(full);
@@ -27,10 +35,30 @@ export function collectFiles(workspaceDirectory, fileSystem = fs) {
 
   for (const sub of SOURCE_DIRECTORIES) {
     const directory = path.join(workspaceDirectory, sub);
-    if (fileSystem.existsSync(directory)) walk(directory);
+    if (fs.existsSync(directory)) walk(directory);
   }
 
   return files;
+}
+
+const toPosix = (value) => value.split(path.sep).join("/");
+
+/**
+ * Report whether the git working tree that contains `directory` is dirty.
+ *
+ * Returns `null` when the directory is not inside a git repository, in which
+ * case the caller has nothing to protect and proceeds.
+ */
+export function workingTreeStatus(directory) {
+  try {
+    return execFileSync("git", ["status", "--porcelain"], {
+      cwd: directory,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch {
+    return null;
+  }
 }
 
 function main() {
@@ -55,17 +83,31 @@ function main() {
     process.exit(2);
   }
 
-  const files = collectFiles(workspace);
+  // The engine performs irreversible `git mv` calls in the same pass that can
+  // throw, and a pass-3 failure leaves renamed files with stale specifiers.
+  // Insisting on a clean tree keeps `git checkout .` a complete undo.
+  const status = workingTreeStatus(workspace);
+  if (status !== null && status.trim() !== "") {
+    console.error(
+      "working tree is not clean — refusing to run.\n" +
+        "This codemod moves files with `git mv` and rewrites imports in two\n" +
+        "separate save steps; a failure part-way is only recoverable with\n" +
+        "`git checkout`. Commit or stash your changes first.\n\n" +
+        status.trimEnd(),
+    );
+    process.exit(1);
+  }
+
+  const files = collectFiles(workspace).map(toPosix);
   const cwd = process.cwd();
-  const { plan, collisions } = buildRenamePlan(
-    files.map((f) => f.split(path.sep).join("/")),
-  );
+  const display = (value) => toPosix(path.relative(cwd, value));
+  const { plan, collisions } = buildRenamePlan(files);
 
   if (collisions.length > 0) {
     console.error(`${collisions.length} collision(s) — refusing to proceed:`);
     for (const { target, sources } of collisions) {
       console.error(
-        `  ${path.relative(cwd, target).split(path.sep).join("/")} <= ${sources.map((s) => path.relative(cwd, s).split(path.sep).join("/")).join(", ")}`,
+        `  ${display(target)} <= ${sources.map(display).join(", ")}`,
       );
     }
     process.exit(1);
@@ -73,43 +115,104 @@ function main() {
 
   const project = new Project({ tsConfigFilePath });
 
-  const computed = auditDynamicImports(project).filter(
-    (entry) => !entry.static,
+  // The workspace tsconfig `include` globs do not always cover everything
+  // `collectFiles` walks — every packages/* tsconfig includes only `src/**`,
+  // and apps/auth excludes `e2e`. Without this the planned files are not
+  // project members and pass 2 aborts with "not in project". Adding them also
+  // makes the test files' own imports rewritable, which is what we want.
+  for (const file of files) {
+    if (!project.getSourceFile(file)) project.addSourceFileAtPath(file);
+  }
+
+  const { computed, aliased } = partitionDynamicImports(
+    auditDynamicImports(project),
   );
+
   if (computed.length > 0) {
     console.warn(
       `${computed.length} computed import() call(s) need manual review:`,
     );
     for (const entry of computed) {
-      const displayFile = path
-        .relative(cwd, entry.file)
-        .split(path.sep)
-        .join("/");
-      console.warn(`  ${displayFile}:${entry.line}  ${entry.text}`);
+      console.warn(`  ${display(entry.file)}:${entry.line}  ${entry.text}`);
+    }
+  }
+
+  if (aliased.length > 0) {
+    console.warn(
+      `${aliased.length} non-relative dynamic import() specifier(s) are NOT rewritten — review each:`,
+    );
+    for (const entry of aliased) {
+      console.warn(`  ${display(entry.file)}:${entry.line}  ${entry.text}`);
     }
   }
 
   console.log(`${plan.length} file(s) to rename in ${values.workspace}`);
   for (const { from, to, caseOnly } of plan) {
-    const displayFrom = path.relative(cwd, from).split(path.sep).join("/");
-    const displayTo = path.relative(cwd, to).split(path.sep).join("/");
     console.log(
-      `  ${displayFrom} -> ${displayTo}${caseOnly ? "  (case-only)" : ""}`,
+      `  ${display(from)} -> ${display(to)}${caseOnly ? "  (case-only)" : ""}`,
     );
   }
 
   if (values["dry-run"]) {
+    // vitest treats a `vi.mock` path that resolves to nothing as a silent
+    // no-op, so preview the mock rewrites too — this is the one class of
+    // breakage neither tsc nor a green test run would ever surface.
+    const mocks = recordMockSpecifiers(project, plan);
+    const rewritable = mocks.filter((entry) => entry.renamed);
+    const unresolved = mocks.filter(
+      (entry) =>
+        entry.callee !== "require" &&
+        (entry.computed ||
+          (entry.resolvedPath === null &&
+            hasNonKebabLastSegment(entry.specifier))),
+    );
+    console.log(
+      `${rewritable.length} vi.mock/require specifier(s) would be rewritten; ` +
+        `${unresolved.length} would need manual attention`,
+    );
+    for (const entry of unresolved) {
+      console.warn(
+        `  ${display(entry.file)}:${entry.line}  ${entry.specifier}`,
+      );
+    }
     console.log("dry run — nothing written");
     return;
   }
 
-  applyRenames(project, plan, { gitMove: gitMoveCaseOnly });
-  console.log(`renamed ${plan.length} file(s)`);
+  const report = applyRenames(project, plan, { gitMove: gitMoveCaseOnly });
+
+  console.log(`renamed ${report.renamed} file(s)`);
+  console.log(
+    `rewrote ${report.importRewrites} recorded import/export specifier(s) ` +
+      `(${report.caseOnlyRelativeRewrites} relative, from case-only renames)`,
+  );
+  console.log(
+    `rewrote ${report.mockRewrites} vi.mock/require specifier(s); ` +
+      `${report.mockManual.length} need manual attention`,
+  );
+
+  if (report.mockManual.length > 0) {
+    console.warn("mock specifiers needing manual attention:");
+    for (const entry of report.mockManual) {
+      console.warn(
+        `  ${display(entry.file)}:${entry.line}  ${entry.specifier}  — ${entry.reason}`,
+      );
+    }
+  }
+
+  if (report.specifierMismatches.length > 0) {
+    console.warn(
+      `${report.specifierMismatches.length} specifier(s) were left untouched because their last segment does not name the renamed file:`,
+    );
+    for (const entry of report.specifierMismatches) {
+      console.warn(
+        `  ${display(entry.file)}:${entry.line}  ${entry.specifier}  -> ${display(entry.target)}`,
+      );
+    }
+  }
 }
 
-if (
-  import.meta.url === `file://${process.argv[1].split(path.sep).join("/")}` ||
-  import.meta.url === `file:///${process.argv[1].split(path.sep).join("/")}`
-) {
+const invokedPath = process.argv[1];
+if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
   main();
 }

--- a/scripts/lib/dynamic-import-audit.mjs
+++ b/scripts/lib/dynamic-import-audit.mjs
@@ -2,11 +2,22 @@
 import { SyntaxKind } from "ts-morph";
 
 /**
- * Find every `import(...)` expression in the project.
+ * Find every `import(...)` expression and `import("...")` type node in the
+ * project.
  *
- * ts-morph rewrites a specifier that is a plain string literal when the target
- * file moves. Anything computed — a template literal, an identifier, a
- * concatenation — is invisible to it and must be checked by hand.
+ * Two kinds of specifier need a human:
+ *
+ *  - **computed** specifiers — a template literal, an identifier, a
+ *    concatenation. ts-morph cannot see through them at all.
+ *  - **non-relative** specifiers — a path alias. `SourceFile.move()` only
+ *    rewrites relative specifiers, and the rename engine's pass 3 only covers
+ *    `ImportDeclaration`/`ExportDeclaration` nodes, so an aliased `import()`
+ *    is rewritten by nobody.
+ *
+ * Each entry therefore carries both `static` (is the argument a string
+ * literal?) and `specifier` (its value, or `null` when computed), so callers
+ * can report both categories. Filtering on `static` alone silently discards
+ * exactly the aliased ones.
  */
 export function auditDynamicImports(project) {
   const found = [];
@@ -18,14 +29,43 @@ export function auditDynamicImports(project) {
       if (call.getExpression().getKind() !== SyntaxKind.ImportKeyword) continue;
 
       const [argument] = call.getArguments();
+      const isStatic = argument?.getKind() === SyntaxKind.StringLiteral;
       found.push({
         file: sourceFile.getFilePath(),
         line: call.getStartLineNumber(),
         text: call.getText(),
-        static: argument?.getKind() === SyntaxKind.StringLiteral,
+        kind: "call",
+        static: isStatic,
+        specifier: isStatic ? argument.getLiteralValue() : null,
+      });
+    }
+
+    for (const node of sourceFile.getDescendantsOfKind(SyntaxKind.ImportType)) {
+      const argument = node.getArgument();
+      const literal = argument?.asKind?.(SyntaxKind.LiteralType)?.getLiteral();
+      const isStatic = literal?.getKind() === SyntaxKind.StringLiteral;
+      found.push({
+        file: sourceFile.getFilePath(),
+        line: node.getStartLineNumber(),
+        text: node.getText(),
+        kind: "type",
+        static: isStatic,
+        specifier: isStatic ? literal.getLiteralValue() : null,
       });
     }
   }
 
   return found;
+}
+
+/**
+ * Split an audit into the two buckets that need reporting: computed
+ * specifiers, and static-but-non-relative ones (path aliases).
+ */
+export function partitionDynamicImports(entries) {
+  const computed = entries.filter((entry) => !entry.static);
+  const aliased = entries.filter(
+    (entry) => entry.static && !entry.specifier.startsWith("."),
+  );
+  return { computed, aliased };
 }

--- a/scripts/lib/dynamic-import-audit.mjs
+++ b/scripts/lib/dynamic-import-audit.mjs
@@ -1,0 +1,31 @@
+// scripts/lib/dynamic-import-audit.mjs
+import { SyntaxKind } from "ts-morph";
+
+/**
+ * Find every `import(...)` expression in the project.
+ *
+ * ts-morph rewrites a specifier that is a plain string literal when the target
+ * file moves. Anything computed — a template literal, an identifier, a
+ * concatenation — is invisible to it and must be checked by hand.
+ */
+export function auditDynamicImports(project) {
+  const found = [];
+
+  for (const sourceFile of project.getSourceFiles()) {
+    for (const call of sourceFile.getDescendantsOfKind(
+      SyntaxKind.CallExpression,
+    )) {
+      if (call.getExpression().getKind() !== SyntaxKind.ImportKeyword) continue;
+
+      const [argument] = call.getArguments();
+      found.push({
+        file: sourceFile.getFilePath(),
+        line: call.getStartLineNumber(),
+        text: call.getText(),
+        static: argument?.getKind() === SyntaxKind.StringLiteral,
+      });
+    }
+  }
+
+  return found;
+}

--- a/scripts/lib/kebab-rename-engine.mjs
+++ b/scripts/lib/kebab-rename-engine.mjs
@@ -1,28 +1,116 @@
 import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { SyntaxKind, ts } from "ts-morph";
+
+/**
+ * Call expressions whose first string-literal argument names a module but which
+ * TypeScript never type-checks, so `tsc` cannot catch a stale path.
+ *
+ * `vi.mock` is the dangerous one: vitest treats a mock path that resolves to
+ * nothing as a silent no-op — the suite stays green while exercising the real
+ * module. See the C3 finding in the whole-branch review.
+ */
+const MOCK_CALLEES = new Set([
+  "vi.mock",
+  "vi.doMock",
+  "vi.unmock",
+  "vi.doUnmock",
+  "vi.importActual",
+  "vi.importMock",
+  "require",
+]);
+
+/** Callees whose computed (non-string-literal) argument is worth reporting. */
+const VITEST_CALLEES = new Set(
+  [...MOCK_CALLEES].filter((name) => name.startsWith("vi.")),
+);
+
+const CANDIDATE_SUFFIXES = [
+  "",
+  ".ts",
+  ".tsx",
+  ".d.ts",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  "/index.ts",
+  "/index.tsx",
+  "/index.js",
+];
 
 /**
  * Move a file through a temporary name so git records the rename on a
  * case-insensitive filesystem. `core.ignorecase` is true in this repository,
  * which makes a direct `git mv Pagination.tsx pagination.tsx` a silent no-op.
+ *
+ * `execFileSync` throws an error whose `stderr` is a Buffer; printing that
+ * error renders the buffer as a list of decimal bytes, which is unreadable.
+ * Both moves are therefore wrapped so the real git message survives, and a
+ * failure of the second move restores the `.casetmp` file to its original
+ * name rather than leaving it stranded.
  */
-export function gitMoveCaseOnly(from, to) {
+export function gitMoveCaseOnly(from, to, options = {}) {
+  const run = options.run ?? execFileSync;
+  const rename = options.rename ?? fs.renameSync;
   const temporary = `${from}.casetmp`;
-  execFileSync("git", ["mv", from, temporary]);
-  execFileSync("git", ["mv", temporary, to]);
+
+  try {
+    run("git", ["mv", from, temporary]);
+  } catch (error) {
+    throw new Error(
+      `git mv "${from}" "${temporary}" failed: ${describeExecError(error)}`,
+    );
+  }
+
+  try {
+    run("git", ["mv", temporary, to]);
+  } catch (error) {
+    const cleanup = restoreTemporary({ run, rename, temporary, from });
+    throw new Error(
+      `git mv "${temporary}" "${to}" failed: ${describeExecError(error)}\n${cleanup}`,
+    );
+  }
+}
+
+function describeExecError(error) {
+  const stderr = error?.stderr;
+  const text =
+    typeof stderr === "string"
+      ? stderr
+      : stderr && typeof stderr.toString === "function"
+        ? stderr.toString("utf8")
+        : "";
+  return text.trim() || error?.message || String(error);
+}
+
+function restoreTemporary({ run, rename, temporary, from }) {
+  try {
+    run("git", ["mv", temporary, from]);
+    return `cleaned up: restored ${temporary} to ${from}`;
+  } catch {
+    try {
+      rename(temporary, from);
+      return `cleaned up: restored ${temporary} to ${from}`;
+    } catch (error) {
+      return `WARNING: could not clean up ${temporary} — remove it by hand (${error?.message ?? error})`;
+    }
+  }
 }
 
 /**
  * Normalize a file path to use forward slashes for consistent comparison.
  */
-function normalizePath(path) {
-  return path.replace(/\\/g, "/");
+function normalizePath(filePath) {
+  return String(filePath).replace(/\\/g, "/");
 }
 
 /**
  * Extract the file stem (basename without extension) from a path.
  */
-function extractStem(path) {
-  const normalized = normalizePath(path);
+function extractStem(filePath) {
+  const normalized = normalizePath(filePath);
   const parts = normalized.split("/");
   const filename = parts[parts.length - 1];
   const dotIndex = filename.lastIndexOf(".");
@@ -30,83 +118,422 @@ function extractStem(path) {
 }
 
 /**
- * Replace the final segment of an import specifier with a new stem.
- * E.g., "@/components/StatusCard" -> "@/components/status-card"
+ * Replace the final segment of an import specifier with a new stem, but only
+ * when that segment actually names the file being renamed.
+ *
+ * A specifier can reach a file through something other than its own name — a
+ * `package.json` `exports` entry or a non-star path alias, e.g.
+ * `shared/app-root-layout` resolving to `AppRootLayout.tsx`. Rewriting the
+ * last segment there would produce a specifier that points nowhere, so this
+ * returns `null` instead and the caller reports the site for manual handling.
  */
-function replaceLastSegment(specifier, newStem) {
+function replaceLastSegment(specifier, expectedStem, newStem) {
   const parts = specifier.split("/");
+  if (parts[parts.length - 1] !== expectedStem) return null;
   parts[parts.length - 1] = newStem;
   return parts.join("/");
+}
+
+/** True when two stems differ only in letter case. */
+function isCaseOnlyStem(oldStem, newStem) {
+  return oldStem.toLowerCase() === newStem.toLowerCase();
+}
+
+/**
+ * True when the last path segment of a specifier is not already kebab-case,
+ * i.e. it could plausibly be pointing at a file this migration renames.
+ */
+export function hasNonKebabLastSegment(specifier) {
+  const last = specifier.split("/").pop() ?? "";
+  return /[A-Z]/.test(last);
+}
+
+/**
+ * Pass 1 recording step for import and export declarations.
+ *
+ * Two categories are recorded, both of which `SourceFile.move()` fails to fix
+ * on its own:
+ *
+ *  - **non-relative specifiers** (path aliases). TypeScript's
+ *    `getEditsForFileRename` only rewrites relative specifiers.
+ *  - **relative specifiers whose target is a case-only rename.** With
+ *    `useCaseSensitiveFileNames === false` TypeScript considers the old and
+ *    new paths to be the same file and emits no edits at all, so a relative
+ *    importer of `Pagination.tsx` keeps pointing at the old casing.
+ *
+ * Exported so the recording step can be asserted directly: a case-insensitive
+ * in-memory ts-morph filesystem cannot be constructed, so the case-only branch
+ * is verified here and on a real (case-insensitive) disk instead.
+ */
+export function recordImportSpecifiers(project, plan) {
+  const pathMap = buildPathMap(plan);
+  const caseOnlyPaths = new Set(
+    plan
+      .filter((entry) => entry.caseOnly)
+      .map((entry) => normalizePath(entry.from)),
+  );
+  const records = [];
+
+  const consider = (declaration) => {
+    const specifier = declaration.getModuleSpecifierValue();
+    if (!specifier) return;
+    const relative = specifier.startsWith(".");
+
+    const resolved = declaration.getModuleSpecifierSourceFile();
+    if (!resolved) return;
+    const resolvedPath = normalizePath(resolved.getFilePath());
+
+    // Relative specifiers are rewritten by ts-morph during the move, EXCEPT
+    // when the rename is case-only. Record only that exception.
+    if (relative && !caseOnlyPaths.has(resolvedPath)) return;
+    if (!pathMap.has(resolvedPath)) return;
+
+    records.push({
+      node: declaration,
+      specifier,
+      relative,
+      resolvedPath,
+      file: normalizePath(declaration.getSourceFile().getFilePath()),
+      line: declaration.getStartLineNumber(),
+    });
+  };
+
+  for (const sourceFile of project.getSourceFiles()) {
+    for (const declaration of sourceFile.getImportDeclarations())
+      consider(declaration);
+    for (const declaration of sourceFile.getExportDeclarations())
+      consider(declaration);
+  }
+
+  return records;
+}
+
+function buildPathMap(plan) {
+  return new Map(
+    plan.map((entry) => [normalizePath(entry.from), normalizePath(entry.to)]),
+  );
+}
+
+/**
+ * Resolve a module specifier to an absolute file path, preferring
+ * TypeScript's own resolver and falling back to a tsconfig-`paths` aware
+ * candidate search. The fallback matters for in-memory projects and for
+ * `moduleResolution` modes where the resolver declines extensionless paths.
+ */
+function resolveSpecifier(specifier, containingFile, context) {
+  const key = `${normalizePath(containingFile)} ${specifier}`;
+  if (context.cache.has(key)) return context.cache.get(key);
+
+  let resolved = null;
+  try {
+    const result = ts.resolveModuleName(
+      specifier,
+      containingFile,
+      context.compilerOptions,
+      context.host,
+    );
+    if (result?.resolvedModule) {
+      resolved = normalizePath(result.resolvedModule.resolvedFileName);
+    }
+  } catch {
+    resolved = null;
+  }
+
+  if (!resolved) {
+    for (const candidate of candidatePaths(
+      specifier,
+      containingFile,
+      context.compilerOptions,
+    )) {
+      if (context.knownFiles.has(candidate)) {
+        resolved = candidate;
+        break;
+      }
+    }
+  }
+
+  context.cache.set(key, resolved);
+  return resolved;
+}
+
+function candidatePaths(specifier, containingFile, compilerOptions) {
+  const bases = [];
+
+  if (specifier.startsWith(".")) {
+    bases.push(
+      path.posix.resolve(
+        path.posix.dirname(normalizePath(containingFile)),
+        specifier,
+      ),
+    );
+  } else {
+    const base = normalizePath(
+      compilerOptions.baseUrl ?? compilerOptions.pathsBasePath ?? "/",
+    );
+    for (const [pattern, targets] of Object.entries(
+      compilerOptions.paths ?? {},
+    )) {
+      const star = pattern.indexOf("*");
+      if (star === -1) {
+        if (pattern !== specifier) continue;
+        for (const target of targets) {
+          bases.push(path.posix.resolve(base, normalizePath(target)));
+        }
+        continue;
+      }
+      const prefix = pattern.slice(0, star);
+      const suffix = pattern.slice(star + 1);
+      if (!specifier.startsWith(prefix)) continue;
+      if (suffix && !specifier.endsWith(suffix)) continue;
+      const middle = specifier.slice(
+        prefix.length,
+        specifier.length - suffix.length,
+      );
+      for (const target of targets) {
+        bases.push(
+          path.posix.resolve(base, normalizePath(target).replace("*", middle)),
+        );
+      }
+    }
+  }
+
+  const candidates = [];
+  for (const bare of bases) {
+    for (const suffix of CANDIDATE_SUFFIXES)
+      candidates.push(`${bare}${suffix}`);
+  }
+  return candidates;
+}
+
+/**
+ * Pass 1 recording step for `vi.mock`-family and `require` specifiers.
+ *
+ * These are plain string arguments. TypeScript does not type-check them and
+ * ts-morph's rename machinery does not touch them, so they are resolved by
+ * hand here — before any file moves, while the old paths still exist — and
+ * rewritten in pass 3.
+ */
+export function recordMockSpecifiers(project, plan) {
+  const pathMap = buildPathMap(plan);
+  const context = {
+    compilerOptions: project.getCompilerOptions(),
+    host: project.getModuleResolutionHost(),
+    knownFiles: new Set(
+      project.getSourceFiles().map((file) => normalizePath(file.getFilePath())),
+    ),
+    cache: new Map(),
+  };
+
+  const records = [];
+
+  for (const sourceFile of project.getSourceFiles()) {
+    const containingFile = normalizePath(sourceFile.getFilePath());
+
+    for (const call of sourceFile.getDescendantsOfKind(
+      SyntaxKind.CallExpression,
+    )) {
+      const callee = call.getExpression().getText();
+      if (!MOCK_CALLEES.has(callee)) continue;
+
+      const [argument] = call.getArguments();
+      const line = call.getStartLineNumber();
+
+      if (!argument || argument.getKind() !== SyntaxKind.StringLiteral) {
+        if (VITEST_CALLEES.has(callee)) {
+          records.push({
+            callee,
+            computed: true,
+            file: containingFile,
+            line,
+            specifier: call.getText(),
+            resolvedPath: null,
+          });
+        }
+        continue;
+      }
+
+      const specifier = argument.getLiteralValue();
+      const resolvedPath = resolveSpecifier(specifier, containingFile, context);
+
+      records.push({
+        node: argument,
+        callee,
+        computed: false,
+        file: containingFile,
+        line,
+        specifier,
+        resolvedPath,
+        renamed: resolvedPath !== null && pathMap.has(resolvedPath),
+      });
+    }
+  }
+
+  return records;
 }
 
 /**
  * Apply a rename plan to a ts-morph project in three passes.
  *
- * Pass 1: Before any move, record all non-relative imports and their resolved paths.
- * Pass 2: Move files (ts-morph rewrites relative specifiers here).
- * Pass 3: Update recorded non-relative specifiers with new paths.
+ * Pass 1: Before any move, record everything the move itself will not fix —
+ *         non-relative import/export specifiers, relative specifiers whose
+ *         target is a case-only rename, and `vi.mock`-family / `require`
+ *         string arguments together with the file each one resolves to.
+ * Pass 2: Move files (ts-morph rewrites ordinary relative specifiers here).
+ * Pass 3: Rewrite every recorded specifier whose target was renamed.
  *
- * Case-only renames are additionally staged through git so the rename is not lost.
+ * Case-only renames are additionally staged through git so the rename is not
+ * lost on a case-insensitive filesystem.
+ *
+ * **Partial-application hazard.** Pass 2 performs irreversible `git mv` calls
+ * inside the same loop that can throw, and the first `saveSync` happens only
+ * after that loop completes. A throw in pass 3 therefore leaves the tree with
+ * correct filenames but stale aliased/mock specifiers. Both states are
+ * recoverable only by `git checkout`, which is why the CLI refuses to run
+ * against a dirty working tree.
+ *
+ * Returns a report describing what was rewritten and what needs a human.
  */
 export function applyRenames(project, plan, options = {}) {
-  // Pass 1: Record non-relative imports and their resolved file paths
-  const records = [];
+  const pathMap = buildPathMap(plan);
 
-  for (const sourceFile of project.getSourceFiles()) {
-    // Record ImportDeclarations
-    for (const importDecl of sourceFile.getImportDeclarations()) {
-      const moduleSpecifier = importDecl.getModuleSpecifierValue();
-      if (!moduleSpecifier.startsWith(".")) {
-        const resolved = importDecl.getModuleSpecifierSourceFile();
-        if (resolved) {
-          records.push({
-            node: importDecl,
-            resolvedPath: normalizePath(resolved.getFilePath()),
-          });
-        }
-      }
-    }
+  // ---- Pass 1: record ----------------------------------------------------
+  const importRecords = recordImportSpecifiers(project, plan);
+  const mockRecords = recordMockSpecifiers(project, plan);
 
-    // Record ExportDeclarations
-    for (const exportDecl of sourceFile.getExportDeclarations()) {
-      const moduleSpecifier = exportDecl.getModuleSpecifierValue();
-      if (moduleSpecifier && !moduleSpecifier.startsWith(".")) {
-        const resolved = exportDecl.getModuleSpecifierSourceFile();
-        if (resolved) {
-          records.push({
-            node: exportDecl,
-            resolvedPath: normalizePath(resolved.getFilePath()),
-          });
-        }
-      }
-    }
-  }
+  const report = {
+    renamed: 0,
+    importRewrites: 0,
+    caseOnlyRelativeRewrites: 0,
+    mockRewrites: 0,
+    mockManual: [],
+    specifierMismatches: [],
+  };
 
-  // Pass 2: Move files (ts-morph rewrites relative specifiers)
+  // ---- Pass 2: move ------------------------------------------------------
   for (const { from, to, caseOnly } of plan) {
     const sourceFile = project.getSourceFile(from);
     if (!sourceFile) throw new Error(`not in project: ${from}`);
 
     if (caseOnly && options.gitMove) options.gitMove(from, to);
     sourceFile.move(to, { overwrite: false });
+    report.renamed += 1;
   }
 
   project.saveSync();
 
-  // Pass 3: Update non-relative specifiers
-  const pathMap = new Map(
-    plan.map((p) => [normalizePath(p.from), normalizePath(p.to)]),
-  );
+  // ---- Pass 3: rewrite recorded specifiers -------------------------------
+  for (const record of importRecords) {
+    const newPath = pathMap.get(record.resolvedPath);
+    if (!newPath) continue;
+    if (record.node.wasForgotten?.()) continue;
 
-  for (const record of records) {
-    if (pathMap.has(record.resolvedPath)) {
-      const newPath = pathMap.get(record.resolvedPath);
-      const newStem = extractStem(newPath);
-      const currentSpecifier = record.node.getModuleSpecifierValue();
-      const newSpecifier = replaceLastSegment(currentSpecifier, newStem);
-      record.node.setModuleSpecifier(newSpecifier);
+    const current = record.node.getModuleSpecifierValue();
+    const oldStem = extractStem(record.resolvedPath);
+    const newStem = extractStem(newPath);
+
+    // A case-only rename may or may not have been rewritten by ts-morph
+    // already, depending on whether the host filesystem is case-sensitive.
+    // If it was, there is nothing to do — and nothing to report either.
+    if (
+      isCaseOnlyStem(oldStem, newStem) &&
+      current.split("/").pop() === newStem
+    )
+      continue;
+
+    const rewritten = replaceLastSegment(current, oldStem, newStem);
+
+    if (rewritten === null) {
+      report.specifierMismatches.push({
+        file: record.file,
+        line: record.line,
+        specifier: current,
+        target: record.resolvedPath,
+        reason: "last segment does not name the renamed file",
+      });
+      continue;
     }
+
+    if (rewritten !== current) record.node.setModuleSpecifier(rewritten);
+    report.importRewrites += 1;
+    if (record.relative) report.caseOnlyRelativeRewrites += 1;
+  }
+
+  for (const record of mockRecords) {
+    if (record.computed) {
+      report.mockManual.push({
+        file: record.file,
+        line: record.line,
+        specifier: record.specifier,
+        reason: "computed specifier — cannot be resolved statically",
+      });
+      continue;
+    }
+
+    const newPath = record.resolvedPath
+      ? pathMap.get(record.resolvedPath)
+      : undefined;
+
+    if (!newPath) {
+      // Unresolvable AND non-kebab means it might have been pointing at a file
+      // this migration renames. Anything already kebab-case, or resolving to a
+      // real module, needs no attention.
+      if (
+        record.resolvedPath === null &&
+        hasNonKebabLastSegment(record.specifier) &&
+        record.callee !== "require"
+      ) {
+        report.mockManual.push({
+          file: record.file,
+          line: record.line,
+          specifier: record.specifier,
+          reason: "could not resolve specifier to a file",
+        });
+      }
+      continue;
+    }
+
+    if (record.node.wasForgotten?.()) {
+      report.mockManual.push({
+        file: record.file,
+        line: record.line,
+        specifier: record.specifier,
+        reason: "AST node was invalidated before it could be rewritten",
+      });
+      continue;
+    }
+
+    const oldStem = extractStem(record.resolvedPath);
+    const newStem = extractStem(newPath);
+    if (
+      isCaseOnlyStem(oldStem, newStem) &&
+      record.specifier.split("/").pop() === newStem
+    )
+      continue;
+
+    const rewritten = replaceLastSegment(record.specifier, oldStem, newStem);
+
+    if (rewritten === null) {
+      report.specifierMismatches.push({
+        file: record.file,
+        line: record.line,
+        specifier: record.specifier,
+        target: record.resolvedPath,
+        reason: "last segment does not name the renamed file",
+      });
+      report.mockManual.push({
+        file: record.file,
+        line: record.line,
+        specifier: record.specifier,
+        reason: "last segment does not name the renamed file",
+      });
+      continue;
+    }
+
+    if (rewritten !== record.specifier) record.node.setLiteralValue(rewritten);
+    report.mockRewrites += 1;
   }
 
   project.saveSync();
+
+  return report;
 }

--- a/scripts/lib/kebab-rename-engine.mjs
+++ b/scripts/lib/kebab-rename-engine.mjs
@@ -1,0 +1,31 @@
+import { execFileSync } from "node:child_process";
+
+/**
+ * Move a file through a temporary name so git records the rename on a
+ * case-insensitive filesystem. `core.ignorecase` is true in this repository,
+ * which makes a direct `git mv Pagination.tsx pagination.tsx` a silent no-op.
+ */
+export function gitMoveCaseOnly(from, to) {
+  const temporary = `${from}.casetmp`;
+  execFileSync("git", ["mv", from, temporary]);
+  execFileSync("git", ["mv", temporary, to]);
+}
+
+/**
+ * Apply a rename plan to a ts-morph project.
+ *
+ * `SourceFile.move()` rewrites every import specifier that references the file,
+ * including barrel re-exports and static `import()` calls. Case-only renames
+ * are additionally staged through git so the rename is not lost.
+ */
+export function applyRenames(project, plan, options = {}) {
+  for (const { from, to, caseOnly } of plan) {
+    const sourceFile = project.getSourceFile(from);
+    if (!sourceFile) throw new Error(`not in project: ${from}`);
+
+    if (caseOnly && options.gitMove) options.gitMove(from, to);
+    sourceFile.move(to, { overwrite: false });
+  }
+
+  project.saveSync();
+}

--- a/scripts/lib/kebab-rename-engine.mjs
+++ b/scripts/lib/kebab-rename-engine.mjs
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { SyntaxKind, ts } from "ts-morph";
+import { toKebab } from "./kebab-rename-plan.mjs";
 
 /**
  * Call expressions whose first string-literal argument names a module but which
@@ -74,7 +75,7 @@ export function gitMoveCaseOnly(from, to, options = {}) {
   }
 }
 
-function describeExecError(error) {
+export function describeExecError(error) {
   const stderr = error?.stderr;
   const text =
     typeof stderr === "string"
@@ -145,7 +146,10 @@ function isCaseOnlyStem(oldStem, newStem) {
  */
 export function hasNonKebabLastSegment(specifier) {
   const last = specifier.split("/").pop() ?? "";
-  return /[A-Z]/.test(last);
+  // Same test the rename plan uses to decide whether a file needs renaming,
+  // rather than a private `/[A-Z]/` approximation of it — one definition of
+  // "not kebab-case" for the whole codemod.
+  return toKebab(last) !== last;
 }
 
 /**
@@ -306,6 +310,22 @@ function candidatePaths(specifier, containingFile, compilerOptions) {
 }
 
 /**
+ * The shared module-resolution context for every by-hand `resolveSpecifier`
+ * call in pass 1: the project's own compiler options and resolution host, the
+ * set of files it knows about, and a per-run cache.
+ */
+function resolutionContext(project) {
+  return {
+    compilerOptions: project.getCompilerOptions(),
+    host: project.getModuleResolutionHost(),
+    knownFiles: new Set(
+      project.getSourceFiles().map((file) => normalizePath(file.getFilePath())),
+    ),
+    cache: new Map(),
+  };
+}
+
+/**
  * Pass 1 recording step for `vi.mock`-family and `require` specifiers.
  *
  * These are plain string arguments. TypeScript does not type-check them and
@@ -315,14 +335,7 @@ function candidatePaths(specifier, containingFile, compilerOptions) {
  */
 export function recordMockSpecifiers(project, plan) {
   const pathMap = buildPathMap(plan);
-  const context = {
-    compilerOptions: project.getCompilerOptions(),
-    host: project.getModuleResolutionHost(),
-    knownFiles: new Set(
-      project.getSourceFiles().map((file) => normalizePath(file.getFilePath())),
-    ),
-    cache: new Map(),
-  };
+  const context = resolutionContext(project);
 
   const records = [];
 
@@ -372,12 +385,92 @@ export function recordMockSpecifiers(project, plan) {
 }
 
 /**
+ * Pass 1 recording step for non-relative dynamic `import("…")` arguments and
+ * `import("…")` type nodes (`typeof import("…").foo`, `import("…").Bar`).
+ *
+ * Neither is touched by anybody else: `SourceFile.move()` rewrites only
+ * relative specifiers, and pass 3's import loop covers only
+ * `ImportDeclaration`/`ExportDeclaration` nodes. A path-aliased
+ * `await import("@/features/users/application/utils/exportCsv")` therefore
+ * survives the rename pointing at a file that no longer exists — and unlike a
+ * `vi.mock` path, `tsc` does flag it, which is exactly how the first real
+ * `apps/admin` run was caught.
+ *
+ * Both node kinds bottom out in a `StringLiteral`, so one record shape covers
+ * them; the `kind` field only distinguishes them for reporting.
+ *
+ * Relative specifiers are deliberately skipped — ts-morph already rewrites
+ * those during the move, and recording them would double-handle them.
+ *
+ * The rewrite is planned here rather than in pass 3 because these literals are
+ * non-relative, so nothing between the two passes can change their text; the
+ * `replaceLastSegment` guard therefore gives the same answer either way, and
+ * planning it here lets `--dry-run` report exactly what the real run would do.
+ */
+export function recordDynamicImportSpecifiers(project, plan) {
+  const pathMap = buildPathMap(plan);
+  const context = resolutionContext(project);
+  const records = [];
+
+  const consider = (literal, kind, containingFile, line) => {
+    const specifier = literal.getLiteralValue();
+    if (specifier.startsWith(".")) return;
+
+    const resolvedPath = resolveSpecifier(specifier, containingFile, context);
+    const newPath = resolvedPath ? (pathMap.get(resolvedPath) ?? null) : null;
+
+    records.push({
+      node: literal,
+      kind,
+      file: containingFile,
+      line,
+      specifier,
+      resolvedPath,
+      renamed: newPath !== null,
+      rewritten:
+        newPath === null
+          ? null
+          : replaceLastSegment(
+              specifier,
+              extractStem(resolvedPath),
+              extractStem(newPath),
+            ),
+    });
+  };
+
+  for (const sourceFile of project.getSourceFiles()) {
+    const containingFile = normalizePath(sourceFile.getFilePath());
+
+    for (const call of sourceFile.getDescendantsOfKind(
+      SyntaxKind.CallExpression,
+    )) {
+      if (call.getExpression().getKind() !== SyntaxKind.ImportKeyword) continue;
+      const [argument] = call.getArguments();
+      if (argument?.getKind() !== SyntaxKind.StringLiteral) continue;
+      consider(argument, "call", containingFile, call.getStartLineNumber());
+    }
+
+    for (const node of sourceFile.getDescendantsOfKind(SyntaxKind.ImportType)) {
+      const literal = node
+        .getArgument()
+        ?.asKind?.(SyntaxKind.LiteralType)
+        ?.getLiteral();
+      if (literal?.getKind() !== SyntaxKind.StringLiteral) continue;
+      consider(literal, "type", containingFile, node.getStartLineNumber());
+    }
+  }
+
+  return records;
+}
+
+/**
  * Apply a rename plan to a ts-morph project in three passes.
  *
  * Pass 1: Before any move, record everything the move itself will not fix —
  *         non-relative import/export specifiers, relative specifiers whose
- *         target is a case-only rename, and `vi.mock`-family / `require`
- *         string arguments together with the file each one resolves to.
+ *         target is a case-only rename, `vi.mock`-family / `require` string
+ *         arguments, and non-relative dynamic `import()` / import-type
+ *         specifiers, together with the file each one resolves to.
  * Pass 2: Move files (ts-morph rewrites ordinary relative specifiers here).
  * Pass 3: Rewrite every recorded specifier whose target was renamed.
  *
@@ -388,8 +481,13 @@ export function recordMockSpecifiers(project, plan) {
  * inside the same loop that can throw, and the first `saveSync` happens only
  * after that loop completes. A throw in pass 3 therefore leaves the tree with
  * correct filenames but stale aliased/mock specifiers. Both states are
- * recoverable only by `git checkout`, which is why the CLI refuses to run
- * against a dirty working tree.
+ * recoverable only by `git reset --hard HEAD && git clean -fd` — `git checkout`
+ * neither unstages the `git mv` renames nor removes the untracked kebab-named
+ * files — which is why the CLI refuses to run against a dirty working tree.
+ * Even then, a case-only rename may need a manual two-step rename back
+ * (via a temporary name), because with `core.ignorecase` git cannot see a
+ * case-only difference and reports a clean tree while the file is still
+ * renamed on disk.
  *
  * Returns a report describing what was rewritten and what needs a human.
  */
@@ -399,12 +497,14 @@ export function applyRenames(project, plan, options = {}) {
   // ---- Pass 1: record ----------------------------------------------------
   const importRecords = recordImportSpecifiers(project, plan);
   const mockRecords = recordMockSpecifiers(project, plan);
+  const dynamicRecords = recordDynamicImportSpecifiers(project, plan);
 
   const report = {
     renamed: 0,
     importRewrites: 0,
     caseOnlyRelativeRewrites: 0,
     mockRewrites: 0,
+    dynamicRewrites: 0,
     mockManual: [],
     specifierMismatches: [],
   };
@@ -453,7 +553,10 @@ export function applyRenames(project, plan, options = {}) {
       continue;
     }
 
-    if (rewritten !== current) record.node.setModuleSpecifier(rewritten);
+    // Count rewrites, not visits: a specifier that already reads the way it
+    // should is not a change and must not inflate the headline number.
+    if (rewritten === current) continue;
+    record.node.setModuleSpecifier(rewritten);
     report.importRewrites += 1;
     if (record.relative) report.caseOnlyRelativeRewrites += 1;
   }
@@ -513,6 +616,8 @@ export function applyRenames(project, plan, options = {}) {
     const rewritten = replaceLastSegment(record.specifier, oldStem, newStem);
 
     if (rewritten === null) {
+      // Reported once, under the guard's own heading. Pushing it to
+      // `mockManual` as well made the CLI print the same site twice.
       report.specifierMismatches.push({
         file: record.file,
         line: record.line,
@@ -520,17 +625,41 @@ export function applyRenames(project, plan, options = {}) {
         target: record.resolvedPath,
         reason: "last segment does not name the renamed file",
       });
-      report.mockManual.push({
-        file: record.file,
-        line: record.line,
-        specifier: record.specifier,
-        reason: "last segment does not name the renamed file",
-      });
       continue;
     }
 
     if (rewritten !== record.specifier) record.node.setLiteralValue(rewritten);
     report.mockRewrites += 1;
+  }
+
+  for (const record of dynamicRecords) {
+    if (!record.renamed) continue;
+
+    if (record.rewritten === null) {
+      report.specifierMismatches.push({
+        file: record.file,
+        line: record.line,
+        specifier: record.specifier,
+        target: record.resolvedPath,
+        reason: "last segment does not name the renamed file",
+      });
+      continue;
+    }
+
+    if (record.node.wasForgotten?.()) {
+      report.specifierMismatches.push({
+        file: record.file,
+        line: record.line,
+        specifier: record.specifier,
+        target: record.resolvedPath,
+        reason: "AST node was invalidated before it could be rewritten",
+      });
+      continue;
+    }
+
+    if (record.rewritten === record.node.getLiteralValue()) continue;
+    record.node.setLiteralValue(record.rewritten);
+    report.dynamicRewrites += 1;
   }
 
   project.saveSync();

--- a/scripts/lib/kebab-rename-engine.mjs
+++ b/scripts/lib/kebab-rename-engine.mjs
@@ -12,19 +12,100 @@ export function gitMoveCaseOnly(from, to) {
 }
 
 /**
- * Apply a rename plan to a ts-morph project.
+ * Normalize a file path to use forward slashes for consistent comparison.
+ */
+function normalizePath(path) {
+  return path.replace(/\\/g, "/");
+}
+
+/**
+ * Extract the file stem (basename without extension) from a path.
+ */
+function extractStem(path) {
+  const normalized = normalizePath(path);
+  const parts = normalized.split("/");
+  const filename = parts[parts.length - 1];
+  const dotIndex = filename.lastIndexOf(".");
+  return dotIndex === -1 ? filename : filename.slice(0, dotIndex);
+}
+
+/**
+ * Replace the final segment of an import specifier with a new stem.
+ * E.g., "@/components/StatusCard" -> "@/components/status-card"
+ */
+function replaceLastSegment(specifier, newStem) {
+  const parts = specifier.split("/");
+  parts[parts.length - 1] = newStem;
+  return parts.join("/");
+}
+
+/**
+ * Apply a rename plan to a ts-morph project in three passes.
  *
- * `SourceFile.move()` rewrites every import specifier that references the file,
- * including barrel re-exports and static `import()` calls. Case-only renames
- * are additionally staged through git so the rename is not lost.
+ * Pass 1: Before any move, record all non-relative imports and their resolved paths.
+ * Pass 2: Move files (ts-morph rewrites relative specifiers here).
+ * Pass 3: Update recorded non-relative specifiers with new paths.
+ *
+ * Case-only renames are additionally staged through git so the rename is not lost.
  */
 export function applyRenames(project, plan, options = {}) {
+  // Pass 1: Record non-relative imports and their resolved file paths
+  const records = [];
+
+  for (const sourceFile of project.getSourceFiles()) {
+    // Record ImportDeclarations
+    for (const importDecl of sourceFile.getImportDeclarations()) {
+      const moduleSpecifier = importDecl.getModuleSpecifierValue();
+      if (!moduleSpecifier.startsWith(".")) {
+        const resolved = importDecl.getModuleSpecifierSourceFile();
+        if (resolved) {
+          records.push({
+            node: importDecl,
+            resolvedPath: normalizePath(resolved.getFilePath()),
+          });
+        }
+      }
+    }
+
+    // Record ExportDeclarations
+    for (const exportDecl of sourceFile.getExportDeclarations()) {
+      const moduleSpecifier = exportDecl.getModuleSpecifierValue();
+      if (moduleSpecifier && !moduleSpecifier.startsWith(".")) {
+        const resolved = exportDecl.getModuleSpecifierSourceFile();
+        if (resolved) {
+          records.push({
+            node: exportDecl,
+            resolvedPath: normalizePath(resolved.getFilePath()),
+          });
+        }
+      }
+    }
+  }
+
+  // Pass 2: Move files (ts-morph rewrites relative specifiers)
   for (const { from, to, caseOnly } of plan) {
     const sourceFile = project.getSourceFile(from);
     if (!sourceFile) throw new Error(`not in project: ${from}`);
 
     if (caseOnly && options.gitMove) options.gitMove(from, to);
     sourceFile.move(to, { overwrite: false });
+  }
+
+  project.saveSync();
+
+  // Pass 3: Update non-relative specifiers
+  const pathMap = new Map(
+    plan.map((p) => [normalizePath(p.from), normalizePath(p.to)]),
+  );
+
+  for (const record of records) {
+    if (pathMap.has(record.resolvedPath)) {
+      const newPath = pathMap.get(record.resolvedPath);
+      const newStem = extractStem(newPath);
+      const currentSpecifier = record.node.getModuleSpecifierValue();
+      const newSpecifier = replaceLastSegment(currentSpecifier, newStem);
+      record.node.setModuleSpecifier(newSpecifier);
+    }
   }
 
   project.saveSync();

--- a/scripts/lib/kebab-rename-plan.mjs
+++ b/scripts/lib/kebab-rename-plan.mjs
@@ -1,0 +1,55 @@
+import path from "node:path";
+
+/**
+ * Convert a filename stem to kebab-case.
+ *
+ * Two passes are needed. The first splits a lowercase-or-digit followed by an
+ * uppercase letter (`loginForm` -> `login-Form`). The second splits a run of
+ * capitals followed by a capital-then-lowercase, which is what separates an
+ * acronym from the word after it (`MSWProvider` -> `MSW-Provider`). Without
+ * the second pass, `MSWProvider` would collapse to `mswprovider`.
+ */
+export function toKebab(stem) {
+  return stem
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+    .toLowerCase();
+}
+
+/**
+ * Split a basename into its stem and the whole remaining suffix, so compound
+ * extensions survive: `LoginForm.test.tsx` -> `LoginForm` + `.test.tsx`.
+ * The search starts at index 1 so a leading dot is never treated as the
+ * separator.
+ */
+function splitBasename(base) {
+  const dot = base.indexOf(".", 1);
+  return dot === -1 ? [base, ""] : [base.slice(0, dot), base.slice(dot)];
+}
+
+export function buildRenamePlan(files) {
+  const plan = [];
+  const byTarget = new Map();
+
+  for (const file of files) {
+    const dir = path.dirname(file);
+    const [stem, suffix] = splitBasename(path.basename(file));
+    const target = path.posix.join(dir, toKebab(stem) + suffix);
+
+    byTarget.set(target, [...(byTarget.get(target) ?? []), file]);
+
+    if (target !== file) {
+      plan.push({
+        from: file,
+        to: target,
+        caseOnly: target.toLowerCase() === file.toLowerCase(),
+      });
+    }
+  }
+
+  const collisions = [...byTarget]
+    .filter(([, sources]) => sources.length > 1)
+    .map(([target, sources]) => ({ target, sources }));
+
+  return { plan, collisions };
+}


### PR DESCRIPTION
Adds the codemod that will rename 694 TypeScript files to kebab-case across 11 workspaces. **This branch contains the tool only — no files have been renamed.** The migration itself runs as 11 separate PRs, one per workspace.

Phase 0 of a wider effort to share tooling and AI documents across the constellation of repos.

## Why kebab-case

`.claude/rules/naming-conventions.md` documents PascalCase components and camelCase hooks/utilities, but the ls-lint rule meant to enforce it is `kebab-case | regex:^[a-z][a-zA-Z0-9]*$ | regex:^[A-Z][A-Za-z0-9]*$` — which accepts all three forms in any location. `FormatDate.ts` passes lint while violating the documented rule. kebab-case is the only convention where the rule and its enforcement are the same artifact.

Full reasoning, including what was weighed against it: `docs/superpowers/specs/2026-09-06-kebab-migration-design.md`.

## What is here

| File | Purpose |
|---|---|
| `scripts/lib/kebab-rename-plan.mjs` | `toKebab` (acronym-aware), `buildRenamePlan` with collision detection |
| `scripts/lib/dynamic-import-audit.mjs` | classifies `import()` specifiers static vs computed |
| `scripts/lib/kebab-rename-engine.mjs` | three-pass rename: resolve, move, rewrite |
| `scripts/codemod-kebab-filenames.mjs` | CLI: `pnpm codemod:kebab --workspace <dir> [--dry-run]` |
| `docs/superpowers/plans/2026-09-06-kebab-migration.md` | per-workspace migration procedure |

207 script tests. `ts-morph` added as a root devDependency.

## Why three passes

`SourceFile.move()` rewrites **relative** import specifiers and leaves non-relative ones untouched. This repo has 914 non-relative imports (`@/` 719, `shared/` 113, `api/` 46, `@ui/` 30, `@shared/` 6) against 364 relative — so a naive implementation would leave ~914 broken specifiers. Pass 1 resolves non-relative specifiers before the move (afterwards the old paths no longer resolve), pass 2 moves, pass 3 rewrites only the final path segment, guarded so a specifier whose last segment does not name the file is reported rather than rewritten.

The codemod also rewrites `vi.mock` / `doMock` / `importActual` / `require` specifiers, and aliased dynamic `import()` / `typeof import()` nodes. The `vi.mock` case matters most: **vitest treats a `vi.mock()` whose target does not exist as a silent no-op** — verified in this repo, a missing path yields `Test Files 1 passed`. Left unhandled, 210+ mocks would quietly stop mocking while the suites stayed green.

## Verification

Beyond unit tests, the codemod was run for real against two workspaces and then reverted:

- **`packages/ui`** — 17 files renamed (including 7 under `tests/`, which the workspace tsconfig excludes), 17 specifiers rewritten, `pnpm typecheck` green across all 12 workspaces, `ui` tests green.
- **`apps/admin`** — 161 files renamed, 179 import/export specifiers, 73 `vi.mock` specifiers, 7 aliased dynamic imports. `turbo typecheck --force` 12/12, `turbo test --filter=admin --force` green, and all 83 resolvable `vi.mock` specifiers confirmed to point at existing files afterwards.

## Known limits, documented in the plan

- Migrating `packages/shared` breaks **44** deep cross-workspace imports plus five hard-coded paths in its `package.json` `exports` map — the codemod builds its project from one workspace's tsconfig and cannot see the others. `pnpm typecheck` names every site.
- Coverage-exclude globs in `apps/*/vitest.config.mts` and per-file overrides in `eslint.config.mjs` reference paths that will stop matching.
- Recovery from a failed run is `git reset --hard HEAD && git clean -fd`, **not** `git checkout` — `git mv` stages case-only renames, and with `core.ignorecase=true` git will report a clean tree while files remain renamed on disk.

Lint enforcement (`unicorn/filename-case`, the ls-lint rewrite) is deliberately **not** turned on here; it lands after all 11 workspaces are migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)